### PR TITLE
Reactions tally

### DIFF
--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -33,7 +33,8 @@ class ReactionController extends ApiController
     public function store(ReactionRequest $request)
     {
         $userId = $request['northstar_id'];
-        $reportbackItemId = $request['reportback_item_id'];
+        $postableId = $request['postable_id'];
+        $postableType = $request['postable_type'];
 
         // Check to see if the reportback_item has a reaction from this particular user with id of northstar_id.
         $reaction = Reaction::withTrashed()->where(['northstar_id' => $userId, 'reportback_item_id' => $reportbackItemId])->first();

--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -18,6 +18,8 @@ class ReactionController extends ApiController
      */
     public function __construct()
     {
+        $this->middleware('api');
+
         $this->transformer = new ReactionTransformer;
     }
 

--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -61,10 +61,26 @@ class ReactionController extends ApiController
             }
         }
 
+        $totalReactions = $this->getTotalPostReactions($postableId, $postableType);
+
         $meta = [
             'action' => $action,
+            'total_reactions' => $totalReactions,
         ];
 
         return $this->item($reaction, $code, $meta);
+    }
+
+    /**
+     * Query for total reactions for a post.
+     *
+     * @param int $postableId
+     * @param int $postableType
+     * @return int total count
+     */
+    public function getTotalPostReactions($postableId, $postableType)
+    {
+        $match = ['postable_id' => $postableId, 'postable_type' => $postableType];
+        return Reaction::where($match)->count();
     }
 }

--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -36,19 +36,21 @@ class ReactionController extends ApiController
         $postableId = $request['postable_id'];
         $postableType = $request['postable_type'];
 
-        // Check to see if the reportback_item has a reaction from this particular user with id of northstar_id.
-        $reaction = Reaction::withTrashed()->where(['northstar_id' => $userId, 'reportback_item_id' => $reportbackItemId])->first();
+        // Check to see if the post has a reaction from this particular user with id of northstar_id.
+        $reaction = Reaction::withTrashed()->where(['northstar_id' => $userId, 'postable_id' => $postableId, 'postable_type' => $postableType])->first();
 
-        // If a reportback_item does not have a reaction from this user, create a reaction.
+        // If a post does not have a reaction from this user, create a reaction.
         if (is_null($reaction)) {
             $reaction = Reaction::create([
                 'northstar_id' => $userId,
-                'reportback_item_id' => $reportbackItemId,
+                'postable_id' => $postableId,
+                'postable_type' => $postableType,
             ]);
+
             $code = 200;
             $action = 'liked';
         } else {
-            // If the reportback_item was previously "liked" by this user, soft delete the reaction. Otherwise, restore the reaction.
+            // If the post was previously "liked" by this user, soft delete the reaction. Otherwise, restore the reaction.
             $code = 201;
             if (is_null($reaction->deleted_at)) {
                 $action = 'unliked';

--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -81,6 +81,7 @@ class ReactionController extends ApiController
     public function getTotalPostReactions($postableId, $postableType)
     {
         $match = ['postable_id' => $postableId, 'postable_type' => $postableType];
+
         return Reaction::where($match)->count();
     }
 }

--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -80,8 +80,6 @@ class ReactionController extends ApiController
      */
     public function getTotalPostReactions($postableId, $postableType)
     {
-        $match = ['postable_id' => $postableId, 'postable_type' => $postableType];
-
-        return Reaction::where($match)->count();
+        return Reaction::where(['postable_id' => $postableId, 'postable_type' => $postableType])->count();
     }
 }

--- a/app/Http/Requests/ReactionRequest.php
+++ b/app/Http/Requests/ReactionRequest.php
@@ -22,7 +22,8 @@ class ReactionRequest extends Request
     public function rules()
     {
         return [
-            'reportback_item_id' => 'required|int',
+            'postable_id' => 'required|int',
+            'postable_type' => 'required'
             'northstar_id' => 'required',
         ];
     }

