### PR TITLE
handle missing images, add signup_id to events table, populate event columns

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'event_type', 'submission_type', 'quantity', 'quantity_pending', 'why_participated', 'caption', 'status', 'source', 'remote_addr', 'reason'];
+    protected $fillable = ['id', 'signup_id', 'northstar_id', 'event_type', 'submission_type', 'quantity', 'quantity_pending', 'why_participated', 'caption', 'status', 'source', 'remote_addr', 'reason'];
 
     /**
      * An event has one signup.

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -50,11 +50,11 @@ class PhotoRepository
 
         if (isset($data['file'])) {
             $fileUrl = $this->aws->storeImage($data['file'], $signupId);
+
+            $editedImage = $this->crop($data, $signupId);
         } else {
             $fileUrl = 'default';
         }
-
-        $editedImage = $this->crop($data, $signupId);
 
         $photo = Photo::create([
             'file_url' => $fileUrl,

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -42,6 +42,9 @@ class PhotoRepository
      */
     public function create(array $data, $signupId)
     {
+        // Include signup_id when we create the Event
+        $data['signup_id'] = $signupId;
+
         // Don't send quantity and why_participated - we don't want this to live on the post_photo event.
         $postEvent = Event::create(array_except($data, ['quantity', 'why_participated']));
 

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -45,7 +45,11 @@ class PhotoRepository
         // Don't send quantity and why_participated - we don't want this to live on the post_photo event.
         $postEvent = Event::create(array_except($data, ['quantity', 'why_participated']));
 
-        $fileUrl = $this->aws->storeImage($data['file'], $signupId);
+        if (isset($data['file'])) {
+            $fileUrl = $this->aws->storeImage($data['file'], $signupId);
+        } else {
+            $fileUrl = 'default';
+        }
 
         $editedImage = $this->crop($data, $signupId);
 

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -45,6 +45,10 @@ class SignupRepository
             $signup->save(['timestamps' => false]);
         }
 
+        // Now that the signup exists, set the signup_id on the signup event
+        $event->signup_id = $signup->id;
+        $event->save();
+
         return $signup;
     }
 

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -15,12 +15,14 @@ class SignupRepository
      */
     public function create($data)
     {
+        // Create the signup event
         $event = Event::create([
             'northstar_id' => $data['northstar_id'],
             'event_type' => 'signup',
             'submission_type' => 'user',
         ]);
 
+        // Create the signup
         $signup = $event->signup()->create([
             'event_id' => $event->id,
             'northstar_id' => $data['northstar_id'],

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -15,12 +15,12 @@ class SignupRepository
      */
     public function create($data)
     {
+        // Add these values to pass to the Event
+        $data['event_type'] = 'signup';
+        $data['submission_type'] = 'user';
+
         // Create the signup event
-        $event = Event::create([
-            'northstar_id' => $data['northstar_id'],
-            'event_type' => 'signup',
-            'submission_type' => 'user',
-        ]);
+        $event = Event::create($data);
 
         // Create the signup
         $signup = $event->signup()->create([

--- a/database/migrations/2017_02_09_165430_add_signup_id_to_events_table.php
+++ b/database/migrations/2017_02_09_165430_add_signup_id_to_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSignupIdToEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->integer('signup_id')->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('signup_id');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This is several small fixes in one! These are things that were either blocking migration work, or that needed to be fixed to make sure the migration is working correctly.

1. Handles receiving broken images
2. Adds `signup_id` to `events` table and populates this field
3. Populates the `quantity`, `why_participated`, etc. fields in the `events` table for `signup` events

#### How should this be reviewed?
👀 
1. Broken images shouldn't break anything and should get `file_url` set as `default`
2. When a `signup` or `post_photo` event is created, the `signup_id` should appear in the `events` table.
3. When a `signup` event occurs, the submitted data should appear in the `events` table.

#### Relevant tickets
Fixes #122
Fixes #123

#### Checklist
- [ ] Tested on staging.