### PR TITLE
makes migration to change kudos table to reactions table, updates mod…

### DIFF
--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 
 namespace Rogue\Models;
 

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -1,10 +1,10 @@
-<?php
+ <?php
 
 namespace Rogue\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Kudo extends Model
+class Reaction extends Model
 {
     /**
      * The attributes that are mass assignable.
@@ -12,4 +12,12 @@ class Kudo extends Model
      * @var array
      */
     protected $fillable = ['id', 'northstar_id', 'drupal_id', 'file_id', 'taxonomy_id'];
+
+    /**
+     * The reportbacks that belont to the reaction.
+     */
+    public function reportbacks()
+    {
+        return $this->belongsToMany('App\Reportbacks');
+    }
 }

--- a/app/Models/Reportback.php
+++ b/app/Models/Reportback.php
@@ -20,4 +20,12 @@ class Reportback extends Model
     {
         return $this->hasMany(ReportbackItem::class);
     }
+
+    /**
+     * The reactions that belong to the reportback.
+     */
+    public function reactions()
+    {
+        return $this->belongsToMany('App\Reaction');
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.18.38",
+            "version": "3.18.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "979470feb19af8b5cd2f7a455407618416cdfadc"
+                "reference": "85f1fddaeb40b95106b2a2764268e9c89fc258ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/979470feb19af8b5cd2f7a455407618416cdfadc",
-                "reference": "979470feb19af8b5cd2f7a455407618416cdfadc",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/85f1fddaeb40b95106b2a2764268e9c89fc258ce",
+                "reference": "85f1fddaeb40b95106b2a2764268e9c89fc258ce",
                 "shasum": ""
             },
             "require": {
@@ -85,7 +85,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-08-09 18:09:34"
+            "time": "2016-08-11 16:40:35"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -988,16 +988,16 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.1.2",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "9a8db2cd42346f96993928ff6a6c22563f555ab1"
+                "reference": "7668cb045296f290588d04c391569c7b7fc1f899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/9a8db2cd42346f96993928ff6a6c22563f555ab1",
-                "reference": "9a8db2cd42346f96993928ff6a6c22563f555ab1",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/7668cb045296f290588d04c391569c7b7fc1f899",
+                "reference": "7668cb045296f290588d04c391569c7b7fc1f899",
                 "shasum": ""
             },
             "require": {
@@ -1042,7 +1042,7 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2016-07-27 11:09:37"
+            "time": "2016-08-13 23:12:58"
         },
         {
             "name": "league/flysystem",

--- a/database/migrations/2016_08_15_182521_rename_kudos_table_to_reactions_table.php
+++ b/database/migrations/2016_08_15_182521_rename_kudos_table_to_reactions_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class RenameKudosTableToReactionsTable extends Migration

--- a/database/migrations/2016_08_15_182521_rename_kudos_table_to_reactions_table.php
+++ b/database/migrations/2016_08_15_182521_rename_kudos_table_to_reactions_table.php
@@ -21,6 +21,6 @@ class RenameKudosTableToReactionsTable extends Migration
      */
     public function down()
     {
-        //
+        Schema::rename('reactions', 'kudos');
     }
 }

--- a/database/migrations/2016_08_15_182521_rename_kudos_table_to_reactions_table.php
+++ b/database/migrations/2016_08_15_182521_rename_kudos_table_to_reactions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameKudosTableToReactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('kudos', 'reactions');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2016_08_15_190345_create_reaction_reportback_table.php
+++ b/database/migrations/2016_08_15_190345_create_reaction_reportback_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReactionReportbackTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reaction_reportback', function (Blueprint $table) {
+            $table->integer('reaction_id')->unsigned()->index();
+            $table->foreign('reaction_id')->references('id')->on('reactions')->onDelete('cascade');
+            $table->integer('reportback_id')->unsigned()->index();
+            $table->foreign('reportback_id')->references('id')->on('reportbacks')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('reaction_reportback');
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
- Makes `2016_08_15_190345_create_reaction_reportback_table` migration to change `kudos` table to `reactions` table.
- Updates `Kudo` model to `Reaction` model. 
- Creates `reaction_reportback` table and updates respective models.  

#### How should this be reviewed?
Pull down code, run `php artisan migrate` and make sure:
 - `kudos` table is changed to `reactions` table in SequelPro
 - `reaction_reportback` table exists with two columns: `reaction_id` and `reportback_id`

#### Relevant tickets
Fixes #16 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
…els, and creates reaction_reportback pivot table