### PR TITLE
Update reportbacks

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -69,7 +69,7 @@ class ApiController extends BaseController
 
         $response = $manager->createData($data)->toArray();
 
-        return response()->json($response, 200, [], JSON_UNESCAPED_SLASHES);
+        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -3,7 +3,7 @@
 namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Reportback;
-use Illuminate\Http\Request;
+use Rogue\Http\Requests\ReportbackRequest;
 use Rogue\Services\ReportbackService;
 use Rogue\Http\Transformers\ReportbackTransformer;
 
@@ -30,8 +30,9 @@ class ReportbackController extends ApiController
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(ReportbackRequest $request)
     {
+        // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
         $type = $request['northstar_id'] ? 'northstar_id' : 'drupal_id';
 

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Controllers\Api;
 
+use Rogue\Models\Reportback;
 use Illuminate\Http\Request;
 use Rogue\Services\ReportbackService;
 use Rogue\Http\Transformers\ReportbackTransformer;
@@ -23,15 +24,27 @@ class ReportbackController extends ApiController
     }
 
     /**
-     * Store a newly created resource in storage.
-     * @todo upsert reportbacks by default.
+     * Store a newly created resource in storage or
+     * update a reportback if it already exists.
+     *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function create(Request $request)
+    public function store(Request $request)
     {
-        $reportback = $this->reportbackService->create($request->all());
+        $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
+        $type = $request['northstar_id'] ? 'northstar_id' : 'drupal_id';
 
-        return $this->item($reportback);
+        $reportback = $this->reportbackService->exists($request['campaign_id'], $request['campaign_run_id'], $userId, $type);
+
+        if (! $reportback) {
+            $reportback = $this->reportbackService->create($request->all());
+
+            return $this->item($reportback);
+        } else {
+            $updatedReportback = $this->reportbackService->update($reportback, $request->all());
+
+            return $this->item($updatedReportback);
+        }
     }
 }

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -36,7 +36,7 @@ class ReportbackController extends ApiController
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
         $type = $request['northstar_id'] ? 'northstar_id' : 'drupal_id';
 
-        $reportback = $this->reportbackService->exists($request['campaign_id'], $request['campaign_run_id'], $userId, $type);
+        $reportback = $this->reportbackService->getReportback($request['campaign_id'], $request['campaign_run_id'], $userId, $type);
 
         if (! $reportback) {
             $reportback = $this->reportbackService->create($request->all());

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -38,14 +38,18 @@ class ReportbackController extends ApiController
 
         $reportback = $this->reportbackService->getReportback($request['campaign_id'], $request['campaign_run_id'], $userId, $type);
 
-        if (! $reportback) {
+        $updating = ! is_null($reportback);
+
+        if (! $updating) {
             $reportback = $this->reportbackService->create($request->all());
 
-            return $this->item($reportback);
+            $code = 200;
         } else {
-            $updatedReportback = $this->reportbackService->update($reportback, $request->all());
+            $reportback = $this->reportbackService->update($reportback, $request->all());
 
-            return $this->item($updatedReportback);
+            $code = 201;
         }
+
+        return $this->item($reportback, $code);
     }
 }

--- a/app/Http/Requests/ReportbackRequest.php
+++ b/app/Http/Requests/ReportbackRequest.php
@@ -2,8 +2,6 @@
 
 namespace Rogue\Http\Requests;
 
-use Rogue\Http\Requests\Request;
-
 class ReportbackRequest extends Request
 {
     /**

--- a/app/Http/Requests/ReportbackRequest.php
+++ b/app/Http/Requests/ReportbackRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rogue\Http\Requests;
+
+use Rogue\Http\Requests\Request;
+
+class ReportbackRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'northstar_id' => 'required_without:drupal_id',
+            'drupal_id' => 'required_without:northstar_id',
+            'campaign_id' => 'required|int',
+            'campaign_run_id' => 'required|int',
+            'quantity' => 'int',
+            'why_participated' => 'string',
+            'caption' => 'string',
+            'source' => 'string',
+        ];
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -21,6 +21,6 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['api']], function () {
     });
 
     Route::get('reportbacks', 'Api\ReportbackController@index');
-    Route::post('reportbacks', 'Api\ReportbackController@create');
+    Route::post('reportbacks', 'Api\ReportbackController@store');
     Route::get('users', 'UsersController@index');
 });

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -120,7 +120,7 @@ class ReportbackRepository
      *
      * @return \Rogue\Models\Reportback|null
      */
