### PR TITLE
Polymorphic post

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -45,6 +45,17 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if ($request->wantsJson()) {
+            $json = [
+                'error' => [
+                    'code' => $e->getStatusCode(),
+                    'message' => $e->getMessage(),
+                ],
+            ];
+
+            return response()->json($json, 400);
+        }
+
         return parent::render($request, $e);
     }
 }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -2,11 +2,11 @@
 
 namespace Rogue\Http\Controllers\Api;
 
-use Rogue\Services\PostService;
-use Rogue\Http\Transformers\PostTransformer;
-use Illuminate\Http\Request;
 use Rogue\Models\Signup;
+use Illuminate\Http\Request;
+use Rogue\Services\PostService;
 use Rogue\Repositories\SignupRepository;
+use Rogue\Http\Transformers\PostTransformer;
 
 class PostsController extends ApiController
 {
@@ -43,7 +43,6 @@ class PostsController extends ApiController
         // Now we have one PostTransformer to handle returning a Post to the API request.
         $this->transformer = new PostTransformer;
     }
-
 
     /**
      * Store a newly created resource in storage.

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -3,8 +3,8 @@
 namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Signup;
-use Illuminate\Http\Request;
 use Rogue\Services\PostService;
+use Rogue\Http\Requests\PostRequest;
 use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
 
@@ -51,7 +51,7 @@ class PostsController extends ApiController
      * @return \Illuminate\Http\Response
      */
     // @TODO - Validate post request.
-    public function store(Request $request)
+    public function store(PostRequest $request)
     {
         $transactionId = incrementTransactionId($request);
 
@@ -66,7 +66,7 @@ class PostsController extends ApiController
             $signup = $this->signups->create($request->all());
         }
 
-        // Send the data to the PostService class which will handle delgating
+        // Send the data to the PostService class which will handle determining
         // which type of post we are dealing with and which repostitory to use to // actually create the post.
         $post = $this->posts->create($request->all(), $signup->id, $transactionId);
 

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -2,11 +2,11 @@
 
 namespace Rogue\Http\Controllers\Api;
 
-use Rogue\Models\Signup;
-use Illuminate\Http\Request;
 use Rogue\Services\PostService;
