### PR TITLE
remove traling comma

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=5.5.9",
-        "laravel/framework": "5.2.*",
+        "laravel/framework": "5.2.*"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6",

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ $ php artisan db:seed
 You can build front-end assets (styles & scripts) with [Webpack](https://github.com/DoSomething/webpack-config):
 
 ```shell
+$ npm install
 $ npm start
 ```
 


### PR DESCRIPTION
#### What's this PR do?
Two little house cleaning things. 

* Removed a trailing comma that was causing `composer install` to bug out
* Updated the readme to include the step of running `npm install`