### PR TITLE
Get user info

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,7 +2,8 @@
 
 namespace Rogue\Http\Controllers;
 
-use DoSomething\Gateway\Northstar;
+// use DoSomething\Gateway\Northstar;
+use Rogue\Services\Registrar as Registrar;
 
 class UsersController extends Controller
 {
@@ -12,8 +13,19 @@ class UsersController extends Controller
      */
     protected $northstar;
 
-    public function __construct(Northstar $northstar)
+    public function __construct(Registrar $registrar)
     {
-        $this->northstar = $northstar;
+        // $this->northstar = $northstar;
+        $this->registrar = $registrar;
+    }
+
+    /**
+     * For now, just a test to have route to send authenticated/logged out users to.
+     */
+    public function index()
+    {
+
+        dd($this->registrar->find('559442cca59dbfc9578b4bf4'));
+        // dd($this->registrar);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,7 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Services\Registrar as Registrar;
+use Rogue\Models\User;
 
 class UsersController extends Controller
 {
@@ -18,10 +19,16 @@ class UsersController extends Controller
     }
 
     /**
-     * List of Rogue users.
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
      */
     public function index()
     {
+        $ids = User::all()->pluck('northstar_id')->all();
 
+        $users = $this->registrar->findAll($ids);
+
+        return view('users.index', compact('users'));
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -24,10 +24,9 @@ class UsersController extends Controller
      */
     public function index()
     {
-
+        // $this->registrar->find('559442cca59dbfc9578b4bf4');
         // dd($this->registrar->find('559442cca59dbfc9578b4bf4'));
 
-        $this->registrar->flush();
         dd($this->registrar->findAll(['5571f4f5a59dbf3c7a8b4569', '559442cca59dbfc9578b4bf4']));
 
         // dd($this->registrar);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Http\Controllers;
 
-// use DoSomething\Gateway\Northstar;
 use Rogue\Services\Registrar as Registrar;
 
 class UsersController extends Controller
@@ -15,20 +14,14 @@ class UsersController extends Controller
 
     public function __construct(Registrar $registrar)
     {
-        // $this->northstar = $northstar;
         $this->registrar = $registrar;
     }
 
     /**
-     * For now, just a test to have route to send authenticated/logged out users to.
+     * List of Rogue users.
      */
     public function index()
     {
-        // $this->registrar->find('559442cca59dbfc9578b4bf4');
-        // dd($this->registrar->find('559442cca59dbfc9578b4bf4'));
 
-        dd($this->registrar->findAll(['5571f4f5a59dbf3c7a8b4569', '559442cca59dbfc9578b4bf4']));
-
-        // dd($this->registrar);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -25,7 +25,11 @@ class UsersController extends Controller
     public function index()
     {
 
-        dd($this->registrar->find('559442cca59dbfc9578b4bf4'));
+        // dd($this->registrar->find('559442cca59dbfc9578b4bf4'));
+
+        $this->registrar->flush();
+        dd($this->registrar->findAll(['5571f4f5a59dbf3c7a8b4569', '559442cca59dbfc9578b4bf4']));
+
         // dd($this->registrar);
     }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -23,6 +23,8 @@ Route::group(['middleware' => 'web'], function () {
     // Default route to send authenticated users to.
     // NOTE: For testing authentication only.
     Route::get('reportbacks', 'ReportbacksController@index');
+
+    Route::get('users', 'UsersController@index');
 });
 
 // API Routes

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -104,10 +104,6 @@ class CacheRepository
      */
     public function resolveMissingItems($items)
     {
-        // @TODO: maybe this should run in the retrieveMany() method?
-        // @TODO: May want to check if calling Class has find() method using method_exists($object, $method_name).
-        // @TODO: Might also be faster to collect the missing items and do a getAll() instead of find() for each individually.
-
         foreach ($items as $key => $value) {
             if ($value === false || $value === null) {
                 if (property_exists($this, 'prefix')) {

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Rogue\Repositories;
+
+use Illuminate\Support\Facades\Cache;
+
+class CacheRepository
+{
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function retrieve($key)
+    {
+        return Cache::get($key);
+    }
+
+    /**
+     * Retrieve multiple items from the cache by key.
+     * Items not found in the cache will have a null value.
+     *
+     * @param  array  $keys
+     * @return array|null
+     */
+    public function retrieveMany(array $keys)
+    {
+        $retrieved = [];
+
+        $data = Cache::many($keys);
+
+        foreach ($data as $item) {
+            if ($item) {
+                $retrieved[] = $item;
+            }
+        }
+
+        if (count($retrieved)) {
+            return $data;
+        }
+    }
+
+    /**
+     * Set a prefix on supplied string used as cache key.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public function setPrefix($string)
+    {
+        if (property_exists($this, 'prefix')) {
+            return $this->prefix . ':' . $string;
+        } else {
+            return $string;
+        }
+    }
+
+    /**
+     * Store an item in the cache for a given number of minutes.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  int     $minutes
+     * @return void
+     */
+    public function store($key, $value, $minutes = 15)
+    {
+        Cache::put($key, $value, $minutes);
+    }
+
+    /**
+     * Store multiple items in the cache for a given number of minutes.
+     *
+     * @param  array  $values
+     * @param  int  $minutes
+     * @return void
+     */
+    public function storeMany(array $values, $minutes = 15)
+    {
+        Cache::putMany($values, $minutes);
+    }
+
+    /**
+     * Unset a prefix on supplied string used as cache key.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public function unsetPrefix($string)
+    {
+        if (property_exists($this, 'prefix')) {
+            return str_replace('campaign:', '', $string);
+        } else {
+            return $string;
+        }
+    }
+
+    /**
+     * Resolving missing cached items in cache collection.
+     *
+     * @param  array $items
+     * @return array
+     */
+    public function resolveMissingItems($items)
+    {
+        // @TODO: maybe this should run in the retrieveMany() method?
+        // @TODO: May want to check if calling Class has find() method using method_exists($object, $method_name).
+        // @TODO: Might also be faster to collect the missing items and do a getAll() instead of find() for each individually.
+
+        foreach ($items as $key => $value) {
+            if ($value === false || $value === null) {
+                if (property_exists($this, 'prefix')) {
+                    $id = $this->unsetPrefix($key);
+                }
+
+                $items[$key] = $this->find($id);
+            }
+        }
+
+        return $items;
+    }
+}

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rogue\Services;
+
+use \DoSomething\Gateway\Northstar;
+
+class Registrar
+{
+    /**
+     * Create new Registrar instance.
+     *
+     */
+    public function __construct()
+    {
+        $this->northstar = gateway('northstar');
+    }
+
+    public function find($northstar_id)
+    {
+        // First look in cache
+        // If not look to Northstar and stor in cache
+        $northstarUser = $this->northstar->getUser('id', $northstar_id);
+
+        // dd($northstarU);
+        if (! $northstarUser) {
+            // throw new NorthstarUserNotFoundException;
+            // @TODO - Handle case where we do not find the user.
+        }
+
+        // @TODO: Can't use Repository method below because it throws exception
+        // and here we just need "null" if user not found in Database. Find a
+        // better fix if necessary!
+        // $user = User::find($northstarUser->id);
+
+        // if (! $user) {
+        //     return $northstarUser;
+        // }
+
+        // return $user;
+        return $northstarUser;
+    }
+}

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -2,15 +2,13 @@
 
 namespace Rogue\Services;
 
-use \DoSomething\Gateway\Northstar;
+use DoSomething\Gateway\Northstar;
 use Rogue\Repositories\CacheRepository;
 
 class Registrar
 {
-
     /**
      * Create new Registrar instance.
-     *
      */
     public function __construct()
     {
@@ -29,8 +27,7 @@ class Registrar
     {
         $user = $this->cache->retrieve($id);
 
-        if (! $user)
-        {
+        if (! $user) {
             $user = $this->northstar->getUser('id', $id);
 
             // @TODO - How long should we store users in Cache?

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -18,12 +18,17 @@ class Registrar
         $this->cache = new CacheRepository;
     }
 
+    /**
+     * Finds a single user in the Rogue/Northstar system. If the user is not found
+     * in the Cache, then we grab it directly from Northstar and store in cache.
+     *
+     * @param  string $id
+     * @return object $user Northstar user object
+     */
     public function find($id)
     {
-        // First look in cache
         $user = $this->cache->retrieve($id);
 
-        // If not look to Northstar and store in cache
         if (! $user)
         {
             $user = $this->northstar->getUser('id', $id);
@@ -35,6 +40,12 @@ class Registrar
         return $user;
     }
 
+    /**
+     * Finds a group of users in the Rogue/Northstar system.
+     *
+     * @param  array $ids
+     * @return array $users|null
+     */
     public function findAll(array $ids = [])
     {
         if ($ids) {
@@ -85,7 +96,6 @@ class Registrar
      */
     protected function getBatchedCollection($ids, $size = 50)
     {
-        // @TODO: Should this be a function in Northstar Client?
         $count = intval(ceil(count($ids) / 50));
         $index = 0;
         $data = [];

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -3,6 +3,7 @@
 namespace Rogue\Services;
 
 use \DoSomething\Gateway\Northstar;
+use Illuminate\Support\Facades\Cache;
 
 class Registrar
 {
@@ -15,28 +16,130 @@ class Registrar
         $this->northstar = gateway('northstar');
     }
 
-    public function find($northstar_id)
+    public function find($id)
     {
         // First look in cache
-        // If not look to Northstar and stor in cache
-        $northstarUser = $this->northstar->getUser('id', $northstar_id);
+        $user = Cache::get($id);
 
-        // dd($northstarU);
-        if (! $northstarUser) {
-            // throw new NorthstarUserNotFoundException;
-            // @TODO - Handle case where we do not find the user.
+        // If not look to Northstar and store in cache
+        if (! $user)
+        {
+            $user = $this->northstar->getUser('id', $id);
+
+            Cache::put($user->id, $user, 15);
         }
 
-        // @TODO: Can't use Repository method below because it throws exception
-        // and here we just need "null" if user not found in Database. Find a
-        // better fix if necessary!
-        // $user = User::find($northstarUser->id);
-
-        // if (! $user) {
-        //     return $northstarUser;
-        // }
-
-        // return $user;
-        return $northstarUser;
+        return $user;
     }
+
+    public function findAll(array $ids = [])
+    {
+        if ($ids) {
+            $users = $this->retrieveMany($ids);
+
+            if (! $users) {
+                $users = $this->getBatchedCollection($ids);
+
+                if (count($users)) {
+                    $group = $users->keyBy('id')->all();
+
+                    Cache::putMany($group, 15);
+                }
+            } else {
+                $users = $this->resolveMissingUsers($users);
+                $users = collect(array_values($users));
+            }
+
+            return $users;
+        }
+
+        return null;
+    }
+
+    /**
+     * @todo - MOVE TO HELPER CLASS (REPO?)
+     * Remove all items from the cache.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        Cache::flush();
+    }
+
+    /**
+     * @todo - MOVE TO HELPER CLASS (REPO?)
+     * Retrieve multiple items from the cache by key.
+     * Items not found in the cache will have a null value.
+     *
+     * @param  array  $keys
+     * @return array|null
+     */
+    protected function retrieveMany(array $keys)
+    {
+        $retrieved = [];
+
+        $data = Cache::many($keys);
+
+        foreach ($data as $item) {
+            if ($item) {
+                $retrieved[] = $item;
+            }
+        }
+
+        if (count($retrieved)) {
+            return $data;
+        }
+
+        return null;
+    }
+
+    /**
+     * @todo - MOVE TO HELPER CLASS (REPO?)
+     * Resolving missing cached users in a user cache collection.
+     *
+     * @param  array $users
+     * @return array
+     */
+    protected function resolveMissingUsers($users)
+    {
+        foreach ($users as $key => $value) {
+            if ($value === false or $value === null) {
+                $users[$key] = $this->find($key);
+            }
+        }
+
+        return $users;
+    }
+
+    /**
+     * Get large number of users in batches from Northstar.
+     *
+     * @param  array  $ids
+     * @param  int $size
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getBatchedCollection($ids, $size = 50)
+    {
+        // @TODO: Should this be a function in Northstar Client?
+        $count = intval(ceil(count($ids) / 50));
+        $index = 0;
+        $data = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $batch = array_slice($ids, $index, $size);
+
+            $parameters['limit'] = '50';
+            $parameters['filter[_id]'] = implode(',', $batch);
+
+            $accounts = $this->northstar->getAllUsers($parameters);
+
+            $data = array_merge($data, $accounts->toArray());
+
+            $index += $size;
+        }
+
+        return collect($data);
+    }
+
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -29,8 +29,7 @@ function incrementTransactionId($request)
 {
     $transactionId = $request->header('X-Request-ID');
 
-    if ($transactionId)
-    {
+    if ($transactionId) {
         $transactionIdParts = explode('-', $transactionId);
         $incrementedStep = $transactionIdParts[1] + 1;
         $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -28,9 +28,15 @@ function edit_image($image, $coords)
 function incrementTransactionId($request)
 {
     $transactionId = $request->header('X-Request-ID');
-    $transactionIdParts = explode('-', $transactionId);
-    $incrementedStep = $transactionIdParts[1] + 1;
-    $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
 
-    return $newTransactionId;
+    if ($transactionId)
+    {
+        $transactionIdParts = explode('-', $transactionId);
+        $incrementedStep = $transactionIdParts[1] + 1;
+        $newTransactionId = $transactionIdParts[0] . '-' . $incrementedStep;
+
+        return $newTransactionId;
+    }
+
+    return null;
 }

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header',[
+        'header' => 'Users'
+    ])
+
+
+    @if ($users->count())
+        @include('users.partials._table_users', ['users' => $users, 'role' => 'Admins'])
+    @endif
+
+@stop

--- a/resources/views/users/partials/_table_users.blade.php
+++ b/resources/views/users/partials/_table_users.blade.php
@@ -1,0 +1,26 @@
+<div class="container">
+    <div class="wrapper">
+        <div class="container__block">
+            <h2 class="heading -banner">{{ $role }}</h2>
+
+            <table class="table">
+                <thead>
+                    <tr class="table__header">
+                        <th class="table__cell">User</th>
+                        <th class="table__cell">Email</th>
+                        <th class="table__cell">Phone</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($users as $user)
+                        <tr class="table__row">
+                            <td class="table__cell"><a href="#">{{ $user->first_name or 'Anonymous' }} {{ $user->last_name or '' }}</a></td>
+                            <td class="table__cell">{{ $user->email or ''}}</td>
+                            <td class="table__cell">{{ $user->mobile or ''}}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/tests/ReportbackApiTest.php
+++ b/tests/ReportbackApiTest.php
@@ -77,7 +77,8 @@ class ReportbackApiTest extends TestCase
         $updatesToReportbackItem = [
             [
                 'rogue_reportback_item_id' => $reportbackItem->id,
-                'status' => 'approved'
+                'status' => 'approved',
+                'reviewer' => str_random(24),
             ]
         ];
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -65,4 +65,24 @@ class UserTest extends TestCase
 
         $this->visit('/logout');
     }
+
+    // public function testRegistrar()
+    // {
+    //     $registrar = new Registrar;
+
+    //     $mock = $this->mock(Northstar::class)
+    //         ->shouldReceive('getUser')
+    //         ->andReturn((object) [
+    //             'id' => str_random(24),
+    //             'first_name' => 'Shae',
+    //             // ...
+    //         ]);
+    //     dd($mock);
+    //     // $user = $registrar->findUserAccount([
+    //     //     'id' => 'bloop@dosomething.org',
+    //     //     'term' => 'email',
+    //     // ]);
+
+    //     // dd($user);
+    // }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -65,24 +65,4 @@ class UserTest extends TestCase
 
         $this->visit('/logout');
     }
-
-    // public function testRegistrar()
-    // {
-    //     $registrar = new Registrar;
-
-    //     $mock = $this->mock(Northstar::class)
-    //         ->shouldReceive('getUser')
-    //         ->andReturn((object) [
-    //             'id' => str_random(24),
-    //             'first_name' => 'Shae',
-    //             // ...
-    //         ]);
-    //     dd($mock);
-    //     // $user = $registrar->findUserAccount([
-    //     //     'id' => 'bloop@dosomething.org',
-    //     //     'term' => 'email',
-    //     // ]);
-
-    //     // dd($user);
-    // }
 }


### PR DESCRIPTION
#### What's this PR do?

Creates the system of grabbing user information in Rogue. 

First we try to grab user information that we stored in cache, if they aren't found there we grab them directly from Northstar. 

This work is based largely on @weerd 's work in Gladiator. The Gladiator system is a little more complicated since we actually store users in Gladiator, but in Rogue we just store references to northstar ids in the reportbacks table. 

So what this sets up is a `Registrar` service that handles the logic of resolving users in northstar vs cache. We also have a `CacheRepository` class that handles the storing/grabbing cache logic [(based on this)](https://github.com/DoSomething/gladiator/blob/master/app/Repositories/CacheStorage.php) 

This also sets up a view at `/users` to just list the users in the users table, which will really only be admins but helps to provide an interface for this work. 

#### How should this be reviewed?

#### Any background context you want to provide?

I started writing tests for this, but decided I needed to get this merged in more. I will flag that work for the future. 

#### Relevant tickets
Fixes #71 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.