### PR TITLE
only send newly added files to Phoenix

### DIFF
--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -20,7 +20,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Reportback $reportback, $hasFile = TRUE)
+    public function __construct(Reportback $reportback, $hasFile = true)
     {
         $this->reportback = $reportback;
         $this->hasFile = $hasFile;

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -47,7 +47,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
         if ($this->hasFile) {
             $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
             $body['file_url'] = is_null($reportbackItem->edited_file_url) ? $reportbackItem->file_url : $reportbackItem->edited_file_url;
-            $body['caption'] = $reportbackItem->caption;
+            $body['caption'] = isset($reportbackItem->caption) ? $reportbackItem->caption : null;
             $body['source'] = $reportbackItem->source;
         }
 

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -43,8 +43,7 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
             'why_participated' => $this->reportback->why_participated,
         ];
 
-        // @TODO: only send this if we have something that Phoenix doesn't yet
-        // Data that everything except and update without a file will have
+        // Data that everything except an update without a file will have
         if ($this->hasFile) {
             $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
             $body['file_url'] = is_null($reportbackItem->edited_file_url) ? $reportbackItem->file_url : $reportbackItem->edited_file_url;

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -13,15 +13,17 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
     use InteractsWithQueue, SerializesModels;
 
     protected $reportback;
+    protected $hasFile;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(Reportback $reportback)
+    public function __construct(Reportback $reportback, $hasFile = TRUE)
     {
         $this->reportback = $reportback;
+        $this->hasFile = $hasFile;
     }
 
     /**
@@ -33,17 +35,22 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
     {
         $phoenix = new Phoenix;
 
-        $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
-
+        // Data that every post will have
         $body = [
             'uid' => $this->reportback->drupal_id,
             'nid' => $this->reportback->campaign_id,
             'quantity' => $this->reportback->quantity,
             'why_participated' => $this->reportback->why_participated,
-            'file_url' => is_null($reportbackItem->edited_file_url) ? $reportbackItem->file_url : $reportbackItem->edited_file_url,
-            'caption' => $reportbackItem->caption,
-            'source' => $reportbackItem->source,
         ];
+
+        // @TODO: only send this if we have something that Phoenix doesn't yet
+        // Data that everything except and update without a file will have
+        if ($this->hasFile) {
+            $reportbackItem = $this->reportback->items()->orderBy('created_at', 'desc')->first();
+            $body['file_url'] = is_null($reportbackItem->edited_file_url) ? $reportbackItem->file_url : $reportbackItem->edited_file_url;
+            $body['caption'] = $reportbackItem->caption;
+            $body['source'] = $reportbackItem->source;
+        }
 
         $phoenix->postReportback($this->reportback->campaign_id, $body);
     }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -64,7 +64,7 @@ class ReportbackService
 
         // POST reportback update back to Phoenix.
         // If request fails, record in failed_jobs table.
-        dispatch(new SendReportbackToPhoenix($reportback));
+        dispatch(new SendReportbackToPhoenix($reportback, isset($data['file']) ? TRUE : FALSE));
 
         return $reportback;
     }

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -64,7 +64,7 @@ class ReportbackService
 
         // POST reportback update back to Phoenix.
         // If request fails, record in failed_jobs table.
-        dispatch(new SendReportbackToPhoenix($reportback, isset($data['file']) ? TRUE : FALSE));
+        dispatch(new SendReportbackToPhoenix($reportback, isset($data['file'])));
 
         return $reportback;
     }


### PR DESCRIPTION
#### What's this PR do?
Reportback images no longer duplicate with every single update to a reportback! 

However, there is a case where the image is still duplicated which stems from how Phoenix checks to see if a new image was added. As far as I can tell, that case is just when you:
1. create a reportback or submit an update with a new image
2. hit the permalink page
3. hit back to return to the campaign page, do not refresh and do not wait to long!
4. change the something in the form but do not add a new image
5. submit again
6. return to the campaign page to see the duplicated image
I couldn't find any differences in the `$form_state` or anything in Phoenix that would hint at it being a new image rather than a duplicated one. 

#### How should this be reviewed?
Submit a new reportback, and make sure you can make updates to the quantity and the why without the image doubling.

#### Any background context you want to provide?
A potential problem with this is that once https://github.com/DoSomething/phoenix/pull/7198 is merged, all calls to the Phoenix endpoint will end up in Rogue. The Phoenix endpoint does not require a `caption` to be provided in any cases, and here we assume that one is given if there is a file, which is what the web form requires.

#### Relevant tickets
Fixes #76

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.