### PR TITLE
Check if editedImage is set before we use it

### DIFF
--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -58,7 +58,7 @@ class PhotoRepository
 
         $photo = Photo::create([
             'file_url' => $fileUrl,
-            'edited_file_url' => $editedImage,
+            'edited_file_url' => isset($editedImage) ? $editedImage : null,
             'caption' => $data['caption'],
             'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => $data['source'],


### PR DESCRIPTION
#### What's this PR do?
If the image is broken we don't even try to set `$editedImage` because there will be no such thing, but that means we can't try to use it later!

#### How should this be reviewed?
If there is no image, does anything break? Does it try to use any variables that don't exist?

#### Relevant tickets
Fixes #127

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.