### PR TITLE
Log transaction id when a request is received

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -43,7 +43,8 @@ class ReportbackController extends ApiController
         $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
         logger()->info('Request received. Transaction ID: ' . $newTransactionId);
 
-        // Add the new transaction ID to the header to send back to Phoenix.
+        // Add new transaction id to header.
+        // $request->headers->set('X-Request-ID', $newTransactionId);
 
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
@@ -54,11 +55,11 @@ class ReportbackController extends ApiController
         $updating = ! is_null($reportback);
 
         if (! $updating) {
-            $reportback = $this->reportbackService->create($request->all());
+            $reportback = $this->reportbackService->create($request->all(), $newTransactionId);
 
             $code = 200;
         } else {
-            $reportback = $this->reportbackService->update($reportback, $request->all());
+            $reportback = $this->reportbackService->update($reportback, $request->all(), $newTransactionId);
 
             $code = 201;
         }

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -36,7 +36,7 @@ class ReportbackController extends ApiController
      */
     public function store(ReportbackRequest $request)
     {
-        $newTransactionId = incrementTransactionId($request);
+        $transactionId = incrementTransactionId($request);
 
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
@@ -47,11 +47,11 @@ class ReportbackController extends ApiController
         $updating = ! is_null($reportback);
 
         if (! $updating) {
-            $reportback = $this->reportbackService->create($request->all(), $newTransactionId);
+            $reportback = $this->reportbackService->create($request->all(), $transactionId);
 
             $code = 200;
         } else {
-            $reportback = $this->reportbackService->update($reportback, $request->all(), $newTransactionId);
+            $reportback = $this->reportbackService->update($reportback, $request->all(), $transactionId);
 
             $code = 201;
         }

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -36,15 +36,10 @@ class ReportbackController extends ApiController
      */
     public function store(ReportbackRequest $request)
     {
-        // Log that the request has been received from Phoenix.
-        $transactionId = $request->header('X-Request-ID');
-        $transactionIdParts = explode('-', $transactionId);
-        $incrementedStep = $transactionIdParts[1] + 1;
-        $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
-        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
+        $newTransactionId = $this->incrementTransactionId($request);
 
-        // Add new transaction id to header.
-        // $request->headers->set('X-Request-ID', $newTransactionId);
+        // Log that the request has been received from Phoenix.
+        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
 
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
@@ -75,7 +70,11 @@ class ReportbackController extends ApiController
      */
     public function updateReportbackItems(Request $request)
     {
-        // TODO: Add transaction id for received updated status of reportback item here.
+        $newTransactionId = $this->incrementTransactionId($request);
+
+        // Log that the request has been received from Phoenix.
+        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
+
         $this->validate($request, [
             '*.rogue_reportback_item_id' => 'required',
             '*.status' => 'required',
@@ -92,5 +91,20 @@ class ReportbackController extends ApiController
         $meta = [];
 
         return $this->collection($items, $code, $meta, $this->itemTransformer);
+    }
+
+    /**
+     * Helper function to increment transaction id.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return $newTransactionId
+     */
+    public function incrementTransactionId($request) {
+        $transactionId = $request->header('X-Request-ID');
+        $transactionIdParts = explode('-', $transactionId);
+        $incrementedStep = $transactionIdParts[1] + 1;
+        $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
+
+        return $newTransactionId;
     }
 }

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -36,6 +36,7 @@ class ReportbackController extends ApiController
      */
     public function store(ReportbackRequest $request)
     {
+        // TODO: This is the first place that it is received so we want to write the transaction id logic here for when reportback/items are received.
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
         $type = $request['northstar_id'] ? 'northstar_id' : 'drupal_id';
@@ -65,6 +66,7 @@ class ReportbackController extends ApiController
      */
     public function updateReportbackItems(Request $request)
     {
+        // TODO: Add transaction id for received updated status of reportback item here.
         $this->validate($request, [
             '*.rogue_reportback_item_id' => 'required',
             '*.status' => 'required',

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -36,7 +36,17 @@ class ReportbackController extends ApiController
      */
     public function store(ReportbackRequest $request)
     {
-        // TODO: This is the first place that it is received so we want to write the transaction id logic here for when reportback/items are received.
+        // Log that the request has been received from Phoenix.
+        $transactionId = $request->header('X-Request-ID');
+        $transactionIdParts = explode('-', $transactionId);
+        $transactionIdBase = $transactionIdParts[0];
+        $incrementedStep = $transactionIdParts[1] + 1;
+        $transactionIdHeader = ['X-Request-ID' => $transactionIdBase . '-' . $incrementedStep];
+        logger()->info('Request received. Transaction ID: ' . $transactionIdBase . '-' . $incrementedStep);
+
+        // Add the new transaction ID to the header to send back to Phoenix.
+
+
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
         $type = $request['northstar_id'] ? 'northstar_id' : 'drupal_id';

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -36,10 +36,7 @@ class ReportbackController extends ApiController
      */
     public function store(ReportbackRequest $request)
     {
-        $newTransactionId = $this->incrementTransactionId($request);
-
-        // Log that the request has been received from Phoenix.
-        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
+        $newTransactionId = incrementTransactionId($request);
 
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];
@@ -70,11 +67,6 @@ class ReportbackController extends ApiController
      */
     public function updateReportbackItems(Request $request)
     {
-        $newTransactionId = $this->incrementTransactionId($request);
-
-        // Log that the request has been received from Phoenix.
-        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
-
         $this->validate($request, [
             '*.rogue_reportback_item_id' => 'required',
             '*.status' => 'required',
@@ -91,20 +83,5 @@ class ReportbackController extends ApiController
         $meta = [];
 
         return $this->collection($items, $code, $meta, $this->itemTransformer);
-    }
-
-    /**
-     * Helper function to increment transaction id.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @return $newTransactionId
-     */
-    public function incrementTransactionId($request) {
-        $transactionId = $request->header('X-Request-ID');
-        $transactionIdParts = explode('-', $transactionId);
-        $incrementedStep = $transactionIdParts[1] + 1;
-        $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
-
-        return $newTransactionId;
     }
 }

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -39,13 +39,11 @@ class ReportbackController extends ApiController
         // Log that the request has been received from Phoenix.
         $transactionId = $request->header('X-Request-ID');
         $transactionIdParts = explode('-', $transactionId);
-        $transactionIdBase = $transactionIdParts[0];
         $incrementedStep = $transactionIdParts[1] + 1;
-        $transactionIdHeader = ['X-Request-ID' => $transactionIdBase . '-' . $incrementedStep];
-        logger()->info('Request received. Transaction ID: ' . $transactionIdBase . '-' . $incrementedStep);
+        $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
+        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
 
         // Add the new transaction ID to the header to send back to Phoenix.
-
 
         // @TODO - instead should probably just have a method that gets northstar_id by default from a drupal_id if that is the only thing provided and then use that to find the reportback.
         $userId = $request['northstar_id'] ? $request['northstar_id'] : $request['drupal_id'];

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -49,5 +49,6 @@ class Kernel extends HttpKernel
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'guest' => \Rogue\Http\Middleware\RedirectIfAuthenticated::class,
         'role' => \Rogue\Http\Middleware\CheckRole::class,
+        'log.received.request' => \Rogue\Http\Middleware\LogReceivedRequest::class,
     ];
 }

--- a/app/Http/Middleware/LogReceivedRequest.php
+++ b/app/Http/Middleware/LogReceivedRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rogue\Http\Middleware;
+
+use Closure;
+
+class LogReceivedRequest
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        // Increment the incoming transaction id's step.
+        $newTransactionId = incrementTransactionId($request);
+
+        // Log that the request has been received.
+        logger()->info('Request received. Transaction ID: ' . $newTransactionId);
+
+        return $next($request);
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -40,6 +40,4 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['auth.api']], function () {
     // /reportbacks
     Route::get('reportbacks', 'Api\ReportbackController@index');
     Route::post('reportbacks', 'Api\ReportbackController@store');
-
-    Route::get('users', 'UsersController@index');
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,7 +26,7 @@ Route::group(['middleware' => 'web'], function () {
 });
 
 // API Routes
-Route::group(['prefix' => 'api/v1', 'middleware' => ['auth.api']], function () {
+Route::group(['prefix' => 'api/v1', 'middleware' => ['api', 'log.received.request']], function () {
     Route::get('/', function () {
         return 'Rogue API version 1';
     });

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -34,6 +34,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
         $phoenix = new Phoenix;
 
         $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
+        dd($this->reportback);
 
         $body = [
             'uid' => $this->reportback->drupal_id,

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -34,7 +34,6 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
         $phoenix = new Phoenix;
 
         $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
-        dd($this->reportback);
 
         $body = [
             'uid' => $this->reportback->drupal_id,

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -31,12 +31,13 @@ class ReportbackService
      * @param array $data
      * @return \Rogue\Models\Reportback $reportback.
      */
-    public function create($data)
+    public function create($data, $newTransactionId)
     {
         $reportback = $this->reportbackRepository->create($data);
 
         // POST reportback back to Phoenix.
         // If request fails, record in failed_jobs table.
+        request()->headers->set('X-Request-ID', $newTransactionId);
         dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;
@@ -50,12 +51,13 @@ class ReportbackService
      *
      * @return \Rogue\Models\Reportback $reportback.
      */
-    public function update($reportback, $data)
+    public function update($reportback, $data, $newTransactionId)
     {
         $reportback = $this->reportbackRepository->update($reportback, $data);
 
         // POST reportback update back to Phoenix.
         // If request fails, record in failed_jobs table.
+        request()->headers->set('X-Request-ID', $newTransactionId);
         dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -35,9 +35,11 @@ class ReportbackService
     {
         $reportback = $this->reportbackRepository->create($data);
 
+        // Add new transaction id to header.
+        request()->headers->set('X-Request-ID', $newTransactionId);
+
         // POST reportback back to Phoenix.
         // If request fails, record in failed_jobs table.
-        request()->headers->set('X-Request-ID', $newTransactionId);
         dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;
@@ -55,9 +57,11 @@ class ReportbackService
     {
         $reportback = $this->reportbackRepository->update($reportback, $data);
 
+        // Add new transaction id to header.
+        request()->headers->set('X-Request-ID', $newTransactionId);
+
         // POST reportback update back to Phoenix.
         // If request fails, record in failed_jobs table.
-        request()->headers->set('X-Request-ID', $newTransactionId);
         dispatch(new SendReportbackToPhoenix($reportback));
 
         return $reportback;

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -29,14 +29,15 @@ class ReportbackService
      * Handles all the logic around creating a reportback.
      *
      * @param array $data
+     * @param string $transactionId
      * @return \Rogue\Models\Reportback $reportback.
      */
-    public function create($data, $newTransactionId)
+    public function create($data, $transactionId)
     {
         $reportback = $this->reportbackRepository->create($data);
 
         // Add new transaction id to header.
-        request()->headers->set('X-Request-ID', $newTransactionId);
+        request()->headers->set('X-Request-ID', $transactionId);
 
         // POST reportback back to Phoenix.
         // If request fails, record in failed_jobs table.
@@ -50,15 +51,16 @@ class ReportbackService
      *
      * @param \Rogue\Models\Reportback $reportback
      * @param array $data
+     * @param string $transactionId
      *
      * @return \Rogue\Models\Reportback $reportback.
      */
-    public function update($reportback, $data, $newTransactionId)
+    public function update($reportback, $data, $transactionId)
     {
         $reportback = $this->reportbackRepository->update($reportback, $data);
 
         // Add new transaction id to header.
-        request()->headers->set('X-Request-ID', $newTransactionId);
+        request()->headers->set('X-Request-ID', $transactionId);
 
         // POST reportback update back to Phoenix.
         // If request fails, record in failed_jobs table.

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -18,3 +18,18 @@ function edit_image($image, $coords)
 
     return $editedImage;
 }
+
+/**
+ * Helper function to increment transaction id.
+ *
+ * @param \Illuminate\Http\Request $request
+ * @return $newTransactionId
+ */
+function incrementTransactionId($request) {
+    $transactionId = $request->header('X-Request-ID');
+    $transactionIdParts = explode('-', $transactionId);
+    $incrementedStep = $transactionIdParts[1] + 1;
+    $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
+
+    return $newTransactionId;
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -25,7 +25,8 @@ function edit_image($image, $coords)
  * @param \Illuminate\Http\Request $request
  * @return $newTransactionId
  */
-function incrementTransactionId($request) {
+function incrementTransactionId($request)
+{
     $transactionId = $request->header('X-Request-ID');
     $transactionIdParts = explode('-', $transactionId);
     $incrementedStep = $transactionIdParts[1] + 1;


### PR DESCRIPTION
#### What's this PR do?
- Adds global helper function to increment transaction id. 
- Adds middleware to log incoming requests. 

#### How should this be reviewed?
- In Postman, add `X-Request-ID` header and testing value (e.g. `test-0` - important to add `-0` to the end to make sure it is incrementing correctly)
- Hit the following endpoints: 
  - `POST /reportbacks`
    - One to make a new reportback. 
    - Second to add a new reportback item. 
  - `PUT /items`
  - `POST /reactions` 
- Check the laravel logs. 
  - When `POST`ing a new reportback, logs should look as follows: 
```
[2016-11-16 18:50:20] local.INFO: Request received. Transaction ID: 1478814474.test-1
[2016-11-16 18:50:21] local.INFO: Request made. {"method":"POST","Transaction ID":"1478814474.test-2","Path":"//dev.dosomething.org:8888/api/v1/auth/login"}
[2016-11-16 18:50:21] local.INFO: Request made. {"method":"POST","Transaction ID":"1478814474.testl-2","Path":"//dev.dosomething.org:8888/api/v1/campaigns/1327/reportback"}
```
  - When `POST`ing a new reportback item, logs should look as follows: 
```
[2016-11-16 18:52:12] local.INFO: Request received. Transaction ID: 1478814474.newtest-1
[2016-11-16 18:52:13] local.INFO: Request made. {"method":"POST","Transaction ID":"1478814474.newtest-2","Path":"//dev.dosomething.org:8888/api/v1/campaigns/1327/reportback"}
```
- Last two only received updates and do not send back to Phoenix, so logs should look as follows: 
`[2016-11-16 19:07:32] local.INFO: Request received. Transaction ID: 1478814474.reactions-1`

#### Relevant tickets
Fixes #74 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.