### PR TITLE
Remove file_id column

### DIFF
--- a/app/Http/Transformers/ReportbackItemTransformer.php
+++ b/app/Http/Transformers/ReportbackItemTransformer.php
@@ -19,7 +19,6 @@ class ReportbackItemTransformer extends TransformerAbstract
             'id' => (string) $reportbackItem->id,
             'reportback_id' => $reportbackItem->reportback_id,
             'media' => [
-                'id' => $reportbackItem->file_id,
                 'url' => $reportbackItem->file_url,
             ],
             'caption' => $reportbackItem->caption,

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -11,13 +11,13 @@ class Reaction extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'drupal_id', 'file_id', 'taxonomy_id'];
+    protected $fillable = ['id', 'northstar_id', 'drupal_id', 'taxonomy_id'];
 
     /**
-     * The reportbacks that belont to the reaction.
+     * The reportback items that belongs to the reaction.
      */
-    public function reportbacks()
+    public function reportbackItems()
     {
-        return $this->belongsToMany('App\Reportbacks');
+        return $this->belongsToMany('App\ReportbackItems');
     }
 }

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -18,6 +18,6 @@ class Reaction extends Model
      */
     public function reportbackItems()
     {
-        return $this->belongsToMany('App\ReportbackItems');
+        return $this->belongsToMany('\Rogue\Models\ReportbackItem');
     }
 }

--- a/app/Models/Reportback.php
+++ b/app/Models/Reportback.php
@@ -20,12 +20,4 @@ class Reportback extends Model
     {
         return $this->hasMany(ReportbackItem::class);
     }
-
-    /**
-     * The reactions that belong to the reportback.
-     */
-    public function reactions()
-    {
-        return $this->belongsToMany('App\Reaction');
-    }
 }

--- a/app/Models/ReportbackItem.php
+++ b/app/Models/ReportbackItem.php
@@ -26,6 +26,6 @@ class ReportbackItem extends Model
      */
     public function reactions()
     {
-        return $this->belongsToMany('App\Reaction');
+        return $this->belongsToMany('\Rogue\Models\Reaction');
     }
 }

--- a/app/Models/ReportbackItem.php
+++ b/app/Models/ReportbackItem.php
@@ -11,7 +11,7 @@ class ReportbackItem extends Model
      *
      * @var array
      */
-    protected $fillable = ['reportback_id', 'file_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr'];
+    protected $fillable = ['reportback_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr'];
 
     /**
      * A reportback item belongs to one reportback.
@@ -19,5 +19,13 @@ class ReportbackItem extends Model
     public function reportback()
     {
         return $this->belongsTo(Reportback::class);
+    }
+
+    /**
+     * The reactions that belong to the reportback item.
+     */
+    public function reactions()
+    {
+        return $this->belongsToMany('App\Reaction');
     }
 }

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -79,7 +79,7 @@ class ReportbackRepository
         $logData = [
             'op' => $operation,
             'reportback_id' => $reportback->id,
-            'files' => $reportback->items->implode('file_id', ','),
+            'files' => $reportback->items->implode('file_url', ','),
             'num_files' => $reportback->items->count(),
         ];
 
