### PR TITLE
Adds Transactional ID logic 

### DIFF
--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -7,6 +7,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Rogue\Services\Phoenix;
 use Rogue\Models\Reportback;
+use Request;
 
 class SendReportbackToPhoenix extends Job implements ShouldQueue
 {

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -7,7 +7,6 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Rogue\Services\Phoenix;
 use Rogue\Models\Reportback;
-use Request;
 
 class SendReportbackToPhoenix extends Job implements ShouldQueue
 {

--- a/app/Services/AuthorizesWithPhoenix.php
+++ b/app/Services/AuthorizesWithPhoenix.php
@@ -3,6 +3,7 @@
 namespace Rogue\Services;
 
 use GuzzleHttp\Cookie\CookieJar;
+use Cache;
 
 trait AuthorizesWithPhoenix
 {

--- a/app/Services/AuthorizesWithPhoenix.php
+++ b/app/Services/AuthorizesWithPhoenix.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rogue\Services;
+
+trait AuthorizesWithPhoenix
+{
+    /**
+     * Run custom tasks before making a request.
+     *
+     * @see RestApiClient@raw
+     */
+    function runAuthorizesWithPhoenixTasks($method, &$path, &$options, &$withAuthorization)
+    {
+        if ($withAuthorization) {
+            if (! isset($options['token'])) {
+                $authorizationHeader = [];
+                $authorizationHeader['X-CSRF-Token'] = $this->getAuthenticationToken();
+                $options['cookies'] = $this->getAuthenticationCookie();
+                $options['headers'] = array_merge($this->defaultHeaders, $authorizationHeader);
+            }
+        }
+    }
+}

--- a/app/Services/AuthorizesWithPhoenix.php
+++ b/app/Services/AuthorizesWithPhoenix.php
@@ -4,6 +4,29 @@ namespace Rogue\Services;
 
 trait AuthorizesWithPhoenix
 {
+
+    /**
+     * Get the CSRF token for the authenticated API session.
+     *
+     * @return string - token
+     */
+    private function getAuthenticationToken()
+    {
+        return $this->authenticate()['token'];
+    }
+
+    /**
+     * Get the cookie for the authenitcated API session.
+     *
+     * @return CookieJar
+     */
+    private function getAuthenticationCookie()
+    {
+        $cookieDomain = parse_url(config('services.phoenix.uri'))['host'];
+
+        return CookieJar::fromArray($this->authenticate()['cookie'], $cookieDomain);
+    }
+
     /**
      * Run custom tasks before making a request.
      *

--- a/app/Services/AuthorizesWithPhoenix.php
+++ b/app/Services/AuthorizesWithPhoenix.php
@@ -9,7 +9,7 @@ trait AuthorizesWithPhoenix
      *
      * @see RestApiClient@raw
      */
-    function runAuthorizesWithPhoenixTasks($method, &$path, &$options, &$withAuthorization)
+    public function runAuthorizesWithPhoenixTasks($method, &$path, &$options, &$withAuthorization)
     {
         if ($withAuthorization) {
             if (! isset($options['token'])) {

--- a/app/Services/AuthorizesWithPhoenix.php
+++ b/app/Services/AuthorizesWithPhoenix.php
@@ -2,9 +2,10 @@
 
 namespace Rogue\Services;
 
+use GuzzleHttp\Cookie\CookieJar;
+
 trait AuthorizesWithPhoenix
 {
-
     /**
      * Get the CSRF token for the authenticated API session.
      *

--- a/app/Services/AuthorizesWithPhoenix.php
+++ b/app/Services/AuthorizesWithPhoenix.php
@@ -7,6 +7,32 @@ use GuzzleHttp\Cookie\CookieJar;
 trait AuthorizesWithPhoenix
 {
     /**
+     * Returns a token for making authenticated requests to the Drupal API.
+     *
+     * @return array - Cookie & token for authenticated requests
+     */
+    private function authenticate()
+    {
+        $authentication = Cache::remember('drupal.authentication', 30, function () {
+            $payload = [
+                'username' => config('services.phoenix.username'),
+                'password' => config('services.phoenix.password'),
+            ];
+
+            $response = $this->post('auth/login', $payload, false);
+            $session_name = $response['session_name'];
+            $session_value = $response['sessid'];
+
+            return [
+                'cookie' => [$session_name => $session_value],
+                'token' => $response['token'],
+            ];
+        });
+
+        return $authentication;
+    }
+
+    /**
      * Get the CSRF token for the authenticated API session.
      *
      * @return string - token

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -4,7 +4,6 @@ namespace Rogue\Services;
 
 use DoSomething\Gateway\Common\RestApiClient;
 use DoSomething\Gateway\ForwardsTransactionIds;
-use GuzzleHttp\Cookie\CookieJar;
 use Cache;
 
 class Phoenix extends RestApiClient

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -4,7 +4,6 @@ namespace Rogue\Services;
 
 use DoSomething\Gateway\Common\RestApiClient;
 use DoSomething\Gateway\ForwardsTransactionIds;
-use Cache;
 
 class Phoenix extends RestApiClient
 {

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -55,28 +55,6 @@ class Phoenix extends RestApiClient
     }
 
     /**
-     * Get the CSRF token for the authenticated API session.
-     *
-     * @return string - token
-     */
-    private function getAuthenticationToken()
-    {
-        return $this->authenticate()['token'];
-    }
-
-    /**
-     * Get the cookie for the authenitcated API session.
-     *
-     * @return CookieJar
-     */
-    private function getAuthenticationCookie()
-    {
-        $cookieDomain = parse_url(config('services.phoenix.uri'))['host'];
-
-        return CookieJar::fromArray($this->authenticate()['cookie'], $cookieDomain);
-    }
-
-    /**
      * Send a POST request to save a copy of the reportback in Phoenix.
      *
      * @param string $nid

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -28,32 +28,6 @@ class Phoenix extends RestApiClient
     }
 
     /**
-     * Returns a token for making authenticated requests to the Drupal API.
-     *
-     * @return array - Cookie & token for authenticated requests
-     */
-    private function authenticate()
-    {
-        $authentication = Cache::remember('drupal.authentication', 30, function () {
-            $payload = [
-                'username' => config('services.phoenix.username'),
-                'password' => config('services.phoenix.password'),
-            ];
-
-            $response = $this->post('auth/login', $payload, false);
-            $session_name = $response['session_name'];
-            $session_value = $response['sessid'];
-
-            return [
-                'cookie' => [$session_name => $session_value],
-                'token' => $response['token'],
-            ];
-        });
-
-        return $authentication;
-    }
-
-    /**
      * Send a POST request to save a copy of the reportback in Phoenix.
      *
      * @param string $nid

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -3,11 +3,14 @@
 namespace Rogue\Services;
 
 use DoSomething\Gateway\Common\RestApiClient;
+use DoSomething\Gateway\ForwardsTransactionIds;
 use GuzzleHttp\Cookie\CookieJar;
 use Cache;
 
 class Phoenix extends RestApiClient
 {
+    use AuthorizesWithPhoenix, ForwardsTransactionIds;
+
     /**
      * Create a new Phoenix API client.
      */
@@ -79,28 +82,5 @@ class Phoenix extends RestApiClient
         $response = $this->post('campaigns/' . $nid . '/reportback', $body);
 
         return is_null($response) ? null : $response;
-    }
-
-    /**
-     * Overrides DoSometing\Northstar\Common\RestApiClient to add Cookie and X-CSRF-Token to header.
-     *
-     * @param $method
-     * @param $path
-     * @param array $options
-     * @param bool $withAuthorization
-     * @return response
-     */
-    public function raw($method, $path, $options, $withAuthorization = true)
-    {
-        if ($withAuthorization) {
-            if (! isset($options['token'])) {
-                $authorizationHeader = [];
-                $authorizationHeader['X-CSRF-Token'] = $this->getAuthenticationToken();
-                $options['cookies'] = $this->getAuthenticationCookie();
-                $options['headers'] = array_merge($this->defaultHeaders, $authorizationHeader);
-            }
-        }
-
-        return $this->client->request($method, $path, $options);
     }
 }

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -12,6 +12,13 @@ class Phoenix extends RestApiClient
     use AuthorizesWithPhoenix, ForwardsTransactionIds;
 
     /**
+     * The class name of the transaction framework bridge.
+     *
+     * @var string
+     */
+    protected $transactionBridge = \DoSomething\Gateway\Laravel\LaravelTransactionBridge::class;
+
+    /**
      * Create a new Phoenix API client.
      */
     public function __construct()


### PR DESCRIPTION
#### What's this PR do?
- Updates Rogue to use Gateway traits to use Transactional IDs when making and receiving requests. 

#### How should this be reviewed?
- `POST` to Rogue's `/reportbacks` endpoint and add any value for `X-Request-ID` header. 
- Check Laravel logs - Transactional ID message should be there! 

#### Relevant tickets
Fixes #47 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

with @katiecrane ! 