### PR TITLE
Backdating posts, photos, and events

### DIFF
--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -65,6 +65,15 @@ class PhotoRepository
             'remote_addr' => $data['remote_addr'],
         ]);
 
+        // @TODO: I think we can remove this after the migration runs
+        // Let Laravel take care of the timestamps unless they are specified in the request
+        if (isset($data['created_at'])) {
+            $photo->created_at = $data['created_at'];
+            $photo->updated_at = $data['created_at'];
+
+            $photo->save(['timestamps' => false]);
+        }
+
         // Create the Post and associate the Photo with it.
         // @Note -- Having some issue using the `create` method here. I think
         // becase the Posts table doesn't have an `id` key, but I can work that out.
@@ -75,8 +84,21 @@ class PhotoRepository
             'northstar_id' => $data['northstar_id'],
         ]);
 
-        $post->content()->associate($photo);
-        $post->save();
+        // @TODO: I think we can remove this after the migration runs
+        // Let Laravel take care of the timestamps unless they are specified in the request
+        // Post and Photo would have the same timestamps
+        if (isset($data['created_at'])) {
+            $post->content()->associate($photo);
+
+            $post->created_at = $data['created_at'];
+            $post->updated_at = $data['created_at'];
+
+            $post->save(['timestamps' => false]);
+        } else {
+            // @TODO: keep this after the migration
+            $post->content()->associate($photo);
+            $post->save();
+        }
 
         return $post;
     }

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -65,13 +65,16 @@ class PhotoRepository
             'remote_addr' => $data['remote_addr'],
         ]);
 
-        // @TODO: I think we can remove this after the migration runs
+        // @TODO: This if can be removed after the migration
         // Let Laravel take care of the timestamps unless they are specified in the request
         if (isset($data['created_at'])) {
             $photo->created_at = $data['created_at'];
             $photo->updated_at = $data['created_at'];
+            $postEvent->created_at = $data['created_at'];
+            $postEvent->updated_at = $data['created_at'];
 
             $photo->save(['timestamps' => false]);
+            $postEvent->save(['timestamps' => false]);
         }
 
         // Create the Post and associate the Photo with it.
@@ -84,7 +87,7 @@ class PhotoRepository
             'northstar_id' => $data['northstar_id'],
         ]);
 
-        // @TODO: I think we can remove this after the migration runs
+        // @TODO: After the migration, only keep the code in the else
         // Let Laravel take care of the timestamps unless they are specified in the request
         // Post and Photo would have the same timestamps
         if (isset($data['created_at'])) {

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -35,19 +35,26 @@ class SignupRepository
         ]);
 
         // Let Laravel take care of the timestamps unless they are specified in the request
+        // @TODO: keep only the else after the migration
         if (isset($data['created_at'])) {
             $signup->created_at = $data['created_at'];
-            $signup->save(['timestamps' => false]);
-        }
+            $event->created_at = $data['created_at'];
 
-        if (isset($data['updated_at'])) {
-            $signup->updated_at = $data['updated_at'];
-            $signup->save(['timestamps' => false]);
-        }
+            if (isset($data['updated_at'])) {
+                $signup->updated_at = $data['updated_at'];
+                $event->updated_at = $data['updated_at'];
+            } else {
+                $signup->updated_at = $data['created_at'];
+                $event->updated_at = $data['created_at'];
+            }
 
-        // Now that the signup exists, set the signup_id on the signup event
-        $event->signup_id = $signup->id;
-        $event->save();
+            $signup->save(['timestamps' => false]);
+            $event->save(['timestamps' => false]);
+        } else {
+            // Now that the signup exists, set the signup_id on the signup event
+            $event->signup_id = $signup->id;
+            $event->save();
+        }
 
         return $signup;
     }


### PR DESCRIPTION
#### What's this PR do?
Allows for backdating of:
- posts
- photos
- events

When timestamp parameters are passed. This is so the migration has more accurate timestamps.

#### How should this be reviewed?
Make sure this still lets Laravel do the timestamps unless we pass `created_at` or `updated_at`.

#### Relevant tickets
Fixes #131

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.