### PR TITLE
Add migrations

### DIFF
--- a/database/migrations/2016_07_26_175053_create_reportback_table.php
+++ b/database/migrations/2016_07_26_175053_create_reportback_table.php
@@ -17,7 +17,7 @@ class CreateReportbackTable extends Migration
             $table->string('northstar_id')->index()->comment('Users northstar id');
             $table->integer('drupal_id')->index()->comment('The phoenix users.uid that reported back.');
             $table->integer('campaign_id')->index()->comment('The campaign node id that the user has reported back for.');
-            $table->integer('campaign_run_nid')->index()->nullable()->comment('The campaign run id that the user reported back for.');
+            $table->integer('campaign_run_id')->index()->nullable()->comment('The campaign run id that the user reported back for.');
             $table->integer('quantity')->comment('The quantity of reportback_nouns reportback_verbed.');
             $table->text('why_participated')->nullable()->comment('Why the user participated.');
             $table->integer('num_participants')->nullable()->comment('The number of participants, if applicable.');

--- a/database/migrations/2016_07_26_175053_create_reportback_table.php
+++ b/database/migrations/2016_07_26_175053_create_reportback_table.php
@@ -14,10 +14,10 @@ class CreateReportbackTable extends Migration
     {
         Schema::create('reportback', function (Blueprint $table) {
             $table->increments('id')->comment('Primary key. Maps to rbid');
-            $table->string('northstar_id')->comment('Users northstar id');
-            $table->integer('drupal_id')->comment('The phoenix users.uid that reported back.');
-            $table->integer('campaign_id')->comment('The campaign node id that the user has reported back for.');
-            $table->integer('campaign_run_nid')->nullable()->comment('The campaign run id that the user reported back for.');
+            $table->string('northstar_id')->index()->comment('Users northstar id');
+            $table->integer('drupal_id')->index()->comment('The phoenix users.uid that reported back.');
+            $table->integer('campaign_id')->index()->comment('The campaign node id that the user has reported back for.');
+            $table->integer('campaign_run_nid')->index()->nullable()->comment('The campaign run id that the user reported back for.');
             $table->integer('quantity')->comment('The quantity of reportback_nouns reportback_verbed.');
             $table->text('why_participated')->nullable()->comment('Why the user participated.');
             $table->integer('num_participants')->nullable()->comment('The number of participants, if applicable.');

--- a/database/migrations/2016_07_26_175053_create_reportback_table.php
+++ b/database/migrations/2016_07_26_175053_create_reportback_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReportbackTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reportback', function (Blueprint $table) {
+            $table->increments('id')->comment('Primary key. Maps to rbid');
+            $table->string('user_id')->comment('The rogue users.id that correlates to their Northstar id');
+            $table->integer('uid')->comment('The phoenix users.uid that reported back.');
+            $table->integer('nid')->comment('The node.nid that the user has reported back for.');
+            $table->integer('run_nid')->nullable()->comment('The node.run_nid that the user reported back for.');
+            $table->integer('quantity')->comment('The quantity of reportback_nouns reportback_verbed.');
+            $table->text('why_participated')->nullable()->comment('Why the user participated.');
+            $table->integer('num_participants')->nullable()->comment('The number of participants, if applicable.');
+            $table->integer('flagged')->nullable()->comment('Whether the Reportback has been flagged.');
+            $table->string('flagged_reason')->nullable()->comment('Reason why reportback was flagged.');
+            $table->integer('promoted')->nullable()->comment('Whether the Reportback has been promoted.');
+            $table->string('promoted_reason')->nullable()->comment('Reason why reportback was promoted.');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('reportback');
+    }
+}

--- a/database/migrations/2016_07_26_175053_create_reportback_table.php
+++ b/database/migrations/2016_07_26_175053_create_reportback_table.php
@@ -14,9 +14,9 @@ class CreateReportbackTable extends Migration
     {
         Schema::create('reportback', function (Blueprint $table) {
             $table->increments('id')->comment('Primary key. Maps to rbid');
-            $table->string('user_id')->comment('The rogue users.id that correlates to their Northstar id');
-            $table->integer('uid')->comment('The phoenix users.uid that reported back.');
-            $table->integer('nid')->comment('The node.nid that the user has reported back for.');
+            $table->string('northstar_id')->comment('Users northstar id');
+            $table->integer('drupal_id')->comment('The phoenix users.uid that reported back.');
+            $table->integer('node_id')->comment('The node.nid that the user has reported back for.');
             $table->integer('run_nid')->nullable()->comment('The node.run_nid that the user reported back for.');
             $table->integer('quantity')->comment('The quantity of reportback_nouns reportback_verbed.');
             $table->text('why_participated')->nullable()->comment('Why the user participated.');

--- a/database/migrations/2016_07_26_175053_create_reportback_table.php
+++ b/database/migrations/2016_07_26_175053_create_reportback_table.php
@@ -16,8 +16,8 @@ class CreateReportbackTable extends Migration
             $table->increments('id')->comment('Primary key. Maps to rbid');
             $table->string('northstar_id')->comment('Users northstar id');
             $table->integer('drupal_id')->comment('The phoenix users.uid that reported back.');
-            $table->integer('node_id')->comment('The node.nid that the user has reported back for.');
-            $table->integer('run_nid')->nullable()->comment('The node.run_nid that the user reported back for.');
+            $table->integer('campaign_id')->comment('The campaign node id that the user has reported back for.');
+            $table->integer('campaign_run_nid')->nullable()->comment('The campaign run id that the user reported back for.');
             $table->integer('quantity')->comment('The quantity of reportback_nouns reportback_verbed.');
             $table->text('why_participated')->nullable()->comment('Why the user participated.');
             $table->integer('num_participants')->nullable()->comment('The number of participants, if applicable.');

--- a/database/migrations/2016_07_27_144623_create_reportback_item_table.php
+++ b/database/migrations/2016_07_27_144623_create_reportback_item_table.php
@@ -15,7 +15,7 @@ class CreateReportbackItemTable extends Migration
         Schema::create('reportback_item', function (Blueprint $table) {
             $table->integer('reportback_id')->unsigned();
             $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
-            $table->integer('fid')->unsigned();
+            $table->integer('file_id')->unsigned();
             $table->string('caption')->nullable();
             $table->string('status')->nullable()->default('pending');
             $table->integer('reviewed')->unsigned()->nullable();

--- a/database/migrations/2016_07_27_144623_create_reportback_item_table.php
+++ b/database/migrations/2016_07_27_144623_create_reportback_item_table.php
@@ -16,13 +16,13 @@ class CreateReportbackItemTable extends Migration
             $table->integer('reportback_id')->unsigned();
             $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
             $table->integer('fid')->unsigned();
-            $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
             $table->string('caption')->nullable();
             $table->string('status')->nullable()->default('pending');
             $table->integer('reviewed')->unsigned()->nullable();
             $table->integer('reviewer')->unsigned()->nullable();
             $table->string('review_source')->nullable()->comment('Source URL which review was submitted from.');
             $table->string('source')->nullable()->comment('Source which reportback file was submitted from.');
+            $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
             $table->timestamps();
         });
     }

--- a/database/migrations/2016_07_27_144623_create_reportback_item_table.php
+++ b/database/migrations/2016_07_27_144623_create_reportback_item_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReportbackItemTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reportback_item', function (Blueprint $table) {
+            $table->integer('reportback_id')->unsigned();
+            $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
+            $table->integer('fid')->unsigned();
+            $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
+            $table->string('caption')->nullable();
+            $table->string('status')->nullable()->default('pending');
+            $table->integer('reviewed')->unsigned()->nullable();
+            $table->integer('reviewer')->unsigned()->nullable();
+            $table->string('review_source')->nullable()->comment('Source URL which review was submitted from.');
+            $table->string('source')->nullable()->comment('Source which reportback file was submitted from.');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('reportback_item');
+    }
+}

--- a/database/migrations/2016_07_27_144623_create_reportback_item_table.php
+++ b/database/migrations/2016_07_27_144623_create_reportback_item_table.php
@@ -15,15 +15,17 @@ class CreateReportbackItemTable extends Migration
         Schema::create('reportback_item', function (Blueprint $table) {
             $table->integer('reportback_id')->unsigned();
             $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
-            $table->integer('file_id')->unsigned();
+            $table->integer('file_id')->index()->unsigned();
             $table->string('caption')->nullable();
-            $table->string('status')->nullable()->default('pending');
+            $table->string('status')->index()->nullable()->default('pending');
             $table->integer('reviewed')->unsigned()->nullable();
             $table->integer('reviewer')->unsigned()->nullable();
             $table->string('review_source')->nullable()->comment('Source URL which review was submitted from.');
             $table->string('source')->nullable()->comment('Source which reportback file was submitted from.');
             $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
             $table->timestamps();
+
+            $table->primary(['reportback_id', 'file_id']);
         });
     }
 

