### PR TITLE
Allow post to /signups to set quantity

### DIFF
--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -28,8 +28,8 @@ class SignupRepository
             'northstar_id' => $data['northstar_id'],
             'campaign_id' => $data['campaign_id'],
             'campaign_run_id' => $data['campaign_run_id'],
-            'quantity' => null,
-            'quantity_pending' => isset($data['quantity']) ? $data['quantity'] : null,
+            'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
+            'quantity_pending' => isset($data['quantity_pending']) ? $data['quantity_pending'] : null,
             'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
             'source' => isset($data['source']) ? $data['source'] : null,
         ]);

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -37,9 +37,14 @@ class SignupRepository
         // Let Laravel take care of the timestamps unless they are specified in the request
         // @TODO: keep only the else after the migration
         if (isset($data['created_at'])) {
+            // Associate the event with the signup
+            $event->signup_id = $signup->id;
+
+            // Set the created_at time
             $signup->created_at = $data['created_at'];
             $event->created_at = $data['created_at'];
 
+            // Set the updated time if provided, if not, assume no updates
             if (isset($data['updated_at'])) {
                 $signup->updated_at = $data['updated_at'];
                 $event->updated_at = $data['updated_at'];


### PR DESCRIPTION
#### What's this PR do?
Two small changes:
1.  For the migration, I needed to be able to set either `quantity` or `quantity_pending` on signups, and not just default to `quantity_pending`. I can't think of any case where the system sending signups to Rogue does not know whether or not the value is the `quantity` or the `quantity_pending`.
2. Fixed some logic to make sure even signup events with timestamps get their `signup_id` put in that column.

#### How should this be reviewed?
Make sure 1. above is a change that makes sense for the future. Otherwise, I can do some more hacking to make it work for the migration! The signups documentation already reflects this behavior though.

#### Relevant tickets
Fixes #137

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.