### PR TITLE
Allow signup updates

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -64,8 +64,6 @@ class PostsController extends ApiController
         // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
         if (is_null($signup)) {
             $signup = $this->signups->create($request->all());
-        } else {
-            $this->signups->update($signup, $request->all());
         }
 
         // Send the data to the PostService class which will handle determining

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -64,6 +64,8 @@ class PostsController extends ApiController
         // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
         if (is_null($signup)) {
             $signup = $this->signups->create($request->all());
+        } else {
+            $this->signups->update($signup, $request->all());
         }
 
         // Send the data to the PostService class which will handle determining

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -48,7 +48,7 @@ class SignupTransformer extends TransformerAbstract
     {
         $event = $signup->event;
 
-        return $this->item($event, new EventTransformer);
+        return $this->collection($event, new EventTransformer);
     }
 
     /**

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -18,7 +18,7 @@ class Event extends Model
      */
     public function signup()
     {
-        return $this->hasOne(Signup::class);
+        return $this->belongsTo(Signup::class);
     }
 
     /**

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -18,7 +18,7 @@ class Signup extends Model
      */
     public function event()
     {
-        return $this->belongsTo(Event::class);
+        return $this->hasMany(Event::class);
     }
 
     /**

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -15,13 +15,15 @@ class SignupRepository
      */
     public function create($data)
     {
+        // Create the post_signup event
         $event = Event::create([
             'northstar_id' => $data['northstar_id'],
-            'event_type' => 'signup',
+            'event_type' => 'post_signup',
             'submission_type' => 'user',
         ]);
 
-        $signup = $event->signup()->create([
+        // Create the signup
+        $signup = Signup::create([
             'event_id' => $event->id,
             'northstar_id' => $data['northstar_id'],
             'campaign_id' => $data['campaign_id'],
@@ -31,6 +33,10 @@ class SignupRepository
             'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
             'source' => isset($data['source']) ? $data['source'] : null,
         ]);
+
+        // Associate the event and the signup
+        $event->signup()->associate($signup);
+        $event->save();
 
         // Let Laravel take care of the timestamps unless they are specified in the request
         if (isset($data['created_at'])) {

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -86,7 +86,6 @@ class SignupRepository
             'submission_type' => 'user',
             'quantity_pending' => isset($data['quantity']) ? $data['quantity'] : null,
             'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
-            'source' => isset($data['source']) ? $data['source'] : null,
         ]);
 
         // Associate the event and the signup
@@ -97,7 +96,6 @@ class SignupRepository
         $signup = $event->signup()->update([
             'quantity_pending' => isset($data['quantity']) ? $data['quantity'] : null,
             'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
-            'source' => isset($data['source']) ? $data['source'] : null,
         ]);
 
         return $signup;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -70,4 +70,36 @@ class SignupRepository
 
         return $signup;
     }
+
+    /**
+     * Update a signup.
+     *
+     * @param  array $data
+     * @return \Rogue\Models\Signup|null
+     */
+    public function update(Signup $signup, $data)
+    {
+        // Create the event for the signup update and include the relevant changes
+        $event = Event::create([
+            'northstar_id' => $data['northstar_id'],
+            'event_type' => 'update_signup',
+            'submission_type' => 'user',
+            'quantity_pending' => isset($data['quantity']) ? $data['quantity'] : null,
+            'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
+            'source' => isset($data['source']) ? $data['source'] : null,
+        ]);
+
+        // Associate the event and the signup
+        $event->signup()->associate($signup);
+        $event->save();
+
+        // Update the actual signup data to the new values
+        $signup = $event->signup()->update([
+            'quantity_pending' => isset($data['quantity']) ? $data['quantity'] : null,
+            'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
+            'source' => isset($data['source']) ? $data['source'] : null,
+        ]);
+
+        return $signup;
+    }
 }

--- a/database/migrations/2017_01_23_184546_add_signup_id_to_events_table.php
+++ b/database/migrations/2017_01_23_184546_add_signup_id_to_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSignupIdToEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->integer('signup_id')->unsigned()->index()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('signup_id');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Added the ability for `quantity` and `why_participated` on a signup to be updated. This allows for Posts to be sent from Phoenix. I think we want to be careful about only using this functionality when there was actually a change in either of those values. If we think that should happen inside the `SignupRepository` `update` function then I am glad to add it there!

Also, regarding `events`, I think the Posts/Events relationship needs to be updated to mimic the Signup/Events relationship here. The `signup_id` column for post events will still have the `signup_id` because `posts` all have that. I'm happy to do that in the future but I thought it was out of scope for this update.

#### How should this be reviewed?
Make sure that when you add a new post that you are able to update the `quantity` and `why_participated` on the signup. Call something like this in `PostsController`: 
```
$this->signups->update($signup, $request->all());
```
Is this how it should be structured?

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.