--- a/database/migrations/2016_07_27_165841_reportback_log.php
+++ b/database/migrations/2016_07_27_165841_reportback_log.php
@@ -16,6 +16,7 @@ class ReportbackLog extends Migration
             $table->increments('id');
             $table->integer('reportback_id')->unsigned();
             $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
+            $table->string('user_id')->comment('The rogue users.id that updated.');
             $table->integer('uid')->comment('The phoenix users.uid that updated.');
             $table->string('op')->nullable()->comment('Operation performed on the reportback.');
             $table->integer('quantity');

--- a/database/migrations/2016_07_27_165841_reportback_log.php
+++ b/database/migrations/2016_07_27_165841_reportback_log.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ReportbackLog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reportback_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('reportback_id')->unsigned();
+            $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
+            $table->integer('uid')->comment('The phoenix users.uid that updated.');
+            $table->string('op')->nullable()->comment('Operation performed on the reportback.');
+            $table->integer('quantity');
+            $table->text('why_participated')->nullable();
+            $table->string('files')->nullable()->comment('Comma separated list of file fids attached to reportback.');
+            $table->integer('num_files')->comment('The number of files attached to reportback.');
+            $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
+            $table->text('reason')->nullable()->comment('The reason the reoportback item was flagged/promoted');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('reportback_log');
+    }
+}

