### PR TITLE
use storage facade to mock sending files to aws

### DIFF
--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -3,26 +3,13 @@
 namespace Rogue\Services;
 
 use finfo;
-use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Filesystem\FilesystemManager;
+use Storage;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class AWS
 {
-    /**
-     * The Amazon S3 file system.
-     * @see https://laravel.com/docs/5.2/filesystem
-     * @var Filesystem
-     */
-    protected $filesystem;
-
-    public function __construct(FilesystemManager $filesystem)
-    {
-        $this->filesystem = $filesystem->disk('s3');
-    }
-
     /**
      * Store a reportback item (image) in S3.
      *
@@ -52,7 +39,7 @@ class AWS
         $path = '/uploads/reportback-items' . '/' . $filename . '-' . time() . '.' . $extension;
 
         // Push file to S3.
-        $success = $this->filesystem->put($path, $data);
+        $success = Storage::put($path, $data);
 
         if (! $success) {
             throw new HttpException(500, 'Unable to save image to S3.');

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -27,7 +27,8 @@ class ReportbackApiTest extends TestCase
     public function testCreatingNewReportback()
     {
         // Mock sending image to AWS.
-        $this->fileSystem->shouldReceive('put')->andReturn(true);
+        Storage::shouldReceive('put')
+                    ->andReturn(true);
 
         // Mock job that sends reportback back to Phoenix.
         $this->expectsJobs(Rogue\Jobs\SendReportbackToPhoenix::class);
@@ -43,11 +44,11 @@ class ReportbackApiTest extends TestCase
             'quantity'         => $this->faker->numberBetween(10, 1000),
             'why_participated' => $this->faker->paragraph(3),
             'num_participants' => null,
-            'file_id' => $this->faker->randomNumber(4),
-            'caption' => $this->faker->sentence(),
-            'source' => 'runscope',
-            'remote_addr' => '207.110.19.130',
-            'file' => $file,
+            'file_id'          => $this->faker->randomNumber(4),
+            'caption'          => $this->faker->sentence(),
+            'source'           => 'runscope',
+            'remote_addr'      => '207.110.19.130',
+            'file'             => $file,
         ];
 
         $this->json('POST', $this->reportbackApiUrl, $reportback);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,9 +33,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         parent::setUp();
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
-
-        // Setup mocks
-        $this->fileSystem = $this->mock(Illuminate\Filesystem\Filesystem::class);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
We now use the `Storage` facade to interact with AWS so we can use more laravel 🔮  and mock the call to put the uploaded files on AWS. Doing this also allowed us to delete some things.

#### How should this be reviewed?
I think the best way to test is to first try to post a reportback and make sure your file still goes to AWS. Then, remove all the aws/s3 credentials from your `.env` and make sure the tests pass. This insures that the mock is working as expected. Don't forget to add your credentials back in.

#### Relevant tickets
no tickets created

#### Checklist
- [ ] Tested on staging.

cc: @chloealee and shoutout to @DFurnes for his Otwellian Magic