### PR TITLE
Adds /reviews endpoint to update photo(s)'s status when it gets reviewed and updates signups/photos 

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -8,6 +8,7 @@ use Rogue\Services\PostService;
 use Rogue\Http\Requests\PostRequest;
 use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
+use Rogue\Http\Transformers\PhotoTransformer;
 
 class PostsController extends ApiController
 {
@@ -31,6 +32,11 @@ class PostsController extends ApiController
     protected $transformer;
 
     /**
+     * @var \Rogue\Http\Transformers\PhotoTransformer
+     */
+    protected $photoTransformer;
+
+    /**
      * Create a controller instance.
      *
      * @param  PostContract  $posts
@@ -43,6 +49,7 @@ class PostsController extends ApiController
 
         // Now we have one PostTransformer to handle returning a Post to the API request.
         $this->transformer = new PostTransformer;
+        $this->photoTransformer = new PhotoTransformer;
     }
 
     /**
@@ -111,8 +118,9 @@ class PostsController extends ApiController
             $code = 201;
         }
 
-        dd($reviewedPosts);
+        $meta = [];
 
-        // TODO: how do we want to return this data?
+        // @TODO: we'll need to change the transformer here depending on what type of post.
+        return $this->collection($reviewedPosts, $code, $meta, $this->photoTransformer);
     }
 }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -2,8 +2,8 @@
 
 namespace Rogue\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
 use Rogue\Models\Signup;
+use Illuminate\Http\Request;
 use Rogue\Services\PostService;
 use Rogue\Http\Requests\PostRequest;
 use Rogue\Repositories\SignupRepository;

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Controllers\Api;
 
+use Illuminate\Http\Request;
 use Rogue\Models\Signup;
 use Rogue\Services\PostService;
 use Rogue\Http\Requests\PostRequest;
@@ -71,9 +72,13 @@ class PostsController extends ApiController
             // which type of post we are dealing with and which repostitory to use to actually create the post.
             $post = $this->posts->create($request->all(), $signup->id, $transactionId);
 
+            $code = 200;
+
             return $this->item($post);
         } else {
             $post = $this->posts->update($signup, $request->all(), $transactionId);
+
+            $code = 201;
 
             if (isset($request['file'])) {
                 return $this->item($post);
@@ -81,5 +86,31 @@ class PostsController extends ApiController
                 return $signup;
             }
         }
+    }
+
+    /**
+     * Update a post(s)'s status when reviewed.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function reviews(Request $request)
+    {
+        // @TODO: where do we write what to say if there is no rogue_event_id or status in the response?
+        $this->validate($request, [
+            '*.rogue_event_id' => 'required',
+            '*.status' => 'required',
+        ]);
+
+        $updatedPosts = $this->posts->reviews($request->all());
+
+        if (empty($updatedPosts)) {
+            $code = 404;
+        } else {
+            $code = 201;
+        }
+
+        // TODO: how do we want to return this data?
     }
 }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -73,12 +73,21 @@ class PostsController extends ApiController
 
             return $this->item($post);
         } else {
-            $post = $this->posts->update($signup, $request->all(), $transactionId);
+            // Check to see if this is a photo's status update or new photo/signup update.
+            if (isset($request->['quantity'])) {
+                $post = $this->posts->update($signup, $request->all(), $transactionId);
 
-            if (isset($request['file'])) {
-                return $this->item($post);
+                if (isset($request['file'])) {
+                    return $this->item($post);
+                } else {
+                    return $signup;
+                }
             } else {
-                return $signup;
+                $this->validate($request, [
+                    '*.rogue_reportback_item_id' => 'required',
+                    '*.status' => 'required',
+                    '*.reviewer' => 'required',
+                ]);
             }
         }
     }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -104,7 +104,6 @@ class PostsController extends ApiController
      */
     public function reviews(Request $request)
     {
-        // @TODO: where do we write what to say if there is no rogue_event_id or status in the response?
         $this->validate($request, [
             '*.rogue_event_id' => 'required',
             '*.status' => 'required',

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -73,6 +73,8 @@ class PostsController extends ApiController
 
             return $this->item($post);
         } else {
+            $post = $this->posts->update($signup, $request->all(), $transactionId);
+
             if (isset($request['file'])) {
                 return $this->item($post);
             } else {

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -70,11 +70,16 @@ class PostsController extends ApiController
             // Send the data to the PostService class which will handle determining
             // which type of post we are dealing with and which repostitory to use to actually create the post.
             $post = $this->posts->create($request->all(), $signup->id, $transactionId);
+
+            return $this->item($post);
         } else {
             $post = $this->posts->update($signup, $request->all(), $transactionId);
-        }
 
-        // QUESTION: what do we want to return here per scenario?
-        return $this->item($post);
+            if (isset($request['file'])) {
+                return $this->item($post);
+            } else {
+                return $signup;
+            }
+        }
     }
 }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -64,7 +64,6 @@ class PostsController extends ApiController
         $transactionId = incrementTransactionId($request);
 
         // @TODO - Remove. This is temporary. Just hardcoding some params in the request that the client would normally pass. But we assume everything is a photo post from a user at the moment.
-        // $request['event_type'] = 'post_photo';
         $request['submission_type'] = 'user';
 
         $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -73,21 +73,10 @@ class PostsController extends ApiController
 
             return $this->item($post);
         } else {
-            // Check to see if this is a photo's status update or new photo/signup update.
-            if (isset($request->['quantity'])) {
-                $post = $this->posts->update($signup, $request->all(), $transactionId);
-
-                if (isset($request['file'])) {
-                    return $this->item($post);
-                } else {
-                    return $signup;
-                }
+            if (isset($request['file'])) {
+                return $this->item($post);
             } else {
-                $this->validate($request, [
-                    '*.rogue_reportback_item_id' => 'required',
-                    '*.status' => 'required',
-                    '*.reviewer' => 'required',
-                ]);
+                return $signup;
             }
         }
     }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -103,13 +103,15 @@ class PostsController extends ApiController
             '*.status' => 'required',
         ]);
 
