### PR TITLE
Remove review source column

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -36,9 +36,8 @@ $factory->define(Reportback::class, function (Generator $faker) {
 // Reaction Factory
 $factory->define(Reaction::class, function (Generator $faker) {
     return [
-        'northstar_id'     => str_random(24),
-        'drupal_id'        => $faker->randomNumber(8),
-        'taxonomy_id'      => $faker->randomElement([0, 641, 646]),
+        'northstar_id' => str_random(24),
+        'reportback_item_id' => $faker->randomNumber(7),
     ];
 });
 

--- a/database/migrations/2016_11_14_193858_remove_review_source_from_items_table.php
+++ b/database/migrations/2016_11_14_193858_remove_review_source_from_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveReviewSourceFromItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reportback_items', function (Blueprint $table) {
+            $table->dropColumn('review_source');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reportback_items', function (Blueprint $table) {
+            $table->string('review_source')->nullable()->comment('Source URL which review was submitted from.')->after('reviewer');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

Mainly removes the `review_source` column from the `reportback_items`table

Also found a small small bug when trying to `db:seed` we updated the `reactions` table but didn't fix the model factory for it, so i just fixed it quick in this PR

#### How should this be reviewed?

run `php artisan migrate` 
Did the migration run? great.
Is the `remove_source` column removed from the `reportback_items` table? great. 

#### Relevant tickets
Fixes #69 