@@ -103,7 +103,7 @@ class ReportbackRepository
     {
         if (isset($data['file'])) {
             // @todo - this part right here might actually belong in the service class now that i think about it.
-            $data['file_url'] = $this->aws->storeImage($data['file'], $data['file_id']);
+            $data['file_url'] = $this->aws->storeImage($data['file'], $data['campaign_id']);
 
             $reportback->items()->create(array_only($data, ['file_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr']));
         }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "aws/aws-sdk-php-laravel": "^3.1",
         "league/fractal": "^0.13.0",
         "guzzlehttp/guzzle": "^6.2",
-        "dosomething/gateway": "1.0.0-rc12",
+        "dosomething/gateway": "1.0.0-rc14",
         "doctrine/dbal": "^2.5"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c0b1195729f689fd317f18f3f5f8395f",
-    "content-hash": "8dc739b3efdb1fb72b714a61136e0298",
+    "hash": "7fe72877d5108c82ccc2385b9e89d5f8",
+    "content-hash": "c5c4c411c90dfb2c61fb326771f4486f",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.19.12",
+            "version": "3.19.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "5d5697c7bc9ab22ce718afb51e5496d0c5cb8778"
+                "reference": "57b0efed8fcf5d8c854bc1c26cf4a685af9108d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5d5697c7bc9ab22ce718afb51e5496d0c5cb8778",
-                "reference": "5d5697c7bc9ab22ce718afb51e5496d0c5cb8778",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/57b0efed8fcf5d8c854bc1c26cf4a685af9108d9",
+                "reference": "57b0efed8fcf5d8c854bc1c26cf4a685af9108d9",
                 "shasum": ""
             },
             "require": {
@@ -85,7 +85,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-09-29 21:07:49"
+            "time": "2016-10-06 21:17:44"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -701,16 +701,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.0.0-rc12",
+            "version": "v1.0.0-rc14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "fdac8a325a36414f7d3ff982d0c326222b0d9f8e"
+                "reference": "2de6ade1b724fc93353545996426ecee49b7cd7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/fdac8a325a36414f7d3ff982d0c326222b0d9f8e",
-                "reference": "fdac8a325a36414f7d3ff982d0c326222b0d9f8e",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/2de6ade1b724fc93353545996426ecee49b7cd7e",
+                "reference": "2de6ade1b724fc93353545996426ecee49b7cd7e",
                 "shasum": ""
             },
             "require": {
@@ -721,6 +721,10 @@
                 "nesbot/carbon": "~1.14",
                 "symfony/psr-http-message-bridge": "^1.0",
                 "zendframework/zend-diactoros": "^1.3"
+            },
+            "require-dev": {
+                "illuminate/database": "^5.2",
+                "phpunit/phpunit": "^4.8"
             },
             "type": "library",
             "autoload": {
@@ -742,20 +746,20 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2016-10-04 18:21:58"
+            "time": "2016-10-06 20:04:26"
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "7.7.1",
+            "version": "7.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "da9a24a60169fedca9a0a4e07baf7e94f9c75fc4"
+                "reference": "245324b87d59fe122945f5cf4521c75af2bd472a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/da9a24a60169fedca9a0a4e07baf7e94f9c75fc4",
-                "reference": "da9a24a60169fedca9a0a4e07baf7e94f9c75fc4",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/245324b87d59fe122945f5cf4521c75af2bd472a",
+                "reference": "245324b87d59fe122945f5cf4521c75af2bd472a",
                 "shasum": ""
             },
             "require": {
@@ -804,21 +808,24 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2016-10-01 21:48:02"
+            "time": "2016-10-06 13:02:39"
         },
         {
             "name": "giggsey/locale",
-            "version": "1.0",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/Locale.git",
-                "reference": "9087acaf8493472fcd129118017fd7e06be3d8fa"
+                "reference": "d936229da2187025f693f25724c5af2a090f5e7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/Locale/zipball/9087acaf8493472fcd129118017fd7e06be3d8fa",
-                "reference": "9087acaf8493472fcd129118017fd7e06be3d8fa",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/d936229da2187025f693f25724c5af2a090f5e7c",
+                "reference": "d936229da2187025f693f25724c5af2a090f5e7c",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
             },
             "require-dev": {
                 "pear/pear-core-minimal": "^1.9",
@@ -850,20 +857,20 @@
                 }
             ],
             "description": "Locale functions required by libphonenumber-for-php",