--- a/database/migrations/2016_07_27_165841_reportback_log.php
+++ b/database/migrations/2016_07_27_165841_reportback_log.php
@@ -16,8 +16,8 @@ class ReportbackLog extends Migration
             $table->increments('id');
             $table->integer('reportback_id')->unsigned();
             $table->foreign('reportback_id')->references('id')->on('reportback')->onDelete('cascade');
-            $table->string('user_id')->comment('The rogue users.id that updated.');
-            $table->integer('uid')->comment('The phoenix users.uid that updated.');
+            $table->string('northstar_id')->comment('The rogue users.id that updated.');
+            $table->integer('drupal_id')->comment('The phoenix users.uid that updated.');
             $table->string('op')->nullable()->comment('Operation performed on the reportback.');
             $table->integer('quantity');
             $table->text('why_participated')->nullable();

--- a/database/migrations/2016_07_27_172344_create_kudos_table.php
+++ b/database/migrations/2016_07_27_172344_create_kudos_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateKudosTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('kudos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('user_id')->comment('The rogue users.id that applied the kudos.');
+            $table->integer('uid')->comment('The phoenix users.uid that applied the kudos.');
+            $table->integer('fid')->comment('The reportback_file.fid that this kudos applies to.');
+            $table->integer('tid')->comment('The taxonomy_term.tid that this kudos belongs to.');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('kudos');
+    }
+}

