### PR TITLE
Queue

### DIFF
--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -7,24 +7,22 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Rogue\Services\Phoenix;
+use Rogue\Models\Reportback;
 
 class SendReportbackToPhoenix extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
 
-    protected $nid;
-    protected $body;
-
+    protected $reportback;
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($nid, $body)
+    public function __construct(Reportback $reportback)
     {
         $this->phoenix = new Phoenix;
-        $this->nid = $nid;
-        $this->body = $body;
+        $this->reportback = $reportback;
     }
 
     /**
@@ -34,7 +32,16 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
      */
     public function handle()
     {
-        dd('made it to the job!');
-        return $this->phoenix->postReportback($this->nid, $this->body);
+        $body = [
+            'uid' => $this->reportback->drupal_id,
+            'nid' => $this->reportback->campaign_id,
+            'quantity' => $this->reportback->quantity,
+            'why_participated' => $this->reportback->why_participated,
+            'file_url' => $this->reportback->items()->first()->file_url,
+            'caption' => $this->reportback->items()->first()->caption,
+            'source' => $this->reportback->items()->first()->source,
+        ];
+
+        return $this->phoenix->postReportback($this->reportback->campaign_id, $body);
     }
 }

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -6,24 +6,25 @@ use Rogue\Jobs\Job;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Rogue\Services\Phoenix;
 
 class SendReportbackToPhoenix extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
 
-    /*
-     * Instance of \Rogue\Services\Phoenix\Phoenix
-     */
-    protected $phoenix;
+    protected $nid;
+    protected $body;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(Phoenix $phoenix)
+    public function __construct($nid, $body)
     {
-        $this->phoenix = $phoenix;
+        $this->phoenix = new Phoenix;
+        $this->nid = $nid;
+        $this->body = $body;
     }
 
     /**
@@ -31,8 +32,9 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
      *
      * @return void
      */
-    public function handle($nid, $body)
+    public function handle()
     {
-        return $this->phoenix->postReportback($nid, $body);
+        dd('made it to the job!');
+        return $this->phoenix->postReportback($this->nid, $this->body);
     }
 }

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -32,6 +32,8 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
      */
     public function handle()
     {
+        $phoenix = new Phoenix;
+
         $body = [
             'uid' => $this->reportback->drupal_id,
             'nid' => $this->reportback->campaign_id,
@@ -42,6 +44,6 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
             'source' => $this->reportback->items()->first()->source,
         ];
 
-        return $this->phoenix->postReportback($this->reportback->campaign_id, $body);
+        return $phoenix->postReportback($this->reportback->campaign_id, $body);
     }
 }

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Jobs;
 
-use Rogue\Jobs\Job;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -14,6 +13,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
     use InteractsWithQueue, SerializesModels;
 
     protected $reportback;
+
     /**
      * Create a new job instance.
      *

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rogue\Jobs;
+
+use Rogue\Jobs\Job;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendReportbackToPhoenix extends Job implements ShouldQueue
+{
+    use InteractsWithQueue, SerializesModels;
+
+    /*
+     * Instance of \Rogue\Services\Phoenix\Phoenix
+     */
+    protected $phoenix;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Phoenix $phoenix)
+    {
+        $this->phoenix = $phoenix;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle($nid, $body)
+    {
+        return $this->phoenix->postReportback($nid, $body);
+    }
+}

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -44,6 +44,6 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
             'source' => $this->reportback->items()->first()->source,
         ];
 
-        return $phoenix->postReportback($this->reportback->campaign_id, $body);
+        $phoenix->postReportback($this->reportback->campaign_id, $body);
     }
 }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -37,7 +37,7 @@ class ReportbackService
 
         // POST reportback back to phoenix.
         // If request fails, record in failed_jobs table.
-        $phoenixResponse = dispatch(new SendReportbackToPhoenix($reportback));
+        dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;
     }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -5,6 +5,7 @@ namespace Rogue\Services;
 use Rogue\Models\Reportback;
 use Rogue\Repositories\ReportbackRepository;
 use Rogue\Models\FailedLog;