-            "time": "2016-08-04 23:02:29"
+            "time": "2016-10-05 20:26:22"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.1",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
                 "shasum": ""
             },
             "require": {
@@ -912,7 +919,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-07-15 17:22:37"
+            "time": "2016-10-08 15:01:37"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1459,16 +1466,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.27",
+            "version": "1.0.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "50e2045ed70a7e75a5e30bc3662904f3b67af8a9"
+                "reference": "a9663643ff2d16d7f66ed1e0d3212c5491bc9044"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/50e2045ed70a7e75a5e30bc3662904f3b67af8a9",
-                "reference": "50e2045ed70a7e75a5e30bc3662904f3b67af8a9",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a9663643ff2d16d7f66ed1e0d3212c5491bc9044",
+                "reference": "a9663643ff2d16d7f66ed1e0d3212c5491bc9044",
                 "shasum": ""
             },
             "require": {
@@ -1538,7 +1545,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-08-10 08:55:11"
+            "time": "2016-10-07 12:20:37"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -2228,16 +2235,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "5277094ed527a1c4477177d102fe4c53551953e0"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/5277094ed527a1c4477177d102fe4c53551953e0",
-                "reference": "5277094ed527a1c4477177d102fe4c53551953e0",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
             "require": {
@@ -2271,7 +2278,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-09-19 16:02:08"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "psy/psysh",
@@ -3402,16 +3409,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.3.6",
+            "version": "1.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "a60da179c37f2c4e44ef734d0b92824a58943f7f"
+                "reference": "969ff423d3f201da3ff718a5831bb999bb0669b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/a60da179c37f2c4e44ef734d0b92824a58943f7f",
-                "reference": "a60da179c37f2c4e44ef734d0b92824a58943f7f",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/969ff423d3f201da3ff718a5831bb999bb0669b0",
+                "reference": "969ff423d3f201da3ff718a5831bb999bb0669b0",
                 "shasum": ""
             },
             "require": {
@@ -3448,7 +3455,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-09-07 17:57:29"
+            "time": "2016-10-11 13:25:21"
         }
     ],
     "packages-dev": [

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -2,7 +2,6 @@
 
 use Faker\Generator;
 use Rogue\Models\Reportback;
-use Rogue\Models\ReportbackItem;
 use Rogue\Models\Reaction;
 
 /*

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -33,14 +33,11 @@ $factory->define(Reportback::class, function (Generator $faker) {
     ];
 });
 
-// Kudo Factory
+// Reaction Factory
 $factory->define(Reaction::class, function (Generator $faker) {
-    $files = ReportbackItem::all()->pluck('file_id');
-
     return [
         'northstar_id'     => str_random(24),
         'drupal_id'        => $faker->randomNumber(8),
-        'file_id'          => $faker->randomElement($files->toArray()),
         'taxonomy_id'      => $faker->randomElement([0, 641, 646]),
     ];
 });

--- a/database/migrations/2016_10_11_200630_drop_file_id_from_reportback_items_table.php
+++ b/database/migrations/2016_10_11_200630_drop_file_id_from_reportback_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropFileIdFromReportbackItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reportback_items', function ($table) {
+            $table->dropColumn('file_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reportback_items', function (Blueprint $table) {
+            $table->integer('file_id')->index()->unsigned();
+        });
+    }
+}

--- a/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
+++ b/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropFileIdFromReactions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reactions', function (Blueprint $table) {
+            $table->dropColumn('file_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reactions', function (Blueprint $table) {
+            $table->integer('file_id')->index()->comment('The reportback_file.fid that this kudos applies to.');
+        });
+    }
+}

--- a/database/migrations/2016_10_11_201943_drop_reaction_reportback_table.php
+++ b/database/migrations/2016_10_11_201943_drop_reaction_reportback_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropReactionReportbackTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('reaction_reportback');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('reaction_reportback', function (Blueprint $table) {
+            $table->integer('reaction_id')->unsigned()->index();
+            $table->foreign('reaction_id')->references('id')->on('reactions')->onDelete('cascade');
+            $table->integer('reportback_id')->unsigned()->index();
+            $table->foreign('reportback_id')->references('id')->on('reportbacks')->onDelete('cascade');
+        });
+    }
+}

--- a/database/migrations/2016_10_11_202519_create_reaction_reportback_item_table.php
+++ b/database/migrations/2016_10_11_202519_create_reaction_reportback_item_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReactionReportbackItemTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reaction_reportback_item', function (Blueprint $table) {
+            $table->integer('reaction_id')->unsigned()->index();
+            $table->foreign('reaction_id')->references('id')->on('reactions')->onDelete('cascade');
+            $table->integer('reportback_item_id')->unsigned()->index();
+            $table->foreign('reportback_item_id')->references('id')->on('reportback_items')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('reaction_reportback_item');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,9 +11,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(ReactionSeeder::class);
         $this->call(ReportbackSeeder::class);
         $this->call(ReportbackItemSeeder::class);
         $this->call(ReportbackLogSeeder::class);
-        $this->call(ReactionSeeder::class);
     }
 }

--- a/database/seeds/ReportbackItemSeeder.php
+++ b/database/seeds/ReportbackItemSeeder.php
@@ -1,5 +1,6 @@
 <?php
 
+use Rogue\Models\Reaction;
 use Rogue\Models\Reportback;
 use Rogue\Models\ReportbackItem;
 use Illuminate\Database\Seeder;
@@ -24,7 +25,6 @@ class ReportbackItemSeeder extends Seeder
                 $reportbackItem = new ReportbackItem;
 
                 $reportbackItem->reportback_id = $reportback->getKey();
-                $reportbackItem->file_id = $faker->numberBetween(1, 9999);
                 $reportbackItem->caption = $faker->text(100);
                 $reportbackItem->status = 'pending';
                 $reportbackItem->reviewed = null;
@@ -34,6 +34,10 @@ class ReportbackItemSeeder extends Seeder
                 $reportbackItem->remote_addr = $faker->randomElement(['100.38.10.249', '207.110.19.130', '96.24.79.91']);
 
                 $reportback->items()->save($reportbackItem);
+
+                // Give this item a reaction.
+                $reaction = Reaction::all()->random(1);
+                $reportbackItem->reactions()->save($reaction);
             }
         }
     }

--- a/database/seeds/ReportbackItemSeeder.php
+++ b/database/seeds/ReportbackItemSeeder.php
@@ -25,6 +25,7 @@ class ReportbackItemSeeder extends Seeder
                 $reportbackItem = new ReportbackItem;
 
                 $reportbackItem->reportback_id = $reportback->getKey();
+                $reportbackItem->file_url = 'https://placekitten.com/g/400/400';
                 $reportbackItem->caption = $faker->text(100);
                 $reportbackItem->status = 'pending';
                 $reportbackItem->reviewed = null;

--- a/database/seeds/ReportbackLogSeeder.php
+++ b/database/seeds/ReportbackLogSeeder.php
@@ -27,7 +27,7 @@ class ReportbackLogSeeder extends Seeder
             $log->op = 'insert';
             $log->quantity = $reportback->quantity;
             $log->why_participated = $reportback->why_participated;
-            $log->files = $reportback->items->implode('file_id', ',');
+            $log->files = $reportback->items->implode('file_url', ',');
             $log->num_files = $reportback->items->count();
             $log->remote_addr = $reportback->remote_addr;
             $log->reason = null;

--- a/documentation/reportbacks.md
+++ b/documentation/reportbacks.md
@@ -20,8 +20,6 @@ POST /api/v1/reportbacks
     The reason why the user participated.
   - **num_participants**: (int).
     How many people participated in the action. 
-  - **file_id**: (int) required.
-    The drupal file id of the reportback item to submit with this reportback. 
   - **caption**: (string).
     Corresponding caption for the reportback image.
   - **source**: (string).

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -2,7 +2,6 @@
 
 use Rogue\Models\Reportback;
 use Rogue\Models\ReportbackItem;
-use Rogue\Services\Phoenix\Phoenix;
 use Faker\Generator;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -17,7 +16,7 @@ class ReportbackApiTest extends TestCase
      * Base URL for the Api.
      */
     protected $reportbackApiUrl = 'api/v1/reportbacks';
-    protected $updateReportbackUrl = 'api/v1/items';
+    protected $reportbackItemsUrl = 'api/v1/items';
 
     /**
      * Test if a POST request to /reportbacks creates a new reportback.
@@ -26,7 +25,7 @@ class ReportbackApiTest extends TestCase
      */
     public function testCreatingNewReportback()
     {
-        // Create test RB with appropriate emoji
+        // Create test RB
         $reportback = $this->createTestReportback();
 
         // Test posting the reportback
@@ -58,9 +57,6 @@ class ReportbackApiTest extends TestCase
                 'quantity' => 2000,
             ],
         ]);