-use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
+use Illuminate\Http\Request;
+use Rogue\Models\Signup;
+use Rogue\Repositories\SignupRepository;
 
 class PostsController extends ApiController
 {

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -6,7 +6,7 @@ use Rogue\Models\Signup;
 use Illuminate\Http\Request;
 use Rogue\Services\PostService;
 use Rogue\Repositories\SignupRepository;
-use Rogue\Http\Transformers\PhotoTransformer;
+use Rogue\Http\Transformers\PostTransformer;
 
 class PostsController extends ApiController
 {
@@ -39,7 +39,9 @@ class PostsController extends ApiController
     {
         $this->posts = $posts;
         $this->signups = $signups;
+        $this->transformer = new PostTransformer;
     }
+
 
     /**
      * Store a newly created resource in storage.
@@ -64,33 +66,6 @@ class PostsController extends ApiController
 
         $post = $this->posts->create($request->all(), $signup->id, $transactionId);
 
-        if ($post) {
-            $code = 200;
-        }
-
-        return $this->resolvePostTransformer($post, $code);
-    }
-
-    /**
-     * Decides how to transform a post based on what kind of post it is.
-     *
-     * @param  Illuminate\Database\Eloquent\Model  $model
-     * @param  int  $code
-     * @return \Illuminate\Http\Response
-     */
-    protected function resolvePostTransformer($model, $code)
-    {
-        $class = get_class($model);
-
-        switch ($class) {
-            case 'Rogue\Models\Photo':
-                $this->transformer = new PhotoTransformer;
-
-                return $this->item($model, $code);
-
-                break;
-            default:
-                break;
-        }
+        return $this->item($post);
     }
 }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -39,6 +39,8 @@ class PostsController extends ApiController
     {
         $this->posts = $posts;
         $this->signups = $signups;
+
+        // Now we have one PostTransformer to handle returning a Post to the API request.
         $this->transformer = new PostTransformer;
     }
 
@@ -49,6 +51,7 @@ class PostsController extends ApiController
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
+    // @TODO - Validate post request.
     public function store(Request $request)
     {
         $transactionId = incrementTransactionId($request);
@@ -64,6 +67,8 @@ class PostsController extends ApiController
             $signup = $this->signups->create($request->all());
         }
 
+        // Send the data to the PostService class which will handle delgating
+        // which type of post we are dealing with and which repostitory to use to // actually create the post.
         $post = $this->posts->create($request->all(), $signup->id, $transactionId);
 
         return $this->item($post);

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -4,7 +4,6 @@ namespace Rogue\Http\Requests;
 
 class PostRequest extends Request
 {
-
     protected $rules = [
         'northstar_id' => 'required|string',
         'campaign_id' => 'required|int',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -2,8 +2,6 @@
 
 namespace Rogue\Http\Requests;
 
-use Rogue\Http\Requests\Request;
-
 class PostRequest extends Request
 {
 
@@ -42,7 +40,7 @@ class PostRequest extends Request
     /**
      * Determines the validation ruleset to use for a particular type of post.
      *
-     * @param  Object $request
+     * @param  object $request
      * @return array|null
      */
     protected function getRules($request)

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rogue\Http\Requests;
+
+use Rogue\Http\Requests\Request;
+
+class PostRequest extends Request
+{
+
+    protected $rules = [
+        'northstar_id' => 'required|string',
+        'campaign_id' => 'required|int',
+        'campaign_run_id' => 'required|int',
+    ];
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        if (! isset($this->request->event_type)) {
+            return [
+                'event_type' => 'required|in:post_photo',
+            ];
+        }
+
+        return $this->getRules($this->request);
+    }
+
+    protected function getRules($request)
+    {
+        switch ($request->event_type) {
+            case 'post_photo':
+                return array_merge($this->rules, $this->setPhotoRules());
+
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    protected function setPhotoRules()
+    {
+        return [
+            'caption' => 'string',
+            'status' => 'pending',
+            'source' => 'string',
+            'remote_addr' => 'ip',
+        ];
+    }
+}

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -39,6 +39,12 @@ class PostRequest extends Request
         return $this->getRules($this->request);
     }
 
+    /**
+     * Determines the validation ruleset to use for a particular type of post.
+     *
+     * @param  Object $request
+     * @return array|null
+     */
     protected function getRules($request)
     {
         switch ($request->event_type) {
@@ -52,6 +58,11 @@ class PostRequest extends Request
         }
     }
 
+    /**
+     * Defines the ruleset for photo posts.
+     *
+     * @return array
+     */
     protected function setPhotoRules()
     {
         return [
@@ -59,6 +70,7 @@ class PostRequest extends Request
             'status' => 'pending',
             'source' => 'string',
             'remote_addr' => 'ip',
+            'file' => 'string', // @TODO - should do some better validation around files.
         ];
     }
 }

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -27,19 +27,19 @@ class PostTransformer extends TransformerAbstract
         return [
             'event_id' => $post->event_id,
             'signup_id' => $post->signup_id,
-            'northstar_id' => $post->postData->northstar_id,
+            'northstar_id' => $post->content->northstar_id,
             'campaign_id' => $post->signup->campaign_id,
             'campaign_run_id' => $post->signup->campaign_run_id,
             'content' => [
                 'type' => $post->event->event_type,
                 'media' => [
-                    'url' => $post->postData->file_url,
-                    'edited_url' => $post->postData->edited_file_url,
+                    'url' => $post->content->file_url,
+                    'edited_url' => $post->content->edited_file_url,
                 ],
-                'caption' => $post->postData->caption,
-                'status' => $post->postData->status,
-                'created_at' => $post->postData->created_at->toIso8601String(),
-                'updated_at' => $post->postData->updated_at->toIso8601String(),
+                'caption' => $post->content->caption,
+                'status' => $post->content->status,
+                'created_at' => $post->content->created_at->toIso8601String(),
+                'updated_at' => $post->content->updated_at->toIso8601String(),
             ],
         ];
     }

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -25,7 +25,6 @@ class PostTransformer extends TransformerAbstract
     public function transform(Post $post)
     {
         return [
-            'event_id' => $post->event_id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->content->northstar_id,
             'campaign_id' => $post->signup->campaign_id,

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -28,8 +28,8 @@ class PostTransformer extends TransformerAbstract
             'event_id' => $post->event_id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->postData->northstar_id,
-            // 'campaign_id' => $photo->signup->campaign_id,
-            // 'campaign_run_id' => $photo->signup->campaign_run_id,
+            'campaign_id' => $post->signup->campaign_id,
+            'campaign_run_id' => $post->signup->campaign_run_id,
             'content' => [
                 'type' => $post->event->event_type,
                 'media' => [

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rogue\Http\Transformers;
+
+use Rogue\Models\Post;
+use League\Fractal\TransformerAbstract;
+
+class PostTransformer extends TransformerAbstract
+{
+    /**
+     * List of resources to automatically include
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [
+        'event',
+    ];
+
+    /**
+     * Transform resource data.
+     *
+     * @param \Rogue\Models\Photo $photo
+     * @return array
+     */
+    public function transform(Post $post)
+    {
+        return [
+            'event_id' => $post->event_id,
+            'signup_id' => $post->signup_id,
+            'northstar_id' => $post->postData->northstar_id,
+            // 'campaign_id' => $photo->signup->campaign_id,
+            // 'campaign_run_id' => $photo->signup->campaign_run_id,
+            'content' => [
+                'type' => $post->event->event_type,
+                'media' => [
+                    'url' => $post->postData->file_url,
+                    'edited_url' => $post->postData->edited_file_url,
+                ],
+                'caption' => $post->postData->caption,
+                'status' => $post->postData->status,
+                'created_at' => $post->postData->created_at->toIso8601String(),
+                'updated_at' => $post->postData->updated_at->toIso8601String(),
+            ],
+        ];
+    }
+
+    /**
+     * Include the event
+     *
+     * @param \Rogue\Models\Post $post
+     * @return \League\Fractal\Resource\Item
+     */
+    public function includeEvent(Post $post)
+    {
+        $event = $post->event;
+
+        return $this->item($event, new EventTransformer);
+    }
+}

--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -54,10 +54,10 @@ class SendPostToPhoenix extends Job implements ShouldQueue
 
         // Data that everything except an update without a file will have
         if ($this->hasFile) {
-            $body['file_url'] = is_null($this->post->postData->edited_file_url) ? $this->photo->file_url : $this->post->postData->edited_file_url;
-            $body['caption'] = isset($this->post->postData->caption) ? $this->post->postData->caption : null;
-            $body['source'] = $this->post->postData->source;
-            $body['remote_addr'] = $this->post->postData->remote_addr;
+            $body['file_url'] = is_null($this->post->content->edited_file_url) ? $this->photo->file_url : $this->post->content->edited_file_url;
+            $body['caption'] = isset($this->post->content->caption) ? $this->post->content->caption : null;
+            $body['source'] = $this->post->content->source;
+            $body['remote_addr'] = $this->post->content->remote_addr;
         }
 
         $phoenix->postReportback($body);

--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -2,7 +2,7 @@
 
 namespace Rogue\Jobs;
 
-use Rogue\Models\Photo;
+use Rogue\Models\Post;
 use Rogue\Services\Phoenix;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -12,11 +12,11 @@ class SendPostToPhoenix extends Job implements ShouldQueue
     use InteractsWithQueue;
 
     /*
-     * Photo instance.
+     * Post instance.
      *
-     * @var Rogue\Models\Photo
+     * @var Rogue\Models\Post
      */
-    protected $photo;
+    protected $post;
 
     /*
      * @var bool
@@ -28,9 +28,9 @@ class SendPostToPhoenix extends Job implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Photo $photo, $hasFile = true)
+    public function __construct(Post $post, $hasFile = true)
     {
-        $this->photo = $photo;
+        $this->post = $post;
 
         $this->hasFile = $hasFile;
     }
@@ -47,17 +47,17 @@ class SendPostToPhoenix extends Job implements ShouldQueue
         // Data that every post will have
         $body = [
             'uid' => 12345, // Grab drupal_id from northstar object?
-            'nid' => $this->photo->signup->campaign_id,
-            'quantity' => $this->photo->signup->quantity,
-            'why_participated' => $this->photo->signup->why_participated,
+            'nid' => $this->post->signup->campaign_id,
+            'quantity' => $this->post->signup->quantity,
+            'why_participated' => $this->post->signup->why_participated,
         ];
 
         // Data that everything except an update without a file will have
         if ($this->hasFile) {
-            $body['file_url'] = is_null($this->photo->edited_file_url) ? $this->photo->file_url : $this->photo->edited_file_url;
-            $body['caption'] = isset($this->photo->caption) ? $this->photo->caption : null;
-            $body['source'] = $this->photo->source;
-            $body['remote_addr'] = $this->photo->remote_addr;
+            $body['file_url'] = is_null($this->post->postData->edited_file_url) ? $this->photo->file_url : $this->post->postData->edited_file_url;
+            $body['caption'] = isset($this->post->postData->caption) ? $this->post->postData->caption : null;
+            $body['source'] = $this->post->postData->source;
+            $body['remote_addr'] = $this->post->postData->remote_addr;
         }
 
         $phoenix->postReportback($body);

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -20,4 +20,12 @@ class Event extends Model
     {
         return $this->hasOne(Signup::class);
     }
+
+    /**
+     * An event has one post.
+     */
+    public function post()
+    {
+        return $this->hasOne(Post::class);
+    }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -20,6 +20,6 @@ class Photo extends Model
      */
     public function post()
     {
-        return $this->morphOne('Rogue\Models\Post', 'post');
+        return $this->morphOne('Rogue\Models\Post', 'postable');
     }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -18,24 +18,8 @@ class Photo extends Model
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function content()
+    public function post()
     {
         return $this->morphOne('Rogue\Models\Post', 'post');
     }
-
-    // /**
-    //  * Each photo belongs to an event.
-    //  */
-    // public function event()
-    // {
-    //     return $this->belongsTo(Event::class);
-    // }
-
-    // /**
-    //  * Each photo belongs to a signup.
-    //  */
-    // public function signup()
-    // {
-    //     return $this->belongsTo(Signup::class);
-    // }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -11,21 +11,31 @@ class Photo extends Model
      *
      * @var array
      */
-    protected $fillable = ['event_id', 'signup_id', 'northstar_id', 'file_url', 'edited_file_url', 'caption', 'status', 'source', 'remote_addr'];
+    protected $fillable = ['signup_id', 'northstar_id', 'file_url', 'edited_file_url', 'caption', 'status', 'source', 'remote_addr'];
 
     /**
-     * Each photo belongs to an event.
+     * Returns a parent Post model.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function event()
+    public function content()
     {
-        return $this->belongsTo(Event::class);
+        return $this->morphOne('Rogue\Models\Post', 'post');
     }
 
-    /**
-     * Each photo belongs to a signup.
-     */
-    public function signup()
-    {
-        return $this->belongsTo(Signup::class);
-    }
+    // /**
+    //  * Each photo belongs to an event.
+    //  */
+    // public function event()
+    // {
+    //     return $this->belongsTo(Event::class);
+    // }
+
+    // /**
+    //  * Each photo belongs to a signup.
+    //  */
+    // public function signup()
+    // {
+    //     return $this->belongsTo(Signup::class);
+    // }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -40,4 +40,12 @@ class Post extends Model
     {
         return $this->belongsTo(Event::class);
     }
+
+    /**
+     * Each post belongs to a signup.
+     */
+    public function signup()
+    {
+        return $this->belongsTo(Signup::class);
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -29,7 +29,7 @@ class Post extends Model
      */
     public function content()
     {
-        return $this->morphTo('post');
+        return $this->morphTo('postable');
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rogue\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['event_id', 'signup_id'];
+
+    protected $primaryKey = ['event_id'];
+
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * Returns Post data
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function postData()
+    {
+        return $this->morphTo('post');
+    }
+
+    /**
+     * Each post belongs to an event.
+     */
+    public function event()
+    {
+        return $this->belongsTo(Event::class);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -15,7 +15,6 @@ class Post extends Model
 
     protected $primaryKey = ['event_id'];
 
-
     /**
      * Indicates if the IDs are auto-incrementing.
      *
@@ -28,7 +27,7 @@ class Post extends Model
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function postData()
+    public function content()
     {
         return $this->morphTo('post');
     }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -20,4 +20,6 @@ class Signup extends Model
     {
         return $this->belongsTo(Event::class);
     }
+
+    // @TODO - A signup has many posts.
 }

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -58,14 +58,14 @@ class PhotoRepository
             'remote_addr' => $data['remote_addr'],
         ]);
 
-        // move in to Post service class as a help?
-        // or a PostRepo that these other specific repos extend?
+        // Create the Post and associate the Photo with it.
+        // @Note -- Having some issue using the `create` method here. I think
+        // becase the Posts table doesn't have an `id` key, but I can work that out.
         $post = new Post([
             'event_id' => $postEvent->id,
             'signup_id' => $signupId,
         ]);
-
-        $post->postData()->associate($photo);
+        $post->content()->associate($photo);
         $post->save();
 
         // $this->registrar->find($data['northstar_id']);

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -65,6 +65,7 @@ class PhotoRepository
             'event_id' => $postEvent->id,
             'signup_id' => $signupId,
         ]);
+
         $post->content()->associate($photo);
         $post->save();
 
@@ -73,6 +74,12 @@ class PhotoRepository
         return $post;
     }
 
+    /**
+     * Crop an image
+     *
+     * @param  int $signupId
+     * @return url|null
+     */
     protected function crop($data)
     {
         $cropValues = array_only($data, $this->cropProperties);

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -2,9 +2,9 @@
 
 namespace Rogue\Repositories;
 
+use Rogue\Models\Post;
 use Rogue\Models\Event;
 use Rogue\Models\Photo;
-use Rogue\Models\Post;
 use Rogue\Services\AWS;
 use Rogue\Services\Registrar;
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -4,6 +4,7 @@ namespace Rogue\Repositories;
 
 use Rogue\Models\Event;
 use Rogue\Models\Photo;
+use Rogue\Models\Post;
 use Rogue\Services\AWS;
 use Rogue\Services\Registrar;
 
@@ -48,8 +49,6 @@ class PhotoRepository
         $editedImage = $this->crop($data);
 
         $photo = Photo::create([
-            'event_id' => $postEvent->id,
-            'signup_id' => $signupId,
             'northstar_id' => $data['northstar_id'],
             'file_url' => $fileUrl,
             'edited_file_url' => $editedImage,
@@ -59,9 +58,19 @@ class PhotoRepository
             'remote_addr' => $data['remote_addr'],
         ]);
 
+        // move in to Post service class as a help?
+        // or a PostRepo that these other specific repos extend?
+        $post = new Post([
+            'event_id' => $postEvent->id,
+            'signup_id' => $signupId,
+        ]);
+
+        $post->postData()->associate($photo);
+        $post->save();
+
         // $this->registrar->find($data['northstar_id']);
 
-        return $photo;
+        return $post;
     }
 
     protected function crop($data)

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -22,8 +22,6 @@ class PostService
      */
     public function create($data, $signupId, $transactionId)
     {
-        // Looks at the event type that is past to figure out which type of post
-        // we are dealing with.
         $this->resolvePostRepository($data['event_type']);
 
         $post = $this->repository->create($data, $signupId);

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -12,17 +12,6 @@ class PostService
      */
     protected $repository;
 
-    // /**
-    //  * Constructor
-    //  *
-    //  * @param \Rogue\Repositories\PhotoRepository $photos
-    //  */
-    // public function __construct(PhotoRepository $post)
-    // {
-    //     // @TODO - Eventually would want to figure out a smarter way of resolving different repositories to use for a post i.e. Video, text, etc.
-    //     $this->post = $post;
-    // }
-
     /*
      * Handles all business logic around creating posts.
      *
@@ -37,14 +26,14 @@ class PostService
 
         $post = $this->repository->create($data, $signupId);
 
-        // // Add new transaction id to header.
-        // request()->headers->set('X-Request-ID', $transactionId);
+        // Add new transaction id to header.
+        request()->headers->set('X-Request-ID', $transactionId);
 
-        // // POST reportback back to Phoenix, unless told not to.
-        // // If request fails, record in failed_jobs table.
-        // if (! isset($data['do_not_forward'])) {
-        //     dispatch(new SendPostToPhoenix($post));
-        // }
+        // POST reportback back to Phoenix, unless told not to.
+        // If request fails, record in failed_jobs table.
+        if (! isset($data['do_not_forward'])) {
+            dispatch(new SendPostToPhoenix($post));
+        }
 
         return $post;
     }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -3,27 +3,25 @@
 namespace Rogue\Services;
 
 use Rogue\Jobs\SendPostToPhoenix;
-use Rogue\Repositories\PhotoRepository;
 
 class PostService
 {
     /*
-     * PhotoRepository Instance
+     * Repository Instance
      *
-     * @var Rogue\Repositories\PhotoRepository;
      */
-    protected $post;
+    protected $repository;
 
-    /**
-     * Constructor
-     *
-     * @param \Rogue\Repositories\PhotoRepository $photos
-     */
-    public function __construct(PhotoRepository $post)
-    {
-        // @TODO - Eventually would want to figure out a smarter way of resolving different repositories to use for a post i.e. Video, text, etc.
-        $this->post = $post;
-    }
+    // /**
+    //  * Constructor
+    //  *
+    //  * @param \Rogue\Repositories\PhotoRepository $photos
+    //  */
+    // public function __construct(PhotoRepository $post)
+    // {
+    //     // @TODO - Eventually would want to figure out a smarter way of resolving different repositories to use for a post i.e. Video, text, etc.
+    //     $this->post = $post;
+    // }
 
     /*
      * Handles all business logic around creating posts.
@@ -35,17 +33,32 @@ class PostService
      */
     public function create($data, $signupId, $transactionId)
     {
-        $post = $this->post->create($data, $signupId);
+        $this->resolvePostRepository($data['event_type']);
 
-        // Add new transaction id to header.
-        request()->headers->set('X-Request-ID', $transactionId);
+        $post = $this->repository->create($data, $signupId);
 
-        // POST reportback back to Phoenix, unless told not to.
-        // If request fails, record in failed_jobs table.
-        if (! isset($data['do_not_forward'])) {
-            dispatch(new SendPostToPhoenix($post));
-        }
+        // // Add new transaction id to header.
+        // request()->headers->set('X-Request-ID', $transactionId);
+
+        // // POST reportback back to Phoenix, unless told not to.
+        // // If request fails, record in failed_jobs table.
+        // if (! isset($data['do_not_forward'])) {
+        //     dispatch(new SendPostToPhoenix($post));
+        // }
 
         return $post;
+    }
+
+    protected function resolvePostRepository($type)
+    {
+        switch ($type) {
+            case 'post_photo':
+                $this->repository = app('Rogue\Repositories\PhotoRepository');
+
+                break;
+
+            default:
+                break;
+        }
     }
 }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -22,6 +22,8 @@ class PostService
      */
     public function create($data, $signupId, $transactionId)
     {
+        // Looks at the event type that is past to figure out which type of post
+        // we are dealing with.
         $this->resolvePostRepository($data['event_type']);
 
         $post = $this->repository->create($data, $signupId);

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -3,6 +3,7 @@
 namespace Rogue\Services;
 
 use Rogue\Jobs\SendPostToPhoenix;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PostService
 {
@@ -38,6 +39,13 @@ class PostService
         return $post;
     }
 
+    /*
+     * Determines which type of post we trying to work with based on the passed 'event_type'
+     *
+     * @param $string $type
+     * @throws HttpException
+     * @return Rogue\Repostitories\PhotoRepository
+     */
     protected function resolvePostRepository($type)
     {
         switch ($type) {
@@ -45,8 +53,9 @@ class PostService
                 $this->repository = app('Rogue\Repositories\PhotoRepository');
 
                 break;
-
             default:
+                throw new HttpException(405, 'Not a valid post type');
+
                 break;
         }
     }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -51,11 +51,9 @@ class PostService
         switch ($type) {
             case 'post_photo':
                 $this->repository = app('Rogue\Repositories\PhotoRepository');
-
                 break;
             default:
                 throw new HttpException(405, 'Not a valid post type');
-
                 break;
         }
     }

--- a/database/migrations/2017_01_06_185724_create_posts_table.php
+++ b/database/migrations/2017_01_06_185724_create_posts_table.php
@@ -19,7 +19,7 @@ class CreatePostsTable extends Migration
             $table->integer('signup_id')->unsigned()->index()->comment('The signup this Post references.');
             $table->foreign('signup_id')->references('id')->on('signups')->onDelete('cascade');
 
-            $table->morphs('post');
+            $table->morphs('postable');
             $table->timestamps();
         });
     }

--- a/database/migrations/2017_01_06_185724_create_posts_table.php
+++ b/database/migrations/2017_01_06_185724_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->integer('event_id')->unsigned()->index()->comment('The event this post corresponds to.');
+            $table->foreign('event_id')->references('id')->on('events')->onDelete('cascade');
+
+            $table->integer('signup_id')->unsigned()->index()->comment('The signup this Post references.');
+            $table->foreign('signup_id')->references('id')->on('signups')->onDelete('cascade');
+
+            $table->morphs('post');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('posts');
+    }
+}

--- a/database/migrations/2017_01_09_165856_remove_event_id_from_photos.php
+++ b/database/migrations/2017_01_09_165856_remove_event_id_from_photos.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveEventIdFromPhotos extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('photos', function (Blueprint $table) {
+            $table->dropForeign('photos_event_id_foreign');
+            $table->dropIndex('photos_event_id_index');
+            $table->dropColumn('event_id');
+
+            $table->dropForeign('photos_signup_id_foreign');
+            $table->dropIndex('photos_signup_id_index');
+            $table->dropColumn('signup_id');
+
+            $table->increments('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('photos', function (Blueprint $table) {
+            $table->dropColumn('id');
+
+            $table->integer('event_id')->unsigned()->index()->comment('The event this post corresponds to.');
+            $table->foreign('event_id')->references('id')->on('events')->onDelete('cascade');
+
+            $table->integer('signup_id')->unsigned()->index()->comment('The signup this Post references.');
+            $table->foreign('signup_id')->references('id')->on('signups')->onDelete('cascade');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

This is a proof of concept PR that implements a [Polymorphic](https://laravel.com/docs/5.3/eloquent-relationships#polymorphic-relations) Relationship between "Posts" and a post sub-type like a `photo`. 

Before a "Post" wasn't a real thing which means we didn't have a unifying way to deal with different types of posts. While they are different content, they serve the similar purpose and we didn't have a great way of tying them together. With this work, we can do things like have a `PostTransformer` for all posts so they have a standard response regardless of type. Or, we can find all posts for a signup across all types. 

#### In a nutshell
- we have a `Post` table that holds the thing that in common with all posts: `event_id`, `signup_id` 
- There is a polymorphic relationship defined on the `Post` and `Photo` model.

_To create a post you first create the photo, or the subtype item and then just do:_

```php
        $post = new Post([
            'event_id' => $postEvent->id,
            'signup_id' => $signupId,
        ]);
        $post->content()->associate($photo);
        $post->save();
```
_which creates a record in the Posts table:_

![image](https://cloud.githubusercontent.com/assets/1700409/21785043/fa426478-d68b-11e6-841a-9d2ff83f43cd.png)

_To use the relationship:_ 

```php
$post = Post::where([
'event_id' => 123
]);

$type = $post->post_type;
$file = $post->content->file_url;
$caption = $post->content->caption;
```

_And here is an example of what the API response would look like after posting to the API to create a post:_ 

![image](https://cloud.githubusercontent.com/assets/1700409/21785383/49f5e8e0-d68d-11e6-84a1-9dd79cfb49e2.png)

#### Any background context you want to provide?

Based a lot of this work on [this blog post. ](https://webscope.co.nz/polymorphic-relations-with-eloquent-and-laravel-5)
