### PR TITLE
adds missing $signupId param

### DIFF
--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -60,6 +60,7 @@ class PhotoRepository
         // Create the Post and associate the Photo with it.
         // @Note -- Having some issue using the `create` method here. I think
         // becase the Posts table doesn't have an `id` key, but I can work that out.
+
         $post = new Post([
             'event_id' => $postEvent->id,
             'signup_id' => $signupId,
@@ -80,7 +81,7 @@ class PhotoRepository
      * @param  int $signupId
      * @return url|null
      */
-    protected function crop($data)
+    protected function crop($data, $signupId)
     {
         $cropValues = array_only($data, $this->cropProperties);
 


### PR DESCRIPTION
#### What's this PR do?
Adds the missing `$signupId` as a param to the `crop` function. 

#### How should this be reviewed?
Hit the `/posts` endpoint and all should be working.
  - Without this, nothing is returned as the response and the following error is thrown: `[2017-01-20 15:58:47] local.ERROR: exception 'ErrorException' with message 'Undefined variable: signupId' in /home/vagrant/DoSomething.org/rogue/app/Repositories/PhotoRepository.php:90`
 