-        // $response = json_decode($response->content());
-
-        // $this->assertEquals($response->data->quantity, 2000);
     }
 
     /**
@@ -86,7 +82,7 @@ class ReportbackApiTest extends TestCase
         ];
 
         // Post updated status to /items
-        $this->call('PUT', $this->updateReportbackUrl, $updatesToReportbackItem);
+        $this->call('PUT', $this->reportbackItemsUrl, $updatesToReportbackItem);
 
         $rbItem = ReportbackItem::where(['id' => $reportbackItem->id])->first();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use Rogue\Jobs\SendReportbackToPhoenix;
+
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
     /**
@@ -17,13 +19,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      * @var \Faker\Generator
      */
     protected $faker;
-
-    /**
-     * File System dependency.
-     *
-     * @var
-     */
-    protected $fileSystem;
 
     /**
      * Setup the test environment.
@@ -102,7 +97,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
             'quantity'         => $this->faker->numberBetween(10, 1000),
             'why_participated' => $this->faker->paragraph(3),
             'num_participants' => null,
-            'file_id'          => $this->faker->randomNumber(4),
             'caption'          => $this->faker->sentence(),
             'source'           => 'runscope',
             'remote_addr'      => '207.110.19.130',
@@ -141,7 +135,9 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
                         ->andReturn(true);
         }
 
-        $this->json('POST', $this->reportbackApiUrl, $reportback);
+        $this->expectsJobs(SendReportbackToPhoenix::class);
+
+        $response = $this->json('POST', $this->reportbackApiUrl, $reportback);
 
         $this->assertResponseStatus(201);
     }


### PR DESCRIPTION
#### What's this PR do?

* Removes references to `file_id` in rogue which was referencing the `fid` as it was stored in drupal. We do not need to store this anymore since rogue does it's own file storage. 
* Updates the previously defined `Reaction` to `Reportback` many-to-many relationship to be a `Reaction` to `ReportbackItem` relationship since reactions actually live on items.
* Added a step to the `ReportbackItem` seeder that will give the item a reaction so we have some data to play with.

#### How should this be reviewed?

pull down this branch, reset, re-migrate and re-seed your database.

`php artisan migrate:refresh --seed` 

all should run well, and you should not see any `file_id` columns in your db.

You can also try out the relationship by grabbing a Reaction from the database and running something like: 

`dd($reaction->reportackItems);` 

You should see all the items that have that reaction.

#### Relevant tickets
Fixes #33 
