### PR TITLE
Image crop & rotate

### DIFF
--- a/app/Http/Transformers/ReportbackItemTransformer.php
+++ b/app/Http/Transformers/ReportbackItemTransformer.php
@@ -20,6 +20,7 @@ class ReportbackItemTransformer extends TransformerAbstract
             'reportback_id' => $reportbackItem->reportback_id,
             'media' => [
                 'url' => $reportbackItem->file_url,
+                'edited_url' => $reportbackItem->edited_file_url,
             ],
             'caption' => $reportbackItem->caption,
             'status' => $reportbackItem->status,

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -40,7 +40,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
             'nid' => $this->reportback->campaign_id,
             'quantity' => $this->reportback->quantity,
             'why_participated' => $this->reportback->why_participated,
-            'file_url' => $reportbackItem->file_url,
+            'file_url' => $reportbackItem->edited_file_url,
             'caption' => $reportbackItem->caption,
             'source' => $reportbackItem->source,
         ];

--- a/app/Models/ReportbackItem.php
+++ b/app/Models/ReportbackItem.php
@@ -11,7 +11,7 @@ class ReportbackItem extends Model
      *
      * @var array
      */
-    protected $fillable = ['reportback_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr'];
+    protected $fillable = ['reportback_id', 'file_url', 'cropped_file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr'];
 
     /**
      * A reportback item belongs to one reportback.

--- a/app/Models/ReportbackItem.php
+++ b/app/Models/ReportbackItem.php
@@ -11,7 +11,7 @@ class ReportbackItem extends Model
      *
      * @var array
      */
-    protected $fillable = ['reportback_id', 'file_url', 'cropped_file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr'];
+    protected $fillable = ['reportback_id', 'file_url', 'edited_file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr'];
 
     /**
      * A reportback item belongs to one reportback.

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -6,11 +6,21 @@ use Rogue\Models\Reportback;
 use Rogue\Models\ReportbackLog;
 use Rogue\Models\ReportbackItem;
 use Rogue\Services\AWS;
+use Intervention\Image\Facades\Image;
+use finfo;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 
 class ReportbackRepository
 {
+    /**
+     * Instance of \Rogue\Services\AWS;
+     *
+     */
     protected $AWS;
 
