### PR TITLE
Adds more details in events table, makes resolvePostRepository function more flexible, and creates two events for update signup and posting a photo

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -29,7 +29,7 @@ class PostRequest extends Request
     {
         if (! isset($this->request->event_type)) {
             return [
-                'event_type' => 'required|in:post_photo',
+                'event_type' => 'required|in:post_photo, review_photo',
             ];
         }
 

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -29,7 +29,7 @@ class PostRequest extends Request
     {
         if (! isset($this->request->event_type)) {
             return [
-                'event_type' => 'required|in:post_photo, review_photo',
+                'event_type' => 'required|in:post_photo,review_photo',
             ];
         }
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'event_type', 'submission_type'];
+    protected $fillable = ['id', 'northstar_id', 'event_type', 'submission_type', 'quantity', 'quantity_pending', 'why_participated', 'caption', 'status', 'source', 'remote_addr', 'reason'];
 
     /**
      * An event has one signup.

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -83,20 +83,23 @@ class PhotoRepository
      */
     public function update($signup, $data)
     {
-        // @TODO: remove the below logic when we are no longer supporting the phoenix-ashes campaign template.
-        // Update the signup's quantity and why_participated data.
+
+        // Update the signup's quantity and why_participated data and log as an event.
         // We will always update these since we can't tell if this has been changed in a good way yet.
+        // @TODO: remove the below logic when we are no longer supporting the phoenix-ashes campaign template.
+        // @TODO: separate event_type into update_why and update_quantity.
+        $data['event_type'] = 'update_signup';
+        Event::create($data);
+
         $data['quantity_pending'] = $data['quantity'];
         $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
         $signup->save();
 
         // If there is a file, create a new photo post.
-        if (isset($data['file'])) {
+        if (! empty($data['file'])) {
+            $data['event_type'] = 'post_photo';
+
             return $this->create($data, $signup->id);
-        } else {
-            // If it doesn't add a new photo, a new event won't be created. Create the event here for an updated signup.
-            // @TODO: right now, an updated signup's event_type is recorded as post_photo. Depending on future decisions, we might want to update this.
-            Event::create($data);
         }
 
         return $signup;

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -89,14 +89,9 @@ class PhotoRepository
         // We will always update these since we can't tell if this has been changed in a good way yet.
         // @TODO: remove the below logic when we are no longer supporting the phoenix-ashes campaign template.
         // @TODO: separate event_type into update_why and update_quantity.
-        $updateSignupData = [];
-        $updateSignupData['northstar_id'] = $data['northstar_id'];
+        $updateSignupData = array_only($data, ['northstar_id', 'submission_type', 'why_participated', 'source', 'remote_addr']);
         $updateSignupData['event_type'] = 'update_signup';
-        $updateSignupData['submission_type'] = $data['submission_type'];
         $updateSignupData['quantity_pending'] = $data['quantity'];
-        $updateSignupData['why_participated'] = $data['why_participated'];
-        $updateSignupData['source'] = $data['source'];
-        $updateSignupData['remote_addr'] = $data['remote_addr'];
 
         Event::create($updateSignupData);
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -89,9 +89,10 @@ class PhotoRepository
         // @TODO: remove the below logic when we are no longer supporting the phoenix-ashes campaign template.
         // @TODO: separate event_type into update_why and update_quantity.
         $data['event_type'] = 'update_signup';
+        $data['quantity_pending'] = $data['quantity'];
+        $data['quantity'] = null;
         Event::create($data);
 
-        $data['quantity_pending'] = $data['quantity'];
         $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
         $signup->save();
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -42,10 +42,8 @@ class PhotoRepository
      */
     public function create(array $data, $signupId)
     {
-        // Set quantity and why_participated to null - we don't want this to live on the post_photo event.
-        $data['quantity'] = null;
-        $data['why_participated'] = null;
-        $postEvent = Event::create($data);
+        // Don't send quantity and why_participated - we don't want this to live on the post_photo event.
+        $postEvent = Event::create(array_except($data, ['quantity', 'why_participated']));
 
         $fileUrl = $this->aws->storeImage($data['file'], $signupId);
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -51,7 +51,10 @@ class PostService
      */
     public function update($signup, $data, $transactionId)
     {
-        $this->resolvePostRepository($data['event_type']);
+        // Get the event type (type is anything after _).
+        $type = explode('_', $data['event_type'])[1];
+
+        $this->resolvePostRepository($type);
 
         $post = $this->repository->update($signup, $data);
 
@@ -86,7 +89,8 @@ class PostService
     public function reviews($data)
     {
         // @TODO: this will need to be updated when other post types are introduced. Right now, all reviews are of photos so everything in this nested array will be a photo. However, if admins can review different types of posts (e.g. photos, videos, links) at once, we'll need to update the logic here.
-        $this->resolvePostRepository($data[0]['event_type']);
+        $type = explode('_', $data[0]['event_type'])[1];
+        $this->resolvePostRepository($type);
 
         $reviewedPosts = $this->repository->reviews($data);
 
@@ -103,7 +107,7 @@ class PostService
     protected function resolvePostRepository($type)
     {
         switch ($type) {
-            case 'post_photo':
+            case 'photo':
                 $this->repository = app('Rogue\Repositories\PhotoRepository');
                 break;
             default:

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -24,7 +24,10 @@ class PostService
      */
     public function create($data, $signupId, $transactionId)
     {
-        $this->resolvePostRepository($data['event_type']);
+        // Get the event type (type is anything after _).
+        $type = explode('_', $data['event_type'])[1];
+
+        $this->resolvePostRepository($type);
 
         $post = $this->repository->create($data, $signupId);
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -24,10 +24,7 @@ class PostService
      */
     public function create($data, $signupId, $transactionId)
     {
-        // Get the event type (type is anything after _).
-        $type = explode('_', $data['event_type'])[1];
-
-        $this->resolvePostRepository($type);
+        $this->resolvePostRepository($data['event_type']);
 
         $post = $this->repository->create($data, $signupId);
 
@@ -54,10 +51,7 @@ class PostService
      */
     public function update($signup, $data, $transactionId)
     {
-        // Get the event type (type is anything after _).
-        $type = explode('_', $data['event_type'])[1];
-
-        $this->resolvePostRepository($type);
+        $this->resolvePostRepository($data['event_type']);
 
         $post = $this->repository->update($signup, $data);
 
@@ -92,8 +86,7 @@ class PostService
     public function reviews($data)
     {
         // @TODO: this will need to be updated when other post types are introduced. Right now, all reviews are of photos so everything in this nested array will be a photo. However, if admins can review different types of posts (e.g. photos, videos, links) at once, we'll need to update the logic here.
-        $type = explode('_', $data[0]['event_type'])[1];
-        $this->resolvePostRepository($type);
+        $this->resolvePostRepository($data[0]['event_type']);
 
         $reviewedPosts = $this->repository->reviews($data);
 
@@ -109,6 +102,9 @@ class PostService
      */
     protected function resolvePostRepository($type)
     {
+        // Get the event type (type is anything after _).
+        $type = explode('_', $type)[1];
+
         switch ($type) {
             case 'photo':
                 $this->repository = app('Rogue\Repositories\PhotoRepository');


### PR DESCRIPTION
#### What's this PR do?
- Added capability for more `event_types`. Now there are: 
  - `signup`
  - `post_photo`
  - `update_signup`
  - `review_photo` 
- When an event gets added to the `events` table, more information (columns) are filled out. 
  - `why_participated` and `quantity_pending` columns are filled with an `update_signup` event.
  - `caption` and `status` columns are filled with a `post_photo` event. 
  - for both, `northstar_id`, `submission_type`, `remote_addr`, and timestamp columns are filled out. 
- Makes the `resolvePostRepository` function more flexible. Now, it determines which repository to use by looking at what comes after the `_` - e.g. determines a type is a `photo` if `post_photo` is sent in. This allows for `review_photo` etc. 
- Creates two separate events for when a signup is updated (for now, this will be every time a new photo is posted) and when a new photo is posted. 

#### How should this be reviewed?
1. Submit a reportback and make sure all information matches up in Phoenix and Rogue databases. 
2. Update the `quantity` and/or `quantity_pending` and all information should match up in Phoenix and Rogue. 
  - In the `events` table, the `event_type` should be `update_signup` with `quantity_pending` and `why_participated` columns should be filled out.
3. Add a new reportback item and make sure all information matches up in Phoenix and Rogue. 
  - In the `events` table, the `event_type` should be `post_photo` and `caption` and `status` columns should be filled out. 
4. Review a reportback item. 
  - In the `events` table, the `event_type` should be `review_photo`, `submission_type` should be `admin`, and `status` column should be filled out. 
5. Cron job should still work.

#### Relevant tickets
Fixes #114 
Fixes #115 
Fixes #116 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.