### PR TITLE
Include hash of image data in file name

### DIFF
--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -36,7 +36,7 @@ class AWS
 
         // Add a unique timestamp (e.g. uploads/folder/filename-1456498664.jpeg) to
         // uploads to prevent AWS cache giving the user an old upload.
-        $path = '/uploads/reportback-items' . '/' . $filename . '-' . time() . '.' . $extension;
+        $path = '/uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
 
         // Push file to S3.
         $success = Storage::put($path, $data);


### PR DESCRIPTION
#### What's this PR do?
Included a hash of the image in the photo url to avoid duplicate filenames. The filename already included the timestamp, but during the migration those could be too similar!

#### How should this be reviewed?
👀  should be good!

#### Any background context you want to provide?
During the migration I noticed that some photos that were all under the same signup all showed the same image, even thought they were different in Phoenix. Some digging showed the the script was sending over different images.

#### Checklist
- [ ] Tested on staging.