+    /**
+     * Constructor
+     */
     public function __construct(AWS $aws)
     {
         $this->aws = $aws;
@@ -105,7 +115,11 @@ class ReportbackRepository
             // @todo - this part right here might actually belong in the service class now that i think about it.
             $data['file_url'] = $this->aws->storeImage($data['file'], $data['campaign_id']);
 
-            $reportback->items()->create(array_only($data, ['file_id', 'file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr']));
+            $img = (string) Image::make($data['file_url'])->crop(100, 100, 25, 25)->encode('data-url');
+
+            $data['cropped_file_url'] = $this->aws->storeImage($img, 'edited_' . $data['campaign_id']);
+
+            $reportback->items()->create(array_only($data, ['file_id', 'file_url', 'cropped_file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr']));
         }
 
         return $reportback;

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -121,7 +121,7 @@ class ReportbackRepository
 
             if ($cropValues)
             {
-                $editedImage = edit_image($data['file_url'], $cropValues);
+                $editedImage = edit_image($data['file'], $cropValues);
 
                 $data['edited_file_url'] = $this->aws->storeImage($editedImage, 'edited_' . $data['campaign_id']);
             }

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -10,12 +10,16 @@ use Rogue\Services\AWS;
 class ReportbackRepository
 {
     /**
-     * Instance of \Rogue\Services\AWS;
+     * AWS service class instance.
+     *
+     * @var \Rogue\Services\AWS
      */
     protected $AWS;
 
     /**
      * Array of properties needed for cropping and rotating.
+     *
+     * @var array
      */
     protected $cropProperties = ['crop_x', 'crop_y', 'crop_width', 'crop_height', 'crop_rotate'];
 

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -120,7 +120,7 @@ class ReportbackRepository
             // @todo - this part right here might actually belong in the service class now that i think about it.
             $data['file_url'] = $this->aws->storeImage($data['file'], $data['campaign_id']);
 
-            $cropValues = extract_values_by_keys($data, $this->cropProperties);
+            $cropValues = array_only($data, $this->cropProperties);
 
             if ($cropValues) {
                 $editedImage = edit_image($data['file'], $cropValues);

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -11,7 +11,6 @@ class ReportbackRepository
 {
     /**
      * Instance of \Rogue\Services\AWS;
-     *
      */
     protected $AWS;
 
@@ -119,8 +118,7 @@ class ReportbackRepository
 
             $cropValues = extract_values_by_keys($data, $this->cropProperties);
 
-            if ($cropValues)
-            {
+            if ($cropValues) {
                 $editedImage = edit_image($data['file'], $cropValues);
 
                 $data['edited_file_url'] = $this->aws->storeImage($editedImage, 'edited_' . $data['campaign_id']);

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -124,7 +124,6 @@ class ReportbackRepository
                 $editedImage = edit_image($data['file_url'], $cropValues);
 
                 $data['edited_file_url'] = $this->aws->storeImage($editedImage, 'edited_' . $data['campaign_id']);
-
             }
 
             $reportback->items()->create(array_only($data, ['file_id', 'file_url', 'edited_file_url', 'caption', 'status', 'reviewed', 'reviewer', 'review_source', 'source', 'remote_addr']));

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -13,6 +13,11 @@ class ReportbackService
      */
     protected $reportbackRepository;
 
+    /**
+     * Contructor
+     *
+     * @param \Rogue\Repositories\ReportbackRepository $reportbackRepository
+     */
     public function __construct(ReportbackRepository $reportbackRepository)
     {
         $this->reportbackRepository = $reportbackRepository;

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -9,12 +9,14 @@ use Rogue\Jobs\SendReportbackToPhoenix;
 class ReportbackService
 {
     /*
-     * Instance of \Rogue\Repositories\ReportbackRepository
+     * Reportback repository instance.
+     *
+     * @var \Rogue\Repositories\ReportbackRepository
      */
     protected $reportbackRepository;
 
     /**
-     * Contructor
+     * Constructor
      *
      * @param \Rogue\Repositories\ReportbackRepository $reportbackRepository
      */

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,36 @@
+<?php
+
+use Intervention\Image\Facades\Image;
+
+/**
+ * Crop and rotate an image based on given parameters.
+ *
+ * @param  mixed  $image
+ * @return string $image base-64 encoded data URI
+ */
+function edit_image($image, $coords)
+{
+    $editedImage = (string) Image::make($image)
+        // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
+        ->rotate(-$coords['crop_rotate'])
+        ->crop($coords['crop_width'], $coords['crop_height'], $coords['crop_x'], $coords['crop_y'])
+        ->encode('data-url');
+
+    return $editedImage;
+}
+
+/**
+ * Given an array of key/value pairs, create a new array with only the
+ * keys given.
+ *
+ * @param  associative array  $data
+ * @param  array $desiredKeys
+ *
+ * @return array
+ */
+function extract_values_by_keys($array, $desiredKeys)
+{
+    $desiredValues = array_intersect_key($array, array_flip($desiredKeys));
+
+    return (count($array) > 0) ? $desiredValues : null;
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -18,19 +18,3 @@ function edit_image($image, $coords)
 
     return $editedImage;
 }
-
-/**
- * Given an array of key/value pairs, create a new array with only the
- * keys given.
- *
- * @param  associative array  $data
- * @param  array $desiredKeys
- *
- * @return array
- */
-function extract_values_by_keys($array, $desiredKeys)
-{
-    $desiredValues = array_intersect_key($array, array_flip($desiredKeys));
-
-    return (count($array) > 0) ? $desiredValues : null;
-}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "league/fractal": "^0.13.0",
         "guzzlehttp/guzzle": "^6.2",
         "dosomething/gateway": "1.0.0-rc14",
-        "doctrine/dbal": "^2.5"
+        "doctrine/dbal": "^2.5",
+        "intervention/image": "^2.3"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "classmap": [
             "database"
         ],
+        "files": [
+            "app/helpers.php"
+        ],
         "psr-4": {
             "Rogue\\": "app/"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7fe72877d5108c82ccc2385b9e89d5f8",
-    "content-hash": "c5c4c411c90dfb2c61fb326771f4486f",
+    "hash": "ab2c3f0dbd546df7c051481a0cd8c3b7",
+    "content-hash": "c1a2bc1a30a64118bf5269c2e68d2cf3",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1029,6 +1029,68 @@
                 "uri"
             ],
             "time": "2016-06-24 23:00:38"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "4064a980324f6c3bfa2bd981dfb247afa705ec3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/4064a980324f6c3bfa2bd981dfb247afa705ec3c",
+                "reference": "4064a980324f6c3bfa2bd981dfb247afa705ec3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "3.*"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@olivervogel.net",
+                    "homepage": "http://olivervogel.net/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "time": "2016-09-01 17:04:03"
         },
         {
             "name": "ircmaxell/random-lib",

--- a/config/app.php
+++ b/config/app.php
@@ -157,6 +157,7 @@ return [
         Spatie\Backup\BackupServiceProvider::class,
         Maknz\Slack\Laravel\ServiceProvider::class,
         Aws\Laravel\AwsServiceProvider::class,
+        Intervention\Image\ImageServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -213,6 +214,7 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
+        'Image' => Intervention\Image\Facades\Image::class,
 
     ],
 

--- a/database/migrations/2016_10_24_180026_add_cropped_image_column_to_items.php
+++ b/database/migrations/2016_10_24_180026_add_cropped_image_column_to_items.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCroppedImageColumnToItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reportback_items', function (Blueprint $table) {
+            $table->string('cropped_file_url')->nullable()->after('file_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reportback_items', function (Blueprint $table) {
+            $table->dropColumn('cropped_file_url');
+        });
+    }
+}

--- a/database/migrations/2016_10_24_180026_add_cropped_image_column_to_items.php
+++ b/database/migrations/2016_10_24_180026_add_cropped_image_column_to_items.php
@@ -13,7 +13,7 @@ class AddCroppedImageColumnToItems extends Migration
     public function up()
     {
         Schema::table('reportback_items', function (Blueprint $table) {
-            $table->string('cropped_file_url')->nullable()->after('file_url');
+            $table->string('edited_file_url')->nullable()->after('file_url');
         });
     }
 
@@ -25,7 +25,7 @@ class AddCroppedImageColumnToItems extends Migration
     public function down()
     {
         Schema::table('reportback_items', function (Blueprint $table) {
-            $table->dropColumn('cropped_file_url');
+            $table->dropColumn('edited_file_url');
         });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -101,6 +101,11 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
             'source'           => 'runscope',
             'remote_addr'      => '207.110.19.130',
             'file'             => $file,
+            'crop_x'           => 0,
+            'crop_y'           => 0,
+            'crop_width'       => 100,
+            'crop_height'      => 100,
+            'crop_rotate'      => 90,
         ];
 
         return $reportback;
@@ -153,8 +158,11 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         // Make sure we created a reportback item for the reportback.
         $this->seeInDatabase('reportback_items', ['reportback_id' => $response['data']['id']]);
 
-        // Make sure the file is saved to S3 and the file_url is saved to the database.
+        // Make sure the file_url is saved to the database.
         $this->seeInDatabase('reportback_items', ['file_url' => $response['data']['reportback_items']['data'][0]['media']['url']]);
+
+        // Make sure the edited_file_url is saved to the database.
+        $this->seeInDatabase('reportback_items', ['edited_file_url' => $response['data']['reportback_items']['data'][0]['media']['edited_url']]);
 
         // Make sure we created a record in the reportback log table.
         $this->seeInDatabase('reportback_logs', ['reportback_id' => $response['data']['id']]);


### PR DESCRIPTION
#### What's this PR do?

* Stores the original image in S3 and also crops and rotates it and stores that new image in a new `edited_file_url` column on the item so we can have both. 

* Exposes both file urls in the response like:

![image](https://cloud.githubusercontent.com/assets/1700409/19876476/f4b93c9a-9fac-11e6-9058-2c9b93be0a30.png)

* Sends the edited file back to phoenix.

#### How should this be reviewed?
I tried to make the commits clear, so you should be able to review commit by commit. 

Run the unit tests!

Post a reportback (or new item) to rogue with cropping properites (`crop_x`, `crop_y`, `crop_height`, `crop_width`, `crop_rotate`). The orginal file should get stored in `file_url` and the cropped file should be stored in `edited_file_url`

#### Any background context you want to provide?

Started a helper file to start extracting some helper functions. I put the image cropping stuff in there cause it didn't feel like anything should really own that. But open to other thoughts on that. 

Also when you pull down this branch you might need to run `composer dump-autoload` to make sure that helper class is pulled in. 

#### Relevant tickets
Fixes #61

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.