### PR TITLE
Allow signup_id in the events table to be NULL

### DIFF
--- a/database/migrations/2017_02_10_154746_make_signup_id_in_events_table_nullable.php
+++ b/database/migrations/2017_02_10_154746_make_signup_id_in_events_table_nullable.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeSignupIdInEventsTableNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->integer('signup_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->integer('signup_id')->nullable(false)->change();
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Added a new migration to allow the `signup_id` column in the `events` table to be `NULL`. Currently, we created the event first, then created the signup, and then add the signup id to the event. Now, when there is no `signup_id` set the value will be `NULL` instead of `0`.

#### How should this be reviewed?
Create a signup event without setting the `signup_id`. That column should be `NULL`.

#### Any background context you want to provide?
Slack conversation starts [here](https://dosomething.slack.com/archives/rogue/p1486738492000208)

#### Relevant tickets
Fixes #125

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.