-    public function getUserReportback($campaignId, $campaignRunId, $userId, $type = 'northstar_id')
+    public function getReportbackByUser($campaignId, $campaignRunId, $userId, $type = 'northstar_id')
     {
         try {
             if ($type === 'drupal_id') {

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -20,7 +20,7 @@ class ReportbackRepository
      *
      * @todo Handle errors better during creation.
      * @param  array $data
-     * @return \Rogue\Models\Reportback
+     * @return \Rogue\Models\Reportback|null
      */
     public function create($data)
     {

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -20,24 +20,63 @@ class ReportbackRepository
      *
      * @todo Handle errors better during creation.
      * @param  array $data
-     * @return \Gladiator\Models\Message
+     * @return \Rogue\Models\Reportback
      */
     public function create($data)
     {
-        // Store reportback
         $reportback = Reportback::create($data);
 
-        // Store reportback item photo in S3.
-        $data['file_url'] = $this->aws->storeImage($data['file'], $data['file_id']);
+        if ($reportback) {
+            $reportback = $this->addItem($reportback, $data);
 
-        // Store reportback item.
-        $reportback->items()->create(array_only($data, ['file_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr']));
+            // Record transaction in log table.
+            $this->log($reportback, $data, 'insert');
 
+            return $reportback;
+        }
+
+        return null;
+    }
+
+    /**
+     * Update an existing reportback.
+     *
+     * @param  \Rogue\Models\Reportback $reportback
+     * @param  array $data
+     *
+     * @return \Rogue\Models\Reportback
+     */
+    public function update($reportback, $data)
+    {
+        if (isset($data['file'])) {
+            $reportback = $this->addItem($reportback, $data);
+        }
+
+        $reportback->fill(array_only($data, ['quantity', 'why_participated', 'num_participants', 'flagged', 'flagged_reason', 'promoted', 'promoted_reason']));
+
+        $reportback->save();
+
+        $this->log($reportback, $data, 'update');
+
+        return $reportback;
+    }
+
+    /**
+     * Log a record in the reportback_logs table to track operations done on a reportback.
+     *
+     * @param  \Rogue\Models\Reportback $reportback
+     * @param  array $data
+     * @param  string $operation
+     *
+     * @return \Rogue\Models\Reportback
+     */
+    public function log($reportback, $data, $operation)
+    {
         // Record transaction in log table.
         $log = new ReportbackLog;
 
         $logData = [
-            'op' => 'insert',
+            'op' => $operation,
             'reportback_id' => $reportback->id,
             'files' => $reportback->items->implode('file_id', ','),
             'num_files' => $reportback->items->count(),
@@ -49,5 +88,58 @@ class ReportbackRepository
         $log->save();
 
         return $reportback;
+    }
+
+    /**
+     * Add a new item to a reportback.
+     *
+     * @param  \Rogue\Models\Reportback $reportback
+     * @param  array $data
+     *
+     * @return \Rogue\Models\Reportback
+     */
+    public function addItem($reportback, $data)
+    {
+        if (isset($data['file'])) {
+            // @todo - this part right here might actually belong in the service class now that i think about it.
+            $data['file_url'] = $this->aws->storeImage($data['file'], $data['file_id']);
+
+            $reportback->items()->create(array_only($data, ['file_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr']));
+        }
+
+        return $reportback;
+    }
+
+    /*
+     * Get a user's reportback based on their drupal id or their northstar id.
+     *
+     * @param string|int $campaignId
+     * @param string|int $campaignRunId
+     * @param string|int $userId
+     * @param string $type
+     *
+     * @return \Rogue\Models\Reportback|null
+     */
+    public function getUserReportback($campaignId, $campaignRunId, $userId, $type = 'northstar_id')
+    {
+        try {
+            if ($type === 'drupal_id') {
+                $reportback = Reportback::where([
+                    ['drupal_id', '=', $userId],
+                    ['campaign_id', '=', $campaignId],
+                    ['campaign_run_id', '=', $campaignRunId],
+                ])->firstOrFail();
+            } else {
+                $reportback = Reportback::where([
+                    ['northstar_id', '=', $userId],
+                    ['campaign_id', '=', $campaignId],
+                    ['campaign_run_id', '=', $campaignRunId],
+                ])->firstOrFail();
+            }
+
+            return $reportback;
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return null;
+        }
     }
 }

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -122,22 +122,18 @@ class ReportbackRepository
      */
     public function getReportbackByUser($campaignId, $campaignRunId, $userId, $type = 'northstar_id')
     {
-        try {
-            if ($type === 'drupal_id') {
-                $reportback = Reportback::where([
-                    ['drupal_id', '=', $userId],
-                    ['campaign_id', '=', $campaignId],
-                    ['campaign_run_id', '=', $campaignRunId],
-                ])->firstOrFail();
-            } else {
-                $reportback = Reportback::where([
-                    ['northstar_id', '=', $userId],
-                    ['campaign_id', '=', $campaignId],
-                    ['campaign_run_id', '=', $campaignRunId],
-                ])->firstOrFail();
-            }
+        if (! in_array($type, ['northstar_id', 'drupal_id'])) {
+            throw new \Exception('Invalid user ID type provided.');
+        }
 
-            return $reportback;
+        $parameters = [
+            $type => $userId,
+            'campaign_id' => $campaignId,
+            'campaign_run_id' => $campaignRunId,
+        ];
+
+        try {
+            return Reportback::where($parameters)->firstOrFail();
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             return null;
         }

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -132,10 +132,6 @@ class ReportbackRepository
             'campaign_run_id' => $campaignRunId,
         ];
 
-        try {
-            return Reportback::where($parameters)->firstOrFail();
-        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
-            return null;
-        }
+        return Reportback::where($parameters)->first();
     }
 }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -63,7 +63,7 @@ class ReportbackService
      *
      * @return \Rogue\Models\Reportback|bool
      */
-    public function exists($campaignId, $campaignRunId, $userId, $type)
+    public function getReportback($campaignId, $campaignRunId, $userId, $type)
     {
         $reportback = $this->reportbackRepository->getReportbackByUser($campaignId, $campaignRunId, $userId, $type);
 

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -2,12 +2,20 @@
 
 namespace Rogue\Services;
 
+use Rogue\Models\Reportback;
 use Rogue\Repositories\ReportbackRepository;
 use Rogue\Services\Phoenix\Phoenix;
 
 class ReportbackService
 {
+    /*
+     * Instance of \Rogue\Repositories\ReportbackRepository
+     */
     protected $reportbackRepository;
+
+    /*
+     * Instance of \Rogue\Services\Phoenix\Phoenix
+     */
     protected $phoenix;
 
     public function __construct(ReportbackRepository $reportbackRepository, Phoenix $phoenix)
@@ -27,5 +35,38 @@ class ReportbackService
         $reportback = $this->reportbackRepository->create($data);
 
         return $reportback;
+    }
+
+    /*
+     * Handles all the business logic around updating a reportback.
+     *
+     * @param \Rogue\Models\Reportback $reportback
+     * @param array $data
+     *
+     * @return \Rogue\Models\Reportback $reportback.
+     */
+    public function update($reportback, $data)
+    {
+        $reportback = $this->reportbackRepository->update($reportback, $data);
+
+        return $reportback;
+    }
+
+    /*
+     * Check if a reportback already exists for a given user,
+     * on a specific campaign, and campaign run.
+     *
+     * @param string|int $campaignId
+     * @param string|int $campaignRunId
+     * @param string|int $userId
+     * @param string $type
+     *
+     * @return \Rogue\Models\Reportback|bool
+     */
+    public function exists($campaignId, $campaignRunId, $userId, $type)
+    {
+        $reportback = $this->reportbackRepository->getUserReportback($campaignId, $campaignRunId, $userId, $type);
+
+        return $reportback ? $reportback : false;
     }
 }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -61,12 +61,12 @@ class ReportbackService
      * @param string|int $userId
      * @param string $type
      *
-     * @return \Rogue\Models\Reportback|bool
+     * @return \Rogue\Models\Reportback|null
      */
     public function getReportback($campaignId, $campaignRunId, $userId, $type)
     {
         $reportback = $this->reportbackRepository->getReportbackByUser($campaignId, $campaignRunId, $userId, $type);
 
-        return $reportback ? $reportback : false;
+        return $reportback ? $reportback : null;
     }
 }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -65,7 +65,7 @@ class ReportbackService
      */
     public function exists($campaignId, $campaignRunId, $userId, $type)
     {
-        $reportback = $this->reportbackRepository->getUserReportback($campaignId, $campaignRunId, $userId, $type);
+        $reportback = $this->reportbackRepository->getReportbackByUser($campaignId, $campaignRunId, $userId, $type);
 
         return $reportback ? $reportback : false;
     }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "aws/aws-sdk-php-laravel": "^3.1",
         "league/fractal": "^0.13.0",
         "guzzlehttp/guzzle": "^6.2",
-        "dosomething/northstar": "1.0.0-rc7"
+        "dosomething/northstar": "1.0.0-rc7",
+        "doctrine/dbal": "^2.5"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5412d074b83eb5c6e04919d336c38508",
-    "content-hash": "dae8db975bb28634de46ee8872b3cb56",
+    "hash": "dd1f63689a64701721222a7387145caf",
+    "content-hash": "b161b3cac07d4dd52630a595ad2055c2",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-<<<<<<< HEAD
-
-=======
->>>>>>> test working
             "version": "3.19.2",
             "source": {
                 "type": "git",
@@ -23,10 +19,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3cb90413129da42c9d3289d542bee0ae1049892c",
                 "reference": "3cb90413129da42c9d3289d542bee0ae1049892c",
-<<<<<<< HEAD
-                league/flysystem-aws-s3-v3: ~1.0
-=======
->>>>>>> test working
                 "shasum": ""
             },
             "require": {
@@ -94,8 +86,6 @@
                 "sdk"
             ],
             "time": "2016-08-23 20:58:48"
-
-            league/flysystem-aws-s3-v3: ~1.0
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -241,6 +231,354 @@
             "time": "2014-10-24 07:27:01"
         },
         {
+            "name": "doctrine/annotations",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Annotations\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2015-08-31 12:32:49"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2015-12-31 16:37:02"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2015-04-14 22:21:58"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~5.5|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2015-12-25 13:18:31"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.4,<2.7-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2016-01-05 22:11:12"
+        },
+        {
             "name": "doctrine/inflector",
             "version": "v1.1.0",
             "source": {
@@ -306,6 +644,60 @@
                 "string"
             ],
             "time": "2015-11-06 14:35:42"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "dosomething/northstar",
@@ -1985,8 +2377,6 @@
         },
         {
             "name": "spatie/laravel-backup",
-<<<<<<< HEAD
-<<<<<<< HEAD
             "version": "3.10.2",
             "source": {
                 "type": "git",
@@ -1997,26 +2387,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
                 "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
-=======
-            "version": "3.10.1",
-=======
-            "version": "3.10.2",
->>>>>>> test working
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/laravel-backup.git",
-                "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf"
-            },
-            "dist": {
-                "type": "zip",
-<<<<<<< HEAD
-                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/e17bed15f5b3f5e52421aa83d3608dc2d4d4d63b",
-                "reference": "e17bed15f5b3f5e52421aa83d3608dc2d4d4d63b",
->>>>>>>         league/flysystem-aws-s3-v3: ~1.0
-=======
-                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
-                "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
->>>>>>> test working
                 "shasum": ""
             },
             "require": {
@@ -2066,15 +2436,7 @@
                 "laravel-backup",
                 "spatie"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
             "time": "2016-08-24 12:02:50"
-=======
-            "time": "2016-08-16 07:43:54"
->>>>>>>         league/flysystem-aws-s3-v3: ~1.0
-=======
-            "time": "2016-08-24 12:02:50"
->>>>>>> test working
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -3,7 +3,7 @@
 use Faker\Generator;
 use Rogue\Models\Reportback;
 use Rogue\Models\ReportbackItem;
-use Rogue\Models\Kudo;
+use Rogue\Models\Reaction;
 
 /*
 |--------------------------------------------------------------------------
@@ -34,7 +34,7 @@ $factory->define(Reportback::class, function (Generator $faker) {
 });
 
 // Kudo Factory
-$factory->define(Kudo::class, function (Generator $faker) {
+$factory->define(Reaction::class, function (Generator $faker) {
     $files = ReportbackItem::all()->pluck('file_id');
 
     return [

--- a/database/migrations/2016_06_29_205018_add_oauth_fields_to_users.php
+++ b/database/migrations/2016_06_29_205018_add_oauth_fields_to_users.php
@@ -33,7 +33,6 @@ class AddOauthFieldsToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropIndex('northstar_id');
             $table->dropColumn('northstar_id');
 
             $table->dropColumn('access_token');

--- a/database/migrations/2016_06_29_205018_create_oauth_client_table.php
+++ b/database/migrations/2016_06_29_205018_create_oauth_client_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateOAuthClientTable extends Migration
+class CreateOauthClientTable extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2016_08_18_182212_add_file_url_to_reportback_items.php
+++ b/database/migrations/2016_08_18_182212_add_file_url_to_reportback_items.php
@@ -12,7 +12,7 @@ class AddFileUrlToReportbackItems extends Migration
     public function up()
     {
         Schema::table('reportback_items', function ($table) {
-            $table->string('file_url');
+            $table->string('file_url')->after('file_id');
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,6 +14,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ReportbackSeeder::class);
         $this->call(ReportbackItemSeeder::class);
         $this->call(ReportbackLogSeeder::class);
-        $this->call(KudoSeeder::class);
+        $this->call(ReactionSeeder::class);
     }
 }

--- a/database/seeds/ReactionSeeder.php
+++ b/database/seeds/ReactionSeeder.php
@@ -1,9 +1,9 @@
 <?php
 
-use Rogue\Models\Kudo;
+use Rogue\Models\Reaction;
 use Illuminate\Database\Seeder;
 
-class KudoSeeder extends Seeder
+class ReactionSeeder extends Seeder
 {
     /**
      * Run the database seeds.
@@ -12,6 +12,6 @@ class KudoSeeder extends Seeder
      */
     public function run()
     {
-        factory(Kudo::class, 10)->create();
+        factory(Reaction::class, 10)->create();
     }
 }

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -84,10 +84,15 @@ class ReportbackApiTest extends TestCase
             'remote_addr' => '207.110.19.130',
         ]);
 
