### PR TITLE
changes quantity to quantity_pending and removes hard coded uid

### DIFF
--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -6,6 +6,7 @@ use Rogue\Models\Post;
 use Rogue\Services\Phoenix;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Rogue\Services\Registrar;
 
 class SendPostToPhoenix extends Job implements ShouldQueue
 {
@@ -40,15 +41,16 @@ class SendPostToPhoenix extends Job implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(Registrar $registrar)
     {
         $phoenix = new Phoenix;
+        $drupal_id = $registrar->find($this->post->signup->northstar_id)->drupal_id;
 
         // Data that every post will have
         $body = [
-            'uid' => 12345, // Grab drupal_id from northstar object?
+            'uid' => $drupal_id,
             'nid' => $this->post->signup->campaign_id,
-            'quantity' => $this->post->signup->quantity,
+            'quantity' => $this->post->signup->quantity_pending,
             'why_participated' => $this->post->signup->why_participated,
         ];
 

--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -56,7 +56,7 @@ class SendPostToPhoenix extends Job implements ShouldQueue
 
         // Data that everything except an update without a file will have
         if ($this->hasFile) {
-            $body['file_url'] = is_null($this->post->content->edited_file_url) ? $this->photo->file_url : $this->post->content->edited_file_url;
+            $body['file_url'] = is_null($this->post->content->edited_file_url) ? $this->post->content->file_url : $this->post->content->edited_file_url;
             $body['caption'] = isset($this->post->content->caption) ? $this->post->content->caption : null;
             $body['source'] = $this->post->content->source;
             $body['remote_addr'] = $this->post->content->remote_addr;

--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -4,9 +4,9 @@ namespace Rogue\Jobs;
 
 use Rogue\Models\Post;
 use Rogue\Services\Phoenix;
+use Rogue\Services\Registrar;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Rogue\Services\Registrar;
 
 class SendPostToPhoenix extends Job implements ShouldQueue
 {


### PR DESCRIPTION
#### What's this PR do?
- Adds the `Registrar` in `SendPostToPhoenix.php` in order to send `drupal_id` (right now it is hard coded). 
- Changes `quantity` to send `quantity_pending` instead since `quantity` will be `NULL` and we want to send user's reported quantity to Phoenix. 

#### How should this be reviewed?
Hit `/posts` endpoint and all should work correctly. 
