### PR TITLE
set reportback item reviewer

### DIFF
--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -176,6 +176,7 @@ class ReportbackRepository
 
                 if ($reportbackItem['status'] && ! empty($reportbackItem['status'])) {
                     $rbItem->status = $reportbackItem['status'];
+                    $rbItem->reviewer = $reportbackItem['reviewer'];
                     $rbItem->save();
 
                     array_push($reportbackItems, $rbItem);

--- a/database/migrations/2016_11_14_172450_update_reportback_items_reviewer_type.php
+++ b/database/migrations/2016_11_14_172450_update_reportback_items_reviewer_type.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateReportbackItemsReviewerType extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reportback_items', function ($table) {
+            $table->string('reviewer')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reportback_items', function ($table) {
+            $table->integer('reviewer')->unsigned()->change();
+        });
+    }
+}

--- a/database/migrations/2016_11_14_172450_update_reportback_items_reviewer_type.php
+++ b/database/migrations/2016_11_14_172450_update_reportback_items_reviewer_type.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateReportbackItemsReviewerType extends Migration


### PR DESCRIPTION
#### What's this PR do?
Phoenix is already sending the reportback reviewer's northstar id (https://github.com/DoSomething/phoenix/pull/7192). This grabs the `reviewer` that was sent and saves it to the reportback item. Also includes a migration to change the type of the `reviewer` column to accept northstar ids (previously setup to accept drupal ids).

#### How should this be reviewed?
Does the reviewer get set correctly? Does the full NS id show up in the database?

#### Relevant tickets
Fixes #72

#### Checklist
- [ ] Tested on staging.