-        $this->assertEquals(200, $response->status());
+        $this->assertResponseStatus(201);
 
-        $response = json_decode($response->content());
+        $this->seeJsonSubset([
+            'data' => [
+                'quantity' => 2000,
+            ],
+        ]);
+        // $response = json_decode($response->content());
 
-        $this->assertEquals($response->data->quantity, 2000);
+        // $this->assertEquals($response->data->quantity, 2000);
     }
 }

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -61,11 +61,11 @@ class ReportbackApiTest extends TestCase
     }
 
     /**
-     * Test if sending a reportback that is already stored throws a 500 error.
+     * Test updating an existing reportback
      *
      * @return void
      */
-    public function testErrorOnDuplicateReportback()
+    public function testUpdatingReportback()
     {
         $reportback = factory(Reportback::class)->create();
 
@@ -74,7 +74,8 @@ class ReportbackApiTest extends TestCase
             'drupal_id' => $reportback->drupal_id,
             'campaign_id' => $reportback->campaign_id,
             'campaign_run_id' => $reportback->campaign_run_id,
-            'quantity' => $this->faker->numberBetween(10, 1000),
+            // Change quanitity.
+            'quantity' => 2000,
             'why_participated' => $this->faker->paragraph(3),
             'num_participated' => null,
             'file_id' => $this->faker->randomNumber(4),
@@ -83,6 +84,10 @@ class ReportbackApiTest extends TestCase
             'remote_addr' => '207.110.19.130',
         ]);
 
-        $this->assertEquals(500, $response->status());
+        $this->assertEquals(200, $response->status());
+
+        $response = json_decode($response->content());
+
+        $this->assertEquals($response->data->quantity, 2000);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
If a reportback already exists, this PR updates the reportback with the data that is passed in the requests. 

Right now "Already exists" means there is a record in the `reportback` table with a unique combination of `drupal_id` or `northstar_id`, `campaign_id`, and `campaign_run_id`. Eventually we could use `id` to determine if a reportback exists. But since we are maintaining two different systems, a reportback might have different ids in Phoenix and Rogue and the systems are unaware of the ids set in the other system. I would be up to discussing if we need to like store `rbid` in rogue or `rogue_reportback_id` in drupal in the meantime. I think it might be useful especially when working with reportback items.

I put some comments on some other things I updated and why. I also left out some stuff that I also think we need to think through like updating reviewed status per item when it is reviewed (how do we identify the corresponding items in phoenix and rogue?) and or an API endpoints that just deal with items. 

#### How should this be reviewed?

run `phpunit` make sure tests pass. Also make a requests to update a value of a reportback that already exists. 

#### Relevant tickets
Fixes #20 #11 
