### PR TITLE
Add columns to the events table to log atomic changes

### DIFF
--- a/database/migrations/2017_01_18_193205_add_log_columns_to_events_table.php
+++ b/database/migrations/2017_01_18_193205_add_log_columns_to_events_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLogColumnsToEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->integer('quantity')->nullable()->after('submission_type');
+            $table->integer('quantity_pending')->nullable()->after('quantity');
+            $table->text('why_participated')->nullable()->after('quantity_pending');
+            $table->text('caption')->nullable()->after('why_participated');
+            $table->text('status')->nullable()->after('caption');
+            $table->text('source')->nullable()->after('status');
+            $table->ipAddress('remote_addr')->nullable()->after('source');
+            $table->text('reason')->nullable()->after('remote_addr');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('quantity');
+            $table->dropColumn('quantity_pending');
+            $table->dropColumn('why_participated');
+            $table->dropColumn('caption');
+            $table->dropColumn('status');
+            $table->dropColumn('source');
+            $table->dropColumn('remote_addr');
+            $table->dropColumn('reason');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

Adds columns to the `events` table to log changes in the system. 

#### How should this be reviewed?

Run migrations, get new columns, rollback migration, lose new columns

#### Relevant tickets

Address #100 

#### Checklist
- [x] If needed, updated wiki documentation. 
- [ ] Tested on staging.
