### PR TITLE
Reportback review bug take 2

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -70,7 +70,6 @@ class ReportbackController extends ApiController
         $this->validate($request, [
             '*.rogue_reportback_item_id' => 'required',
             '*.status' => 'required',
-            '*.reviewer' => 'required',
         ]);
 
         $items = $this->reportbackService->updateReportbackItems($request->all());

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -70,6 +70,7 @@ class ReportbackController extends ApiController
         $this->validate($request, [
             '*.rogue_reportback_item_id' => 'required',
             '*.status' => 'required',
+            '*.reviewer' => 'required',
         ]);
 
         $items = $this->reportbackService->updateReportbackItems($request->all());

--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -66,7 +66,6 @@ class ReviewsController extends ApiController
 
         $reportbackItems = [];
         $photos = [];
-
         // Loop through the $request and separate reportback items from photos.
         foreach ($request->all() as $review) {
             $post = Post::where(['event_id' => $review['rogue_event_id']])->first();
@@ -78,11 +77,16 @@ class ReviewsController extends ApiController
             }
         }
 
-        $reviewedReportbackItems = $this->reportbacks->updateReportbackItems($reportbackItems);
-        $reviewedReportbackItemsCode = $this->code($reviewedReportbackItems);
+        if ($reportbackItems) {
+            $reviewedReportbackItems = $this->reportbacks->updateReportbackItems($reportbackItems);
 
-        $reviewedPhotos = $this->posts->reviews($photos);
-        $reviewedPhotosCode = $this->code($reviewedPhotos);
+            $reviewedReportbackItemsCode = $this->code($reviewedReportbackItems);
+        }
+
+        if ($photos) {
+            $reviewedPhotos = $this->posts->reviews($photos);
+            $reviewedPhotosCode = $this->code($reviewedPhotos);
+        }
 
         $meta = [];
 

--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -66,6 +66,7 @@ class ReviewsController extends ApiController
 
         $reportbackItems = [];
         $photos = [];
+
         // Loop through the $request and separate reportback items from photos.
         foreach ($request->all() as $review) {
             $post = Post::where(['event_id' => $review['rogue_event_id']])->first();
@@ -90,9 +91,9 @@ class ReviewsController extends ApiController
 
         $meta = [];
 
-        if ($reviewedReportbackItems) {
+        if (isset($reviewedReportbackItems)) {
             return $this->collection($reviewedReportbackItems, $reviewedReportbackItemsCode, $meta, $this->reportbackItemTransformer);
-        } elseif ($reviewedPhotos) {
+        } elseif (isset($reviewedPhotos)) {
             return $this->collection($reviewedPhotos, $reviewedPhotosCode, $meta, $this->photoTransformer);
         } else {
             return 404;

--- a/app/Repositories/ReportbackRepository.php
+++ b/app/Repositories/ReportbackRepository.php
@@ -177,7 +177,7 @@ class ReportbackRepository
         $reportbackItems = [];
 
         foreach ($data as $reportbackItem) {
-            if ($reportbackItem['rogue_reportback_item_id'] && ! empty($reportbackItem['rogue_reportback_item_id'])) {
+            if (isset($reportbackItem['rogue_reportback_item_id']) && ! empty($reportbackItem['rogue_reportback_item_id'])) {
                 $rbItem = ReportbackItem::where(['id' => $reportbackItem['rogue_reportback_item_id']])->first();
 
                 if ($reportbackItem['status'] && ! empty($reportbackItem['status'])) {


### PR DESCRIPTION
#### What's this PR do?
Adds checks to make sure variables are set to determine which Service class to go to and to prevent errors. 

#### How should this be reviewed?
- Find a reportback item in the `reportback_items` table in the Rogue database that has not yet been reviewed. 
- Review the reportback item in Phoenix and make sure it gets updated in Rogue and doesn't enter into the `dosomething_rogue_failed_task_log`.
- Find a photo in the `photos` table in the Rogue database that has not yet been reviewed. 
- Review the reportback item in Phoenix and make sure it gets updated in Rogue and doesn't enter into the `dosomething_rogue_failed_task_log`,
- Make sure cron job is working properly.

#### Any background context you want to provide?
Phoenix was not receiving a `$response` because it was always sending to both the Reportback Service and Post Service, even if only reportback item objects were being reviewed. Now, we have checks to make sure it only gets sent to the service if there is a reportback item object or photo object. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.