### PR TITLE
updates documnetation and adds reviewer to requirement in validation

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -70,6 +70,7 @@ class ReportbackController extends ApiController
         $this->validate($request, [
             '*.rogue_reportback_item_id' => 'required',
             '*.status' => 'required',
+            '*.reviewer' => 'required',
         ]);
 
         $items = $this->reportbackService->updateReportbackItems($request->all());

--- a/documentation/endpoints/reportbackitems.md
+++ b/documentation/endpoints/reportbackitems.md
@@ -11,3 +11,5 @@ PUT /api/v1/items
     The reportback item's Rogue id (id column in Rogue's reportback_items table).
   - **status**: (string) required
     The status of the reportback item. 
+  - **reviewer**: (varchar) required
+    The Northstar id of the reviewer who updated the reportback item's status. 


### PR DESCRIPTION
#### What's this PR do?
- Updates `/items` documentation to add requirement of `reviewer`.
- Updates `/items` validation to make sure that `reviewer` is required.

#### How should this be reviewed?
Try to hit the `/items` endpoint without a reviewer. Should get error: `{"0.reviewer":["The 0.reviewer field is required."]}`

#### Relevant tickets
Fixes #90 