--- a/app/Http/Requests/ReactionRequest.php
+++ b/app/Http/Requests/ReactionRequest.php
@@ -23,7 +23,7 @@ class ReactionRequest extends Request
     {
         return [
             'postable_id' => 'required|int',
-            'postable_type' => 'required'
+            'postable_type' => 'required',
             'northstar_id' => 'required',
         ];
     }

--- a/app/Http/Transformers/ReactionTransformer.php
+++ b/app/Http/Transformers/ReactionTransformer.php
@@ -18,7 +18,8 @@ class ReactionTransformer extends TransformerAbstract
         return [
             'reaction_id' => (string) $reaction->id,
             'northstar_id' => $reaction->northstar_id,
-            'reportback_item_id' => (string) $reaction->reportback_item_id,
+            'postable_id' => (string) $reaction->postable_id,
+            'postable_type' => $reaction->postable_type,
             'created_at' => $reaction->created_at,
             'updated_at' => $reaction->updated_at,
             'deleted_at' => $reaction->deleted_at,

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -36,9 +36,6 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['api', 'log.received.reques
     // items
     Route::put('items', 'Api\ReportbackController@updateReportbackItems');
 
-    // reactions
-    Route::post('reactions', 'Api\ReactionController@store');
-
     // reportbacks
     Route::get('reportbacks', 'Api\ReportbackController@index');
     Route::post('reportbacks', 'Api\ReportbackController@store');
@@ -52,6 +49,9 @@ Route::group(['prefix' => 'api/v2', 'middleware' => ['log.received.request']], f
 
     // posts
     Route::post('posts', 'Api\PostsController@store');
+
+    // reactions
+    Route::post('reactions', 'Api\ReactionController@store');
 
     // reviews
     Route::put('reviews', 'Api\ReviewsController@reviews');

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -47,4 +47,12 @@ class Post extends Model
     {
         return $this->belongsTo(Signup::class);
     }
+
+    /**
+     * Each post has many reactions.
+     */
+    public function reactions()
+    {
+        return $this->hasMany(Reaction::class);
+    }
 }

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -20,7 +20,7 @@ class Reaction extends Model {
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'post_id'];
+    protected $fillable = ['id', 'northstar_id', 'postable_id', 'postable_type'];
 
     /**
      * Each reaction belongs to a post.

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -5,7 +5,8 @@ namespace Rogue\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Reaction extends Model {
+class Reaction extends Model
+{
     use SoftDeletes;
 
     /**

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -5,8 +5,7 @@ namespace Rogue\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Reaction extends Model
-{
+class Reaction extends Model {
     use SoftDeletes;
 
     /**
@@ -21,13 +20,13 @@ class Reaction extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'reportback_item_id'];
+    protected $fillable = ['id', 'northstar_id', 'post_id'];
 
     /**
-     * The reportback items that belongs to the reaction.
+     * Each reaction belongs to a post.
      */
-    public function reportbackItems()
+    public function post()
     {
-        return $this->belongsTo('\Rogue\Models\ReportbackItem');
+        return $this->belongsTo(Post::class);
     }
 }

--- a/database/migrations/2017_02_22_210956_update_reactions_table_to_include_postable_id_and_postable_type.php
+++ b/database/migrations/2017_02_22_210956_update_reactions_table_to_include_postable_id_and_postable_type.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateReactionsTableToIncludePostableIdAndPostableType extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reactions', function (Blueprint $table) {
+            $table->renameColumn('reportback_item_id', 'postable_id');
+            $table->string('postable_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reactions', function ($table) {
+            $table->renameColumn('postable_id', 'reportback_item_id');
+            $table->dropColumn('postable_type');
+        });
+    }
+}

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -15,11 +15,6 @@ Endpoint                                       | Functionality
 ---------------------------------------------- | --------------------------------------------------------
 `PUT /api/v1/items`                            | [Reportback Items](endpoints/reportbackitems.md#reportbackitems)
 
-#### Reactions
-Endpoint                                       | Functionality                                           
----------------------------------------------- | --------------------------------------------------------
-`POST /api/v1/reactions`                       | [Create or update a reaction](endpoints/reactions.md#reactions)
-
 
 ### v2
 #### Activity
@@ -31,6 +26,11 @@ Endpoint                                       | Functionality
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `POST /api/v2/posts`                           | [Create a post](endpoints/posts.md#posts)
+
+#### Reactions
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`POST /api/v2/reactions`                       | [Create or update a reaction](endpoints/reactions.md#reactions)
 
 #### Reviews
 Endpoint                                       | Functionality                                           

--- a/documentation/endpoints/reactions.md
+++ b/documentation/endpoints/reactions.md
@@ -7,43 +7,49 @@ POST /api/v1/reactions
 ```
   - **northstar_id**: (int) required
     The northstar id of the user who "liked" or "unliked" the reportback item. 
-  - **reportback_item_id**: (int) required 
-    The reportback item that the reaction belongs to. 
+  - **postable_id**: (int) required 
+    The post that the reaction belongs to. 
+  - **postable_type**: (string) required
+    The post type of the post.
     
 Example Request
 ```
-curl http://rogue.dev:8000/api/v1/reactions
+curl http://rogue.dev:8000/api/v2/reactions
  -d '{
   "northstar_id":1234,
-  "reportback_item_id":1
+  "postable_id":1,
+  "postable_type":"Rogue\Models\Photo",
   }'
   --header "Accept: application/json"
 ```
 Example Response 
 ```
 {
+{
   "data": {
-    "reaction_id": 11,
-    "northstar_id": "1234",
-    "reportback_item_id": 1,
+    "reaction_id": "21",
+    "northstar_id": "8888",
+    "postable_id": "352",
+    "postable_type": "Rogue\\Models\\Photo",
     "created_at": {
-      "date": "2016-10-12 17:31:41.000000",
+      "date": "2017-02-24 16:10:01.000000",
       "timezone_type": 3,
       "timezone": "UTC"
     },
     "updated_at": {
-      "date": "2016-10-21 20:03:28.000000",
+      "date": "2017-02-24 16:11:07.000000",
       "timezone_type": 3,
       "timezone": "UTC"
     },
     "deleted_at": {
-      "date": "2016-10-21 20:04:07.000000",
+      "date": "2017-02-24 16:11:14.000000",
       "timezone_type": 3,
       "timezone": "UTC"
     }
   },
   "meta": {
-    "action": "liked"
+    "action": "unliked",
+    "total_reactions": 1
   }
 }
 ```


### PR DESCRIPTION
#### What's this PR do?
- Moves `/reactions` endpoint to v2
- Updates Reaction Model to accept `postable_id` and `postable_type` instead of `reportback_item_id`
- Updates Reaction equest validation.
- Updates Reaction relation to Post Model.
- Creates a migration to update the `reactions` table with `postable_id` and `postable_type`
- Updates Reaction Controller to:
  - include `postable_id` and `postable_type` in logic
  - include a query to find total reactions for a post 
- Updates Reaction Transformer to return `postable_id` and `postable_type` instead of `reportback_item_id`. Also returns total reactions in `meta` data.
- Updates documentation.

#### How should this be reviewed?
- Hit `/reactions` endpoint and response should look like the following:
```
{
  "data": {
    "reaction_id": "21",
    "northstar_id": "8888",
    "postable_id": "352",
    "postable_type": "Rogue\\Models\\Photo",
    "created_at": {
      "date": "2017-02-24 16:10:01.000000",
      "timezone_type": 3,
      "timezone": "UTC"
    },
    "updated_at": {
      "date": "2017-02-24 16:11:07.000000",
      "timezone_type": 3,
      "timezone": "UTC"
    },
    "deleted_at": {
      "date": "2017-02-24 16:11:14.000000",
      "timezone_type": 3,
      "timezone": "UTC"
    }
  },
  "meta": {
    "action": "unliked",
    "total_reactions": 1
  }
}
```
- If you hit that same endpoint with same info, the total reactions should change to 0 and `deleted_ad` should be `null`

#### Relevant tickets
Fixes #140 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.