--- a/database/migrations/2016_07_27_172344_create_kudos_table.php
+++ b/database/migrations/2016_07_27_172344_create_kudos_table.php
@@ -14,10 +14,10 @@ class CreateKudosTable extends Migration
     {
         Schema::create('kudos', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('user_id')->comment('The rogue users.id that applied the kudos.');
-            $table->integer('uid')->comment('The phoenix users.uid that applied the kudos.');
-            $table->integer('fid')->comment('The reportback_file.fid that this kudos applies to.');
-            $table->integer('tid')->comment('The taxonomy_term.tid that this kudos belongs to.');
+            $table->string('northstar_id')->comment('Users northstar id');
+            $table->integer('drupal_id')->comment('The phoenix users.uid that applied the kudos.');
+            $table->integer('file_id')->comment('The reportback_file.fid that this kudos applies to.');
+            $table->integer('taxonomy_id')->comment('The taxonomy_term.tid that this kudos belongs to.');
             $table->timestamps();
         });
     }

--- a/database/migrations/2016_07_27_172344_create_kudos_table.php
+++ b/database/migrations/2016_07_27_172344_create_kudos_table.php
@@ -14,11 +14,13 @@ class CreateKudosTable extends Migration
     {
         Schema::create('kudos', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('northstar_id')->comment('Users northstar id');
-            $table->integer('drupal_id')->comment('The phoenix users.uid that applied the kudos.');
-            $table->integer('file_id')->comment('The reportback_file.fid that this kudos applies to.');
-            $table->integer('taxonomy_id')->comment('The taxonomy_term.tid that this kudos belongs to.');
+            $table->string('northstar_id')->index()->comment('Users northstar id');
+            $table->integer('drupal_id')->index()->comment('The phoenix users.uid that applied the kudos.');
+            $table->integer('file_id')->index()->comment('The reportback_file.fid that this kudos applies to.');
+            $table->integer('taxonomy_id')->index()->comment('The taxonomy_term.tid that this kudos belongs to.');
             $table->timestamps();
+
+            $table->unique(['file_id', 'drupal_id', 'northstar_id', 'taxonomy_id']);
         });
     }
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,16 @@
+#### What's this PR do?
+tell us, what have you changed?
+
+#### How should this be reviewed?
+tell us, how can we review, to test that this works
+
+#### Any background context you want to provide?
+what else?
+
+#### Relevant tickets
+Fixes #
+
+#### Checklist
+- [ ] Documentation added for new features/changed endpoints.
+- [ ] Tested on staging.
+- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,11 @@ After the initial Homestead installation `ssh` into the vagrant box, head to the
 $ composer install
 ```
 
+Once all vendor dependencies are installed, run the migrations to setup the database:
+
+```shell
+$ php artisan migrate
+```
 # Laravel PHP Framework
 
 [![Build Status](https://travis-ci.org/laravel/framework.svg)](https://travis-ci.org/laravel/framework)


### PR DESCRIPTION
#### What's this PR do?

This PR adds migrations to the Rogue app to start to flush out the db structure. The goal is to have the db work just like it currently does now. 

Tables added:
* `reportback`
* `reportback_log`
* `reportback_item` formally known as `dosomething_reportback_file`
* `kudos`

#### How should this be reviewed?

Set up the app and run the migrations. The migrations should run smoothly. Compare the tables created to their corresponding tables in phoenix and the column settings should match up.

#### Any background context you want to provide?

Wasn't sure about how to handle northstar ids. I decided that, like in gladiator, since the user table will be storing northstar ids, we should just call columns that store northstar ids `user_id` 

To keep things consistent, I put `user_id` wherever `uid` is stored so we can have references to the northstar user on those tables, open to thoughts about that.

#### Relevant tickets
Addresses #1 

/cc @weerd @DFurnes @aaronschachter 