### PR TITLE
Move northstar_id to posts table

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -67,7 +67,7 @@ class PostsController extends ApiController
         }
 
         // Send the data to the PostService class which will handle determining
-        // which type of post we are dealing with and which repostitory to use to // actually create the post.
+        // which type of post we are dealing with and which repostitory to use to actually create the post.
         $post = $this->posts->create($request->all(), $signup->id, $transactionId);
 
         return $this->item($post);

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -26,7 +26,7 @@ class PostTransformer extends TransformerAbstract
     {
         return [
             'signup_id' => $post->signup_id,
-            'northstar_id' => $post->content->northstar_id,
+            'northstar_id' => $post->northstar_id,
             'campaign_id' => $post->signup->campaign_id,
             'campaign_run_id' => $post->signup->campaign_run_id,
             'content' => [

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -11,7 +11,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['event_id', 'signup_id'];
+    protected $fillable = ['event_id', 'signup_id', 'northstar_id'];
 
     protected $primaryKey = ['event_id'];
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -49,7 +49,6 @@ class PhotoRepository
         $editedImage = $this->crop($data);
 
         $photo = Photo::create([
-            'northstar_id' => $data['northstar_id'],
             'file_url' => $fileUrl,
             'edited_file_url' => $editedImage,
             'caption' => $data['caption'],
@@ -64,6 +63,7 @@ class PhotoRepository
         $post = new Post([
             'event_id' => $postEvent->id,
             'signup_id' => $signupId,
+            'northstar_id' => $data['northstar_id'],
         ]);
 
         $post->content()->associate($photo);

--- a/database/migrations/2017_01_18_205404_move_northstar_id_column_to_posts.php
+++ b/database/migrations/2017_01_18_205404_move_northstar_id_column_to_posts.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MoveNorthstarIdColumnToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('northstar_id')->index()->after('signup_id')->comment('The users Northstar ID');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('northstar_id');
+        });
+    }
+}

--- a/database/migrations/2017_01_18_205748_drop_northstar_id_from_photos_table.php
+++ b/database/migrations/2017_01_18_205748_drop_northstar_id_from_photos_table.php
@@ -36,11 +36,10 @@ class DropNorthstarIdFromPhotosTable extends Migration
     public function down()
     {
         Schema::table('photos', function (Blueprint $table) {
-           $table->string('northstar_id')->index()->after('id')->comment('The users Northstar ID');
+            $table->string('northstar_id')->index()->after('id')->comment('The users Northstar ID');
 
             $table->dropColumn('source');
             $table->dropColumn('remote_addr');
-
         });
 
         Schema::table('photos', function (Blueprint $table) {

--- a/database/migrations/2017_01_18_205748_drop_northstar_id_from_photos_table.php
+++ b/database/migrations/2017_01_18_205748_drop_northstar_id_from_photos_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropNorthstarIdFromPhotosTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('photos', function (Blueprint $table) {
+            $table->dropIndex('photos_northstar_id_index');
+            $table->dropColumn('northstar_id');
+
+            $table->dropColumn('source');
+
+            $table->dropColumn('remote_addr');
+        });
+
+        Schema::table('photos', function (Blueprint $table) {
+            $table->string('source')->nullable()->after('status')->comment('Source which reportback file was submitted from.');
+
+            $table->ipAddress('remote_addr')->nullable()->after('source')->comment('The IP address of the user that submitted the file.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('photos', function (Blueprint $table) {
+           $table->string('northstar_id')->index()->after('id')->comment('The users Northstar ID');
+
+            $table->dropColumn('source');
+            $table->dropColumn('remote_addr');
+
+        });
+
+        Schema::table('photos', function (Blueprint $table) {
+            $table->string('source')->nullable()->after('updated_at')->comment('Source which reportback file was submitted from.');
+
+            $table->ipAddress('remote_addr')->nullable()->after('source')->comment('The IP address of the user that submitted the file.');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

Moves the `northstar_id` associated with posts to the `posts` table instead of it living on the item record. Also updates the functionality of storing posts, to store the `northstar_id` on the `posts` record. 

#### How should this be reviewed?

Run migrations, see that `northstar_id` is now on the `posts` table and not on the `photos` table.

Also hit the new `/posts` endpoint and the post should be created with the `northstar_id` living on the post record. 

#### Relevant tickets
Fixes #102 

#### Checklist
- [ ] Rogue wiki updated
- [ ] Tested on staging.