### PR TITLE
fixes url to find correct place where image is stored

### DIFF
--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -58,7 +58,7 @@ class AWS
             throw new HttpException(500, 'Unable to save image to S3.');
         }
 
-        return config('filesystems.disks.s3.public_url') . $path;
+        return config('filesystems.disks.s3.public_url') . '/ds-rogue-prod' . $path;
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Corrected the AWS URL to point to correct URL where image is stored. 

#### How should this be reviewed?
To manually test:
  - Log into your local. 
  - Sign up for a campaign. 
  - Go to your "My Account" page. 
  - See that you are signed up for that campaign.
  - Post reportback via postman for that campaign and campaign run, with your `drupal_id`. 
  - Refresh your "My Account" page and make sure the campaign has been moved from "YOU'RE DOING" to "YOU DID" and that your reportback photo correctly shows up instead of a broken image icon. 
Example Postman request: 
![screen shot 2016-09-15 at 3 31 28 pm](https://cloud.githubusercontent.com/assets/9019452/18564449/81bdc9f8-7b59-11e6-8ba8-f50355ffbdc4.png)

#### Relevant tickets
Fixes [this user story](https://trello.com/c/PV5hS3ts/9-as-a-developer-i-want-the-images-transferring-from-rogue-to-phoenix-to-not-be-broken). 
