### PR TITLE
Optionally embed user info in activity response

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -64,12 +64,16 @@ class ApiController extends BaseController
      * @param  array  $meta
      * @return \Illuminate\Http\JsonResponse
      */
-    public function transform($data, $code = 200, $meta = [])
+    public function transform($data, $code = 200, $meta = [], $include = null)
     {
         $data->setMeta($meta);
 
         $manager = new Manager;
         $manager->setSerializer(new DataArraySerializer);
+
+        if (isset($include)) {
+            $manager->parseIncludes($include);
+        }
 
         $response = $manager->createData($data)->toArray();
 
@@ -114,6 +118,8 @@ class ApiController extends BaseController
         $resource->setMeta($meta);
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
-        return $this->transform($resource, $code);
+        $include = isset($request->include) ? $request->include : null;
+
+        return $this->transform($resource, $code, [], $include);
     }
 }

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -86,7 +86,7 @@ class SignupTransformer extends TransformerAbstract
      */
     public function includeUser(Signup $signup)
     {
-        $registrar = new Registrar();
+        $registrar = app(Registrar::class);
         $northstar_id = $signup->northstar_id;
 
         return $this->item($registrar->find($northstar_id), new UserTransformer);

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -3,8 +3,8 @@
 namespace Rogue\Http\Transformers;
 
 use Rogue\Models\Event;
-use Rogue\Services\Registrar;
 use Rogue\Models\Signup;
+use Rogue\Services\Registrar;
 use League\Fractal\TransformerAbstract;
 
 class SignupTransformer extends TransformerAbstract
@@ -90,6 +90,5 @@ class SignupTransformer extends TransformerAbstract
         $northstar_id = $signup->northstar_id;
 
         return $this->item($registrar->find($northstar_id), new UserTransformer);
-
     }
 }

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -3,6 +3,7 @@
 namespace Rogue\Http\Transformers;
 
 use Rogue\Models\Event;
+use Rogue\Services\Registrar;
 use Rogue\Models\Signup;
 use League\Fractal\TransformerAbstract;
 
@@ -16,6 +17,15 @@ class SignupTransformer extends TransformerAbstract
     protected $defaultIncludes = [
         'posts',
         'events',
+    ];
+
+    /**
+     * List of resources possible to include
+     *
+     * @var array
+     */
+    protected $availableIncludes = [
+        'user',
     ];
 
     /**
@@ -66,5 +76,20 @@ class SignupTransformer extends TransformerAbstract
         $event = $signup->events;
 
         return $this->collection($event, new EventTransformer);
+    }
+
+    /**
+     * Include the user data (optionally)
+     *
+     * @param \Rogue\Models\Signup $signup
+     * @return \League\Fractal\Resource\Item
+     */
+    public function includeUser(Signup $signup)
+    {
+        $registrar = new Registrar();
+        $northstar_id = $signup->northstar_id;
+
+        return $this->item($registrar->find($northstar_id), new UserTransformer);
+
     }
 }

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rogue\Http\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class UserTransformer extends TransformerAbstract
+{
+    /**
+     * Transform resource data.
+     *
+     * @param \Rogue\Models\Photo $user
+     * @return array
+     */
+    public function transform($user)
+    {
+        return [
+            'first_name' => $user->first_name,
+        ];
+    }
+}

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -18,6 +18,9 @@ GET /api/v2/activity
 - **campaign_run_id** _(integer)_
   - The campaign run nid(s) to filter the response by.
   - e.g. `/activity?filter[campaign_run_id]=1771`
+- **user** _(integer)_
+  - Whether or not to include information about the user with the response.
+  - e.g. `/activity?include=user`
 
 
 Example Response:
@@ -129,6 +132,11 @@ Example Response:
             "updated_at": "2017-01-18T20:33:39+0000"
           }
         ]
+      }
+      "user": {
+        "data": {
+          "first_name": "Chloe"
+        }
       }
     }
   ],


### PR DESCRIPTION
#### What's this PR do?
Adds the ability to include an optional parameter to bundle the user info with the request. As of now, the user info provided is just the first name. To have this included, just put `include=user` in your request.

#### How should this be reviewed?
I'm not crazy about having to pass the empty array here `return $this->transform($resource, $code, [], $include)` in `ApiController.php`, but I couldn't figure out any other way to pass the `include` info to the transformer. Is anyone else bothered by this or have any thoughts on how to avoid this weirdness?

#### Any background context you want to provide?
This is to be used in the gallery 📸 !

#### Relevant tickets
Fixes #157

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.