### PR TITLE
Sends updated reportback and new reportback items to phoenix

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -48,7 +48,6 @@ class ReportbackController extends ApiController
             $reportback = $this->reportbackService->create($request->all());
 
             $code = 200;
-            dd('hi');
         } else {
             $reportback = $this->reportbackService->update($reportback, $request->all());
 

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -48,6 +48,7 @@ class ReportbackController extends ApiController
             $reportback = $this->reportbackService->create($request->all());
 
             $code = 200;
+            dd('hi');
         } else {
             $reportback = $this->reportbackService->update($reportback, $request->all());
 

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -32,6 +32,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
     public function handle()
     {
         $phoenix = new Phoenix;
+
         $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
 
         $body = [

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -32,15 +32,16 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
     public function handle()
     {
         $phoenix = new Phoenix;
+        $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
 
         $body = [
             'uid' => $this->reportback->drupal_id,
             'nid' => $this->reportback->campaign_id,
             'quantity' => $this->reportback->quantity,
             'why_participated' => $this->reportback->why_participated,
-            'file_url' => $this->reportback->items()->first()->file_url,
-            'caption' => $this->reportback->items()->first()->caption,
-            'source' => $this->reportback->items()->first()->source,
+            'file_url' => $reportbackItem->file_url,
+            'caption' => $reportbackItem->caption,
+            'source' => $reportbackItem->source,
         ];
 
         $phoenix->postReportback($this->reportback->campaign_id, $body);

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -44,5 +44,6 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
         ];
 
         $phoenix->postReportback($this->reportback->campaign_id, $body);
+
     }
 }

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -44,6 +44,5 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
         ];
 
         $phoenix->postReportback($this->reportback->campaign_id, $body);
-
     }
 }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -47,8 +47,8 @@ class ReportbackService
     {
         $reportback = $this->reportbackRepository->update($reportback, $data);
 
-        // Update reportback in Phoenix.
-        // If request fails, record in the failed_jobs table.
+        // POST reportback update back to Phoenix.
+        // If request fails, record in failed_jobs table.
         dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -28,7 +28,7 @@ class ReportbackService
     {
         $reportback = $this->reportbackRepository->create($data);
 
-        // POST reportback back to phoenix.
+        // POST reportback back to Phoenix.
         // If request fails, record in failed_jobs table.
         dispatch(new SendReportbackToPhoenix($reportback));
 
@@ -46,6 +46,10 @@ class ReportbackService
     public function update($reportback, $data)
     {
         $reportback = $this->reportbackRepository->update($reportback, $data);
+
+        // Update reportback in Phoenix.
+        // If request fails, record in the failed_jobs table.
+        dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;
     }

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -76,6 +76,9 @@ class ReportbackApiTest extends TestCase
     {
         $reportback = factory(Reportback::class)->create();
 
+        // Mock job that sends reportback back to Phoenix.
+        $this->expectsJobs(Rogue\Jobs\SendReportbackToPhoenix::class);
+
         $response = $this->call('POST', $this->reportbackApiUrl, [
             'northstar_id' => $reportback->northstar_id,
             'drupal_id' => $reportback->drupal_id,

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -107,11 +107,11 @@ class ReportbackApiTest extends TestCase
     }
 
     /**
-     * Test updating an existing reportback item
+     * Test updating the status of an existing reportback item
      *
      * @return void
      */
-    public function testUpdatingReportbackItem()
+    public function testUpdatingStatusOfReportbackItem()
     {
         // Create a reportback item and save to the reportback_items table.
         $reportback = factory(Reportback::class)->create();

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -76,7 +76,7 @@ class ReportbackApiTest extends TestCase
     {
         $reportback = factory(Reportback::class)->create();
 
-        // Mock job that sends reportback back to Phoenix.
+        // Mock job that sends updated reportback back to Phoenix.
         $this->expectsJobs(Rogue\Jobs\SendReportbackToPhoenix::class);
 
         $response = $this->call('POST', $this->reportbackApiUrl, [


### PR DESCRIPTION
#### What's this PR do?
- Sends updated reportback and new reportback items to Phoenix 
- Fixes bug that takes information from first reportback item instead of reportback item that was most recently created
- Updates comment and test function name to add more specificity. 

#### How should this be reviewed?
- In Postman, create a new reportback. Make sure this is in both Rogue and Phoenix. 
- Create a new reportback item. Make sure this is also in both Rogue and Phoenix. 
- Update the `why_participated` field and make sure this is reflected in Rogue and Phoenix. 

#### Relevant tickets
Fixes #44

With help from @katiecrane ! 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.