-        $updatedPosts = $this->posts->reviews($request->all());
+        $reviewedPosts = $this->posts->reviews($request->all());
 
-        if (empty($updatedPosts)) {
+        if (empty($reviewedPosts)) {
             $code = 404;
         } else {
             $code = 201;
         }
+
+        dd($reviewedPosts);
 
         // TODO: how do we want to return this data?
     }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -46,7 +46,7 @@ class PostRequest extends Request
     {
         switch ($request->event_type) {
             case 'post_photo':
-                return array_merge($this->rules, $this->setPhotoRules());
+                return array_merge($this->rules, $this->getPhotoRules());
 
                 break;
 
@@ -60,7 +60,7 @@ class PostRequest extends Request
      *
      * @return array
      */
-    protected function setPhotoRules()
+    protected function getPhotoRules()
     {
         return [
             'caption' => 'string',

--- a/app/Http/Transformers/PhotoTransformer.php
+++ b/app/Http/Transformers/PhotoTransformer.php
@@ -25,11 +25,11 @@ class PhotoTransformer extends TransformerAbstract
     public function transform(Photo $photo)
     {
         return [
-            'event_id' => $photo->event_id,
-            'signup_id' => $photo->signup_id,
-            'northstar_id' => $photo->northstar_id,
-            'campaign_id' => $photo->signup->campaign_id,
-            'campaign_run_id' => $photo->signup->campaign_run_id,
+            'event_id' => $photo->post->event_id,
+            'signup_id' => $photo->post->signup_id,
+            'northstar_id' => $photo->post->northstar_id,
+            'campaign_id' => $photo->post->signup->campaign_id,
+            'campaign_run_id' => $photo->post->signup->campaign_run_id,
             'post' => [
                 'type' => 'photo',
                 'media' => [
@@ -52,7 +52,7 @@ class PhotoTransformer extends TransformerAbstract
      */
     public function includeEvent(Photo $photo)
     {
-        $event = $photo->event;
+        $event = $photo->post->event;
 
         return $this->item($event, new EventTransformer);
     }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -46,7 +46,12 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['api', 'log.received.reques
 
 // v2 routes
 Route::group(['prefix' => 'api/v2', 'middleware' => ['api', 'log.received.request']], function () {
+
+    // posts
     Route::post('posts', 'Api\PostsController@store');
+
+    // reviews
+    Route::put('reviews', 'Api\PostsController@reviews');
 
     // signups
     Route::post('signups', 'Api\SignupsController@store');

--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -44,8 +44,8 @@ class SendPostToPhoenix extends Job implements ShouldQueue
     public function handle(Registrar $registrar)
     {
         $phoenix = new Phoenix;
-        $drupal_id = $registrar->find($this->post->signup->northstar_id)->drupal_id;
 
+        $drupal_id = $registrar->find($this->post->signup->northstar_id)->drupal_id;
         // Data that every post will have
         $body = [
             'uid' => $drupal_id,
@@ -53,7 +53,14 @@ class SendPostToPhoenix extends Job implements ShouldQueue
             'quantity' => $this->post->signup->quantity_pending,
             'why_participated' => $this->post->signup->why_participated,
         ];
+        dd($body);
 
+//      array:4 [
+//          "uid" => "1704953"
+//          "nid" => 1173
+//          "quantity" => 300
+//          "why_participated" => "Because"
+//      ]
         // Data that everything except an update without a file will have
         if ($this->hasFile) {
             $body['file_url'] = is_null($this->post->content->edited_file_url) ? $this->post->content->file_url : $this->post->content->edited_file_url;

--- a/app/Jobs/SendPostToPhoenix.php
+++ b/app/Jobs/SendPostToPhoenix.php
@@ -46,6 +46,7 @@ class SendPostToPhoenix extends Job implements ShouldQueue
         $phoenix = new Phoenix;
 
         $drupal_id = $registrar->find($this->post->signup->northstar_id)->drupal_id;
+
         // Data that every post will have
         $body = [
             'uid' => $drupal_id,
@@ -53,14 +54,7 @@ class SendPostToPhoenix extends Job implements ShouldQueue
             'quantity' => $this->post->signup->quantity_pending,
             'why_participated' => $this->post->signup->why_participated,
         ];
-        dd($body);
 
-//      array:4 [
-//          "uid" => "1704953"
-//          "nid" => 1173
-//          "quantity" => 300
-//          "why_participated" => "Because"
-//      ]
         // Data that everything except an update without a file will have
         if ($this->hasFile) {
             $body['file_url'] = is_null($this->post->content->edited_file_url) ? $this->post->content->file_url : $this->post->content->edited_file_url;

--- a/app/Jobs/SendReportbackToPhoenix.php
+++ b/app/Jobs/SendReportbackToPhoenix.php
@@ -34,7 +34,6 @@ class SendReportbackToPhoenix extends Job implements ShouldQueue
     public function handle()
     {
         $phoenix = new Phoenix;
-
         // Data that every post will have
         $body = [
             'uid' => $this->reportback->drupal_id,

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -83,7 +83,8 @@ class PhotoRepository
      *
      * @return \Rogue\Models\Photo
      */
-    public function update($signup, $data) {
+    public function update($signup, $data)
+    {
         // Update the signup's quantity and why_participated data.
         // We will always update these since we can't tell if this has been changed in a good way yet.
         Event::create($data);
@@ -98,6 +99,43 @@ class PhotoRepository
         }
 
         return $signup;
+    }
+
+    /**
+     * Updates a photo(s)'s status after being reviewed.
+     *
+     * @param array $data
+     *
+     * @return
+     */
+    public function reviews($data)
+    {
+        $reviewed = [];
+
+        foreach ($data as $review) {
+            if ($review['rogue_event_id'] && ! empty($review['rogue_event_id'])) {
+                $post = Post::where(['event_id' => $review['rogue_event_id']])->first();
+
+                $photo = Photo::where(['id' => $post->postable_id])->first();
+
+                if ($review['status'] && ! empty($review['status'])) {
+                    // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
+                    $review['submission_type'] = 'admin review';
+                    $review['status'] = 'accepted';
+                    Event::create($review);
+
+                    $photo->status = $review['status'];
+                    $photo->save();
+
+                    array_push($reviewed, $photo);
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+            return $reviewed;
+        }
     }
 
     /**

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -85,6 +85,7 @@ class PhotoRepository
      */
     public function update($signup, $data)
     {
+        // @TODO: remove the below logic when we are no longer supporting the phoenix-ashes campaign template.
         // Update the signup's quantity and why_participated data.
         // We will always update these since we can't tell if this has been changed in a good way yet.
         $data['quantity_pending'] = $data['quantity'];

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -110,7 +110,7 @@ class PhotoRepository
      */
     public function reviews($data)
     {
-        $reviewed = [];
+        $reviewedPhotos = [];
 
         foreach ($data as $review) {
             if ($review['rogue_event_id'] && ! empty($review['rogue_event_id'])) {
@@ -122,19 +122,21 @@ class PhotoRepository
                     // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
                     $review['submission_type'] = 'admin review';
                     $review['status'] = 'accepted';
+
                     Event::create($review);
 
                     $photo->status = $review['status'];
                     $photo->save();
 
-                    array_push($reviewed, $photo);
+                    array_push($reviewedPhotos, $photo);
                 } else {
                     return null;
                 }
             } else {
                 return null;
             }
-            return $reviewed;
+
+            return $reviewedPhotos;
         }
     }
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -70,8 +70,6 @@ class PhotoRepository
         $post->content()->associate($photo);
         $post->save();
 
-        // $this->registrar->find($data['northstar_id']);
-
         return $post;
     }
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -115,13 +115,11 @@ class PhotoRepository
         foreach ($data as $review) {
             if ($review['rogue_event_id'] && ! empty($review['rogue_event_id'])) {
                 $post = Post::where(['event_id' => $review['rogue_event_id']])->first();
-
                 $photo = Photo::where(['id' => $post->postable_id])->first();
 
                 if ($review['status'] && ! empty($review['status'])) {
                     // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
                     $review['submission_type'] = 'admin review';
-                    $review['status'] = 'accepted';
 
                     Event::create($review);
 
@@ -135,9 +133,9 @@ class PhotoRepository
             } else {
                 return null;
             }
-
-            return $reviewedPhotos;
         }
+
+        return $reviewedPhotos;
     }
 
     /**

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -103,7 +103,6 @@ class PhotoRepository
         }
     }
 
-
     /**
      * Crop an image
      *

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -121,7 +121,8 @@ class PhotoRepository
 
                 if ($review['status'] && ! empty($review['status'])) {
                     // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
-                    $review['submission_type'] = 'admin review';
+                    $review['submission_type'] = 'admin';
+                    $review['event_type'] = 'review';
 
                     Event::create($review);
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -84,25 +84,16 @@ class PhotoRepository
      * @return \Rogue\Models\Photo
      */
     public function update($signup, $data) {
-        // Update the signup's quantity and/or why_participated data.
-        // We will always update why_participated since we can't tell if this has been changed in a good way yet.
-        if ($signup->quantity_pending != $data['quantity']) {
-            Event::create($data);
+        // Update the signup's quantity and why_participated data.
+        // We will always update these since we can't tell if this has been changed in a good way yet.
+        Event::create($data);
 
-            $data['quantity_pending'] = $data['quantity'];
-            $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
-            $signup->save();
-        } else {
-            Event::create($data);
-
-            $signup->fill(array_only($data, ['why_participated']));
-            $signup->save();
-        }
+        $data['quantity_pending'] = $data['quantity'];
+        $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
+        $signup->save();
 
         // If there is a file, create a new photo post.
         if (isset($data['file'])) {
-            return $this->create($data, $signup->id);
-        } elseif (array_key_exists('file', $data)) {
             return $this->create($data, $signup->id);
         }
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -76,6 +76,35 @@ class PhotoRepository
     }
 
     /**
+     * Update an existing photo post and signup.
+     *
+     * @param \Rogue\Models\Photo $signup
+     * @param array $data
+     *
+     * @return \Rogue\Models\Photo
+     */
+    public function update($signup, $data) {
+        // If there is a file, create a new photo post.
+        if (isset($data['file'])) {
+            return $this->create($data, $signup->id);
+        } elseif (array_key_exists('file', $data)) {
+            return $this->create($data, $signup->id);
+        // Otherwise, only update the signup's quantity and/or why_participated data.
+        } else {
+            Event::create($data);
+
+            $data['quantity_pending'] = $data['quantity'];
+
+            $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
+
+            $signup->save();
+
+            return $signup;
+        }
+    }
+
+
+    /**
      * Crop an image
      *
      * @param  int $signupId

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -87,8 +87,6 @@ class PhotoRepository
     {
         // Update the signup's quantity and why_participated data.
         // We will always update these since we can't tell if this has been changed in a good way yet.
-        Event::create($data);
-
         $data['quantity_pending'] = $data['quantity'];
         $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
         $signup->save();
@@ -96,6 +94,10 @@ class PhotoRepository
         // If there is a file, create a new photo post.
         if (isset($data['file'])) {
             return $this->create($data, $signup->id);
+        } else {
+            // If it doesn't add a new photo, a new event won't be created. Create the event here for an updated signup.
+            // @TODO: right now, an updated signup's event_type is recorded as post_photo. Depending on future decisions, we might want to update this.
+            Event::create($data);
         }
 
         return $signup;

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -116,7 +116,7 @@ class PhotoRepository
         $reviewedPhotos = [];
 
         foreach ($data as $review) {
-            if ($review['rogue_event_id'] && ! empty($review['rogue_event_id'])) {
+            if (isset($review['rogue_event_id']) && ! empty($review['rogue_event_id'])) {
                 $post = Post::where(['event_id' => $review['rogue_event_id']])->first();
                 $photo = Photo::where(['id' => $post->postable_id])->first();
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -84,23 +84,29 @@ class PhotoRepository
      * @return \Rogue\Models\Photo
      */
     public function update($signup, $data) {
+        // Update the signup's quantity and/or why_participated data.
+        // We will always update why_participated since we can't tell if this has been changed in a good way yet.
+        if ($signup->quantity_pending != $data['quantity']) {
+            Event::create($data);
+
+            $data['quantity_pending'] = $data['quantity'];
+            $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
+            $signup->save();
+        } else {
+            Event::create($data);
+
+            $signup->fill(array_only($data, ['why_participated']));
+            $signup->save();
+        }
+
         // If there is a file, create a new photo post.
         if (isset($data['file'])) {
             return $this->create($data, $signup->id);
         } elseif (array_key_exists('file', $data)) {
             return $this->create($data, $signup->id);
-        // Otherwise, only update the signup's quantity and/or why_participated data.
-        } else {
-            Event::create($data);
-
-            $data['quantity_pending'] = $data['quantity'];
-
-            $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
-
-            $signup->save();
-
-            return $signup;
         }
+
+        return $signup;
     }
 
     /**

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -118,7 +118,6 @@ class PhotoRepository
         foreach ($data as $review) {
             if (isset($review['rogue_event_id']) && ! empty($review['rogue_event_id'])) {
                 $post = Post::where(['event_id' => $review['rogue_event_id']])->first();
-                $photo = Photo::where(['id' => $post->postable_id])->first();
 
                 if ($review['status'] && ! empty($review['status'])) {
                     // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
@@ -127,10 +126,10 @@ class PhotoRepository
 
                     Event::create($review);
 
-                    $photo->status = $review['status'];
-                    $photo->save();
+                    $post->content->status = $review['status'];
+                    $post->content->save();
 
-                    array_push($reviewedPhotos, $photo);
+                    array_push($reviewedPhotos, $post->content);
                 } else {
                     return null;
                 }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -72,6 +72,7 @@ class PostService
         if (! isset($data['do_not_forward'])) {
             dispatch(new SendPostToPhoenix($post, isset($data['file'])));
         }
+
         return $post;
     }
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -71,6 +71,8 @@ class PostService
         if (! isset($data['do_not_forward'])) {
             dispatch(new SendPostToPhoenix($post, isset($data['file'])));
         }
+
+        return $post;
     }
 
     /*

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -2,8 +2,8 @@
 
 namespace Rogue\Services;
 
-use Rogue\Jobs\SendPostToPhoenix;
 use Rogue\Models\Post;
+use Rogue\Jobs\SendPostToPhoenix;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PostService

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -14,7 +14,7 @@ class PostService
      */
     protected $repository;
 
-    /*
+    /**
      * Handles all business logic around creating posts.
      *
      * @param array $data
@@ -40,7 +40,7 @@ class PostService
         return $post;
     }
 
-    /*
+    /**
      * Handles all business logic around updating posts.
      *
      * @param \Rogue\Models\Signup $signup
@@ -75,7 +75,7 @@ class PostService
         return $post;
     }
 
-    /*
+    /**
      * Determines which type of post we trying to work with based on the passed 'event_type'
      *
      * @param $string $type

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -49,7 +49,8 @@ class PostService
      *
      * @return \Illuminate\Database\Eloquent\Model $model
      */
-    public function update($signup, $data, $transactionId) {
+    public function update($signup, $data, $transactionId)
+    {
         $this->resolvePostRepository($data['event_type']);
 
         $post = $this->repository->update($signup, $data);
@@ -73,6 +74,22 @@ class PostService
         }
 
         return $post;
+    }
+
+    /**
+     * Handles all business logic around updating the posts(s)'s status after being reviewed.
+     *
+     * @param array $data
+     *
+     * @return
+     */
+    public function reviews($data)
+    {
+        $this->resolvePostRepository($data[0]['event_type']);
+
+        $updatedPosts = $this->repository->reviews($data);
+
+        return $updatedPosts;
     }
 
     /**

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -3,6 +3,7 @@
 namespace Rogue\Services;
 
 use Rogue\Jobs\SendPostToPhoenix;
+use Rogue\Models\Post;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PostService
@@ -52,6 +53,16 @@ class PostService
         $this->resolvePostRepository($data['event_type']);
 
         $post = $this->repository->update($signup, $data);
+
+        // @TODO: This will is only temporary and will be removed!
+        // If this is a signup update, get the most recent post.
+        // If there is a quantity_pending, this is a signup.
+        if ($post->quantity_pending) {
+            $signupId = $post->id;
+            // Find the post with this signup id.
+            $post = Post::where('signup_id', $signupId)->first();
+        }
+
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -85,6 +85,7 @@ class PostService
      */
     public function reviews($data)
     {
+        // @TODO: this will need to be updated when other post types are introduced. Right now, all reviews are of photos so everything in this nested array will be a photo. However, if admins can review different types of posts (e.g. photos, videos, links) at once, we'll need to update the logic here.
         $this->resolvePostRepository($data[0]['event_type']);
 
         $reviewedPosts = $this->repository->reviews($data);

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -72,7 +72,6 @@ class PostService
         if (! isset($data['do_not_forward'])) {
             dispatch(new SendPostToPhoenix($post, isset($data['file'])));
         }
-
         return $post;
     }
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -87,9 +87,9 @@ class PostService
     {
         $this->resolvePostRepository($data[0]['event_type']);
 
-        $updatedPosts = $this->repository->reviews($data);
+        $reviewedPosts = $this->repository->reviews($data);
 
-        return $updatedPosts;
+        return $reviewedPosts;
     }
 
     /**

--- a/app/Services/ReportbackService.php
+++ b/app/Services/ReportbackService.php
@@ -25,7 +25,7 @@ class ReportbackService
         $this->reportbackRepository = $reportbackRepository;
     }
 
-    /*
+    /**
      * Handles all the logic around creating a reportback.
      *
      * @param array $data
@@ -48,7 +48,7 @@ class ReportbackService
         return $reportback;
     }
 
-    /*
+    /**
      * Handles all the business logic around updating a reportback.
      *
      * @param \Rogue\Models\Reportback $reportback
@@ -73,7 +73,7 @@ class ReportbackService
         return $reportback;
     }
 
-    /*
+    /**
      * Check if a reportback already exists for a given user,
      * on a specific campaign, and campaign run.
      *
@@ -91,7 +91,7 @@ class ReportbackService
         return $reportback ? $reportback : null;
     }
 
-    /*
+    /**
      * Handles all business logic around update a reportbackitem(s).
      *
      * @param array $data

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,10 +2,9 @@
 This is the Rogue API, it is used to capture activity from members.
 All `POST` and `PUT` endpoints require an api key (`X-DS-Rogue-API-Key`) in the header to be submitted with the request. 
 
-Refer to this [document](https://github.com/DoSomething/rogue/wiki/API) for the most updated documentation. 
-
 ## Endpoints
 
+### v1
 #### Reportbacks
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
@@ -20,3 +19,15 @@ Endpoint                                       | Functionality
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `POST /api/v1/reactions`                       | [Create or update a reaction](endpoints/reactions.md#reactions)
+
+
+### v2
+#### Posts
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`POST /api/v2/posts`                     | [Create a post](endpoints/posts.md#posts)
+
+#### Reviews
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`POST /api/v2/reviews`                     | [Update a post or multiple posts' status when admin reviews](endpoints/reviews.md#reviews)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,6 +2,8 @@
 This is the Rogue API, it is used to capture activity from members.
 All `POST` and `PUT` endpoints require an api key (`X-DS-Rogue-API-Key`) in the header to be submitted with the request. 
 
+Refer to this [document](https://github.com/DoSomething/rogue/wiki/API) for the most updated documentation. 
+
 ## Endpoints
 
 #### Reportbacks

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -35,7 +35,7 @@ POST /api/v2/posts
   - **crop_rotate** (int).
     The copy rotate coordinates of the post image if the user cropped the image.
 
-Example Response: The signup and associated content (post and event).
+Example Response:
 
 ```
 {

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -1,0 +1,69 @@
+## Posts
+
+Create a Post and/or Create/Update a Signup
+
+```
+POST /api/v2/posts
+```
+
+  - **northstar_id**: (string) required.
+    The northstar id of the user creating the post.
+  - **campaign_id**: (int) required.
+    The drupal node id of the campaign that the user's post is associated with. 
+  - **campaign_run_id**: (int) required.
+    The drupal campaign run node id of the campaign that the user's post is associated with.
+  - **quantity**: (int).
+    The number of reportback nouns verbed. 
+  - **why_participated**: (string).
+    The reason why the user participated.
+  - **caption**: (string).
+    Corresponding caption for the post.
+  - **source**: (string).
+    Where the post was submitted from.
+  - **remote_addr**: (string).
+    IP address of where the post is submitted from. 
+  - **file**: (string) required.
+    File string to save of post image.
+  - **crop_x**: (int).
+    The crop x coordinates of the post image if the user cropped the image.
+  - **crop_y**: (int).
+    The crop y coordinates of the post image if the user cropped the image.
+  - **crop_width** (int).
+    The copy width coordinates of the post image if the user cropped the image.
+  - **crop_height** (int).
+    The copy height coordinates of the post image if the user cropped the image.
+  - **crop_rotate** (int).
+    The copy rotate coordinates of the post image if the user cropped the image.
+
+Example Response: The signup and associated content (post and event).
+
+```
+{
+  "data": {
+    "signup_id": 31,
+    "northstar_id": "1233",
+    "campaign_id": 74,
+    "campaign_run_id": 1790,
+    "content": {
+      "type": "post_photo",
+      "media": {
+        "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/31-1485896463.jpeg",
+        "edited_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_31-1485896464.jpeg"
+      },
+      "caption": "1234",
+      "status": "pending",
+      "created_at": "2017-01-31T21:01:04+0000",
+      "updated_at": "2017-01-31T21:01:04+0000"
+    },
+    "event": {
+      "data": {
+        "event_id": "559",
+        "event_type": "post_photo",
+        "submission_type": "user",
+        "created_at": "2017-01-31T21:01:03+0000",
+        "updated_at": "2017-01-31T21:01:03+0000"
+      }
+    }
+  }
+}
+```

--- a/documentation/endpoints/reviews.md
+++ b/documentation/endpoints/reviews.md
@@ -1,0 +1,75 @@
+## Reviews
+
+Update a post or multiple posts' status when an admin reviews.
+
+```
+PUT /api/v2/reviews
+```
+
+  - **rogue_event_id**: (string) required.
+    The reportback item's Rogue event id (id column in Rogue's event table).
+  - **status**: (string) required.
+    The status of the post. 
+
+Example Response:
+
+```
+{
+  "data": [
+    {
+      "event_id": 407,
+      "signup_id": 32,
+      "northstar_id": "1234",
+      "campaign_id": 1222,
+      "campaign_run_id": 1822,
+      "post": {
+        "type": "photo",
+        "media": {
+          "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/32-1485545279.jpeg",
+          "edited_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_32-1485545279.jpeg"
+        },
+        "caption": "third post",
+        "status": "approved",
+        "created_at": "2017-01-27T19:28:00+0000",
+        "updated_at": "2017-01-30T16:12:52+0000"
+      },
+      "event": {
+        "data": {
+          "event_id": "407",
+          "event_type": "post_photo",
+          "submission_type": "user",
+          "created_at": "2017-01-27T19:27:59+0000",
+          "updated_at": "2017-01-27T19:27:59+0000"
+        }
+      }
+    },
+    {
+      "event_id": 410,
+      "signup_id": 32,
+      "northstar_id": "1234",
+      "campaign_id": 1222,
+      "campaign_run_id": 1822,
+      "post": {
+        "type": "photo",
+        "media": {
+          "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/32-1485545448.jpeg",
+          "edited_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_32-1485545449.jpeg"
+        },
+        "caption": "second post 1/27",
+        "status": "approved",
+        "created_at": "2017-01-27T19:30:49+0000",
+        "updated_at": "2017-01-30T16:14:07+0000"
+      },
+      "event": {
+        "data": {
+          "event_id": "410",
+          "event_type": "post_photo",
+          "submission_type": "user",
+          "created_at": "2017-01-27T19:30:48+0000",
+          "updated_at": "2017-01-27T19:30:48+0000"
+        }
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
#### What's this PR do?
- Adds update functionality to update a signup (`why_participated` and `quantity`)
- Adds update functionality to add a new photo post to a signup 
- Adds `/reviews` endpoint to update a photo(s)'s status when reviewed by an admin

#### How should this be reviewed?
This should be tested with [corresponding Phoenix work](https://github.com/DoSomething/phoenix/pull/7295).

1.Change Rogue API version number field to v2 in the Phoenix Rogue API settings.
2.  Run `drush ubdb` in drupal to reflect new database changes.

Make sure all information matches up between Phoenix and Rogue databases for below scenarios:
- Create a new signup (RB) and photo (reportback item) from Phoenix web.
- Add another photo (rb item).
- Add another photo (rb item) and update the signup (reportback's quantity and why_participated).
- Only update the signup (reportback's quantity and why_participated).
- Review a photo (reportback item's status as an admin).
- Cron job for reportbacks and reportback items.

#### Any background context you want to provide?
A few notes: 
1. If we're adding a new photo AND changing the signup's `quantity` and/or `why_participated`, this is all one event because we don't have a good way differentiate  if it is only adding a new photo or adding new photo and changing `quantity` and/or `why_participated` at the moment e.g. is it sufficient to use character count to see if `why_participated` has changed? This will be for decisions to make in the future cc @ngjo @jessleenyc 
2. In this PR, the signup's `event_id` that gets returned is the original `event_id` when the signup was created, not the `event_id` of when the signup was updated. A new event is still created when a signup update occurs. However, the `event_type` is a `post_photo` since we mentioned not wanting to complicate this now. We don't have a great way of tying this signup update back to the signup. @sbsmith86 @katiecrane Do you think this is ok for now until we make more decisions? 
3. We don't have a `reviewer` column in the `photos` table like we do in the `reportback_items` table and don't have information on who reviewed it. However, when a photo is reviewed, I've changed the `submission_type` of the event to be `admin review`. I can add: 
  - add more info here instead of the hard coded `admin review` (admin's name/email/northstar id/etc) in this column 
  - add `reviewer` to the `photo` table (mimicking the `reportback_items` table)?
  - change `event_type` to `admin review` (wasn't sure about this since we talked about keeping `event_type`s as only `post_photo` for now and make decisions about this later cc @sbsmith86 @katiecrane 
4. When an admin reviews a photo, right now we have no idea which photo it is. It only creates a new event and the only info we have is that it is a `submission_type` `admin_review`. Do we want to add something to the `events` table to refer to which post is it? Then it is a little tricky though because we'd have to add `photo_id` or `video_id` etc? cc @sbsmith86 @katiecrane 

#### Relevant tickets
Fixes #100 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.