### PR TITLE
Add test for creating a new signup

### DIFF
--- a/tests/SignupApiTest.php
+++ b/tests/SignupApiTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class SignupApiTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /*
+     * Base URL for the Api.
+     */
+    protected $signupsApiUrl = 'api/v2/signups';
+
+    /**
+     * Test that a POST request to /signupss creates a new signup.
+     *
+     * @group creatingAPhoto
+     * @return void
+     */
+    public function testCreatingASignup()
+    {
+    	// Create test signup
+        $signup = [
+            'northstar_id'     => str_random(24),
+            'campaign_id'      => $this->faker->randomNumber(4),
+            'campaign_run_id'  => $this->faker->randomNumber(4),
+            'source'           => 'the-fox-den',
+            'do_not_forward'   => true,
+        ];
+
+        // Send the signup and make sure the response has the data we expect
+        $response = $this->json('POST', $this->signupsApiUrl, $signup)
+        				 ->seeJson([
+        				 	'northstar_id' => $signup['northstar_id'],
+        				 	'campaign_id' => $signup['campaign_id'],
+        				 	'campaign_run_id' => $signup['campaign_run_id'],
+        				 	'source' => 'the-fox-den',
+        				 	'quantity' => null,
+        				 	'why_participated' => null,
+        					]);
+
+        // Make sure we get the 201 Created response
+        $this->assertResponseStatus(201);
+
+        $response = $this->decodeResponseJson();
+
+        // Make sure the signup event got created
+        $this->seeInDatabase('events', [
+            'northstar_id' => $response['data']['northstar_id'],
+        ]);
+
+        // Make sure the signup got created
+        $this->seeInDatabase('signups', [
+            'northstar_id' => $response['data']['northstar_id'],
+        ]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Added the first test for `/signup`! It tests creating a new signup with the bare minimum parameters (I figure this is what this endpoint will mainly be used for as things stand now). 

#### How should this be reviewed?
See if this test tests what I said it does and if you think there are any more tests that could be applied to `/signups`.

#### Any background context you want to provide?
I didn't test the functionality of passing a photo with the signup because that will not be used outside of data migration. I thought about doing a test with `why_participated` and things, but I don't think that would ever all be passed at one time in the wild.

#### Relevant tickets
Fixes #109

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