+use Rogue\Jobs\SendReportbackToPhoenix;
 
 class ReportbackService
 {
@@ -14,14 +15,14 @@ class ReportbackService
     protected $reportbackRepository;
 
     /*
-     * Instance of \Rogue\Services\Phoenix\Phoenix
+     * Instance of \Rogue\Jobs\SendReportbackToPhoenix
      */
-    protected $phoenix;
+    protected $sendReportbackToPhoenix;
 
-    public function __construct(ReportbackRepository $reportbackRepository, Phoenix $phoenix)
+    public function __construct(ReportbackRepository $reportbackRepository, SendReportbackToPhoenix $sendReportbackToPhoenix)
     {
         $this->reportbackRepository = $reportbackRepository;
-        $this->phoenix = $phoenix;
+        $this->sendReportbackToPhoenix = $sendReportbackToPhoenix;
     }
 
     /*
@@ -45,9 +46,10 @@ class ReportbackService
             'source' => $reportback->items()->first()->source,
         ];
 
-        // $phoenixResponse = $this->phoenix->postReportback($reportback->campaign_id, $body);
+        $nid = $reportback->campaign_id;
 
-        $phoenixResponse = $this->dispatch(new SendReportbackToPhoenix($reportback->campaign_id, $body));
+        // $phoenixResponse = $this->phoenix->postReportback($reportback->campaign_id, $body);
+        $phoenixResponse = dispatch(new SendReportbackToPhoenix($nid, $body));
 
         // If POST to Phoenix fails, record in failed_logs table.
         // if ($phoenixResponse === false) {

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -45,26 +45,28 @@ class ReportbackService
             'source' => $reportback->items()->first()->source,
         ];
 
-        $phoenixResponse = $this->phoenix->postReportback($reportback->campaign_id, $body);
+        // $phoenixResponse = $this->phoenix->postReportback($reportback->campaign_id, $body);
+
+        $phoenixResponse = $this->dispatch(new SendReportbackToPhoenix($reportback->campaign_id, $body));
 
         // If POST to Phoenix fails, record in failed_logs table.
-        if ($phoenixResponse === false) {
-            $failedLog = new FailedLog;
+        // if ($phoenixResponse === false) {
+        //     $failedLog = new FailedLog;
 
-            $logData = [
-                'op' => 'POST to Phoenix',
-                'drupal_id' => $body['uid'],
-                'nid' => $body['nid'],
-                'quantity' => $body['quantity'],
-                'why_participated' => $body['why_participated'],
-                'file_url' => $body['file_url'],
-                'caption' => $body['caption'],
-                'source' => $body['source'],
-            ];
+        //     $logData = [
+        //         'op' => 'POST to Phoenix',
+        //         'drupal_id' => $body['uid'],
+        //         'nid' => $body['nid'],
+        //         'quantity' => $body['quantity'],
+        //         'why_participated' => $body['why_participated'],
+        //         'file_url' => $body['file_url'],
+        //         'caption' => $body['caption'],
+        //         'source' => $body['source'],
+        //     ];
 
-            $failedLog->fill($logData);
-            $failedLog->save();
-        }
+        //     $failedLog->fill($logData);
+        //     $failedLog->save();
+        // }
 
         return $reportback;
     }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -36,20 +36,7 @@ class ReportbackService
         $reportback = $this->reportbackRepository->create($data);
 
         // POST reportback back to phoenix.
-        $body = [
-            'uid' => $reportback->drupal_id,
-            'nid' => $reportback->campaign_id,
-            'quantity' => $reportback->quantity,
-            'why_participated' => $reportback->why_participated,
-            'file_url' => $reportback->items()->first()->file_url,
-            'caption' => $reportback->items()->first()->caption,
-            'source' => $reportback->items()->first()->source,
-        ];
-
-        $nid = $reportback->campaign_id;
-
-        // $phoenixResponse = $this->phoenix->postReportback($reportback->campaign_id, $body);
-        $phoenixResponse = dispatch(new SendReportbackToPhoenix($nid, $body));
+        $phoenixResponse = dispatch(new SendReportbackToPhoenix($reportback));
 
         // If POST to Phoenix fails, record in failed_logs table.
         // if ($phoenixResponse === false) {

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -36,26 +36,8 @@ class ReportbackService
         $reportback = $this->reportbackRepository->create($data);
 
         // POST reportback back to phoenix.
+        // If request fails, record in failed_jobs table.
         $phoenixResponse = dispatch(new SendReportbackToPhoenix($reportback));
-
-        // If POST to Phoenix fails, record in failed_logs table.
-        // if ($phoenixResponse === false) {
-        //     $failedLog = new FailedLog;
-
-        //     $logData = [
-        //         'op' => 'POST to Phoenix',
-        //         'drupal_id' => $body['uid'],
-        //         'nid' => $body['nid'],
-        //         'quantity' => $body['quantity'],
-        //         'why_participated' => $body['why_participated'],
-        //         'file_url' => $body['file_url'],
-        //         'caption' => $body['caption'],
-        //         'source' => $body['source'],
-        //     ];
-
-        //     $failedLog->fill($logData);
-        //     $failedLog->save();
-        // }
 
         return $reportback;
     }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -4,7 +4,6 @@ namespace Rogue\Services;
 
 use Rogue\Models\Reportback;
 use Rogue\Repositories\ReportbackRepository;
-use Rogue\Models\FailedLog;
 use Rogue\Jobs\SendReportbackToPhoenix;
 
 class ReportbackService

--- a/database/migrations/2016_09_08_154007_create_failed_jobs_table.php
+++ b/database/migrations/2016_09_08_154007_create_failed_jobs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateFailedJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('failed_jobs');
+    }
+}

--- a/database/migrations/2016_09_12_153211_drop_failed_logs_table.php
+++ b/database/migrations/2016_09_12_153211_drop_failed_logs_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropFailedLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('failed_logs');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('failed_logs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('drupal_id')->comment('The phoenix users.uid.');
+            $table->integer('nid');
+            $table->integer('quantity');
+            $table->text('why_participated')->nullable();
+            $table->string('file_url');
+            $table->string('caption');
+            $table->string('source');
+            $table->string('op')->nullable()->comment('Operation performed on the reportback.');
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -132,9 +132,10 @@ class ReportbackApiTest extends TestCase
         ];
 
         $this->json('POST', $this->reportbackApiUrl, $reportback);
+        dd($this->json('POST', $this->reportbackApiUrl, $reportback));
         $response = $this->decodeResponseJson();
 
         // Make sure we created a record in the reportback log table.
-        $this->seeInDatabase('failed_logs', ['drupal_id' => $response['data']['drupal_id']]);
+        $this->seeInDatabase('failed_jobs', ['drupal_id' => $response['data']['drupal_id']]);
     }
 }

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -27,8 +27,8 @@ class ReportbackApiTest extends TestCase
         // Mock sending image to AWS.
         $this->fileSystem->shouldReceive('put')->andReturn(true);
 
-        // Mock sending reportback back to Phoenix.
-        $this->phoenix->shouldReceive('postReportback')->andReturn('12345');
+        // Mock job that sends reportback back to Phoenix.
+        $this->expectsJobs(Rogue\Jobs\SendReportbackToPhoenix::class);
 
         // Create an uploaded file.
         $file = $this->mockFile();
@@ -98,44 +98,5 @@ class ReportbackApiTest extends TestCase
         // $response = json_decode($response->content());
 
         // $this->assertEquals($response->data->quantity, 2000);
-    }
-
-    /**
-     * Test that a record is created in the failed log table if Phoenix returns FALSE.
-     *
-     * @return void
-     */
-    public function testErrorOnPostToPhoenix()
-    {
-        // Mock sending image to AWS.
-        $this->fileSystem->shouldReceive('put')->andReturn(true);
-
-        // Mock sending reportback back to Phoenix.
-        $this->phoenix->shouldReceive('postReportback')->andReturn(FALSE);
-
-        // Create an uploaded file.
-        $file = $this->mockFile();
-
-        $reportback = [
-            'northstar_id'     => str_random(24),
-            'drupal_id'        => $this->faker->randomNumber(8),
-            'campaign_id'      => $this->faker->randomNumber(4),
-            'campaign_run_id'  => $this->faker->randomNumber(4),
-            'quantity'         => $this->faker->numberBetween(10, 1000),
-            'why_participated' => $this->faker->paragraph(3),
-            'num_participants' => null,
-            'file_id' => $this->faker->randomNumber(4),
-            'caption' => $this->faker->sentence(),
-            'source' => 'runscope',
-            'remote_addr' => '207.110.19.130',
-            'file' => $file,
-        ];
-
-        $this->json('POST', $this->reportbackApiUrl, $reportback);
-        dd($this->json('POST', $this->reportbackApiUrl, $reportback));
-        $response = $this->decodeResponseJson();
-
-        // Make sure we created a record in the reportback log table.
-        $this->seeInDatabase('failed_jobs', ['drupal_id' => $response['data']['drupal_id']]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,7 +36,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 
         // Setup mocks
         $this->fileSystem = $this->mock(Illuminate\Filesystem\Filesystem::class);
-        $this->phoenix = $this->mock(Rogue\Services\Phoenix::class);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Refactors to use Laravel queues and error handling.
- Updates test to mock the job that sends reporback from Rogue->Phoenix instead of the Phoenix class.
- Drops the `failed_logs` table.
- Adds the `failed_jobs` table. 

#### How should this be reviewed?
- Make sure the tests are passing by running `phpunit` in the vagrant box.
- To manually test:
  - Log into your local. 
  - Sign up for a campaign. 
  - Go to your "My Account" page. 
  - See that you are signed up for that campaign.
  - Post reportback via postman for that campaign and campaign run, with your `drupal_id`. 
  - Refresh your "My Account" page and make sure the campaign has been moved from "YOU'RE DOING" to "YOU DID"
  Example Postman request:
![screen shot 2016-09-12 at 3 06 15 pm](https://cloud.githubusercontent.com/assets/9019452/18448807/7c679b48-78fa-11e6-8ea8-f53a78319439.png)

#### Any background context you want to provide?
Question -  @sbsmith86 when we are updating the reportback, do we want to dispatch the job to send this to Phoenix as well?

Note from Shae for future planning: 
Shae Smith [11:27 AM]  
I don’t know if this is needed at the moment, but we could also use the event system in laravel to send stuff to queues since we might want a way of notifiying a bunch of systems that something happened in rogue. but I think this approach is fine for now.
https://dosomething.slack.com/archives/rogue/p1473348457000138

#### Relevant tickets
Fixes #34 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.