### PR TITLE
Add migration to make a signup_id index on the events table

### DIFF
--- a/database/migrations/2017_03_09_192255_add_signup_id_index_to_events_table.php
+++ b/database/migrations/2017_03_09_192255_add_signup_id_index_to_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSignupIdIndexToEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->index('signup_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropIndex(['signup_id']);
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Added a signup_id index on the events table!

#### How should this be reviewed?
I tested by migrating and rolling back and migrating and making sure the index appeared and disappeared and appeared. You can probably just 👀 

#### Any background context you want to provide?
Somewhere deep in the guts of what happens in Rogue when we migrate, this query happens:
```
select * from `events` where `events`.`signup_id` = ? and `events`.`signup_id` is not null`
```
So with no index, as the events table grew, everything got slower. This should help with that! Plus, with how we now will want to get events per signup, we are going to want this anyway.

#### Checklist
- [ ] Tested on staging.