### PR TITLE
changes transformer to group reportbackItem info in media array

### DIFF
--- a/app/Http/Transformers/ReportbackItemTransformer.php
+++ b/app/Http/Transformers/ReportbackItemTransformer.php
@@ -18,8 +18,10 @@ class ReportbackItemTransformer extends TransformerAbstract
         return [
             'id' => (string) $reportbackItem->id,
             'reportback_id' => $reportbackItem->reportback_id,
-            'file_id' => $reportbackItem->file_id,
-            'file_url' => $reportbackItem->file_url,
+            'media' => [
+                'id' => $reportbackItem->file_id,
+                'url' => $reportbackItem->file_url,
+            ],
             'caption' => $reportbackItem->caption,
             'status' => $reportbackItem->status,
             'reviewed' => $reportbackItem->reviewed,

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -54,7 +54,7 @@ class ReportbackApiTest extends TestCase
         $this->seeInDatabase('reportback_items', ['reportback_id' => $response->data->id]);
 
         // Make sure the file is saved to S3 and the file_url is saved to the database.
-        $this->seeInDatabase('reportback_items', ['file_url' => $response->data->reportback_items->data[0]->file_url]);
+        $this->seeInDatabase('reportback_items', ['file_url' => $response->data->reportback_items->data[0]->media->url]);
 
         // Make sure we created a record in the reportback log table.
         $this->seeInDatabase('reportback_logs', ['reportback_id' => $response->data->id]);


### PR DESCRIPTION
#### What's this PR do?
updates `ReportbackItemTransformer.php` to group `file_id` and `file_url` under `media` to avoid long list of file properties and mirrors RB items resource endpoint. 

#### How should this be reviewed?
Run all tests again to make sure it works, similar to https://github.com/DoSomething/rogue/pull/25

#### Relevant tickets
Refs #https://github.com/DoSomething/rogue/pull/25#discussion-diff-76612494

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
