### PR TITLE
Campaign overview with data

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -7,7 +7,9 @@ use Rogue\Services\Registrar;
 
 class CampaignsController extends Controller
 {
-    public function __construct()
+    protected $phoenix;
+
+    public function __construct(Phoenix $phoenix)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
@@ -19,6 +21,10 @@ class CampaignsController extends Controller
      */
     public function index()
     {
+        $allCampaigns = $this->phoenix->getAllCampaigns();
+
+        dd($allCampaigns['data'][1]);
+
         $staffPicks = collect([
             ['name' => 'Campaign 1', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
             ['name' => 'Campaign 2', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -3,7 +3,6 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Signup;
-use Rogue\Services\Phoenix;
 use Rogue\Services\Registrar;
 use Illuminate\Support\Facades\DB;
 use Rogue\Services\CampaignService;
@@ -20,13 +19,6 @@ class CampaignsController extends Controller
     /**
      * Phoenix instance
      *
-     * @var Rogue\Services\Phoenix
-     */
-    protected $phoenix;
-
-    /**
-     * Phoenix instance
-     *
      * @var Rogue\Services\CampaignService
      */
     protected $campaignService;
@@ -36,12 +28,11 @@ class CampaignsController extends Controller
      *
      * @param \Rogue\Services\Phoenix $phoenix
      */
-    public function __construct(Phoenix $phoenix, Registrar $registrar, CampaignService $campaignService)
+    public function __construct(Registrar $registrar, CampaignService $campaignService)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
 
-        $this->phoenix = $phoenix;
         $this->registrar = $registrar;
         $this->campaignService = $campaignService;
     }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -51,10 +51,7 @@ class CampaignsController extends Controller
      */
     public function index()
     {
-        // Get campaigns ids for all signups in rogue.
-        $campaigns = DB::table('signups')->select('campaign_id')->groupBy('campaign_id')->get();
-        $ids = collect($campaigns)->pluck('campaign_id')->toArray();
-
+        $ids = $this->campaignService->getCampaignIdsFromSignups();
         $campaigns = $this->campaignService->findAll($ids);
         $campaigns = $this->campaignService->groupByCause($campaigns);
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -36,14 +36,14 @@ class CampaignsController extends Controller
      *
      * @param \Rogue\Services\Phoenix $phoenix
      */
-    public function __construct(Phoenix $phoenix)
+    public function __construct(Phoenix $phoenix, Registrar $registrar, CampaignService $campaignService)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
 
         $this->phoenix = $phoenix;
-        $this->registrar = new Registrar();
-        $this->campaignService = new CampaignService;
+        $this->registrar = $registrar;
+        $this->campaignService = $campaignService;
     }
 
     /**

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -26,7 +26,8 @@ class CampaignsController extends Controller
     /**
      * Constructor
      *
-     * @param \Rogue\Services\Phoenix $phoenix
+     * @param Rogue\Services\Registrar $registrar
+     * @param Rogue\Services\CampaignService $campaignService
      */
     public function __construct(Registrar $registrar, CampaignService $campaignService)
     {

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -2,18 +2,27 @@
 
 namespace Rogue\Http\Controllers;
 
+
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
+use Rogue\Services\Phoenix;
+use Rogue\Models\Post;
+use Illuminate\Support\Facades\DB;
+use Rogue\Services\CampaignService;
 
 class CampaignsController extends Controller
 {
     protected $phoenix;
+
+    protected $campaignService;
 
     public function __construct(Phoenix $phoenix)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
         $this->registrar = new Registrar();
+        $this->phoenix = $phoenix;
+        $this->campaignService = new CampaignService;
     }
 
     /**
@@ -21,34 +30,79 @@ class CampaignsController extends Controller
      */
     public function index()
     {
-        $allCampaigns = $this->phoenix->getAllCampaigns();
+        // $campaigns = DB::table('posts')
+        //         ->join('signups', 'signups.id', '=', 'posts.signup_id')
+        //         ->select('signups.campaign_id', DB::raw('count(posts.northstar_id)'))
+        //         ->groupBy('signups.campaign_id')
+        //         ->get();
 
-        dd($allCampaigns['data'][1]);
+        // dd($campaigns);
+        //
+        // THE DREAM:
+        // $posts = Campaigns::withCount('signups.posts');
 
-        $staffPicks = collect([
-            ['name' => 'Campaign 1', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
-            ['name' => 'Campaign 2', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
-            ['name' => 'Campaign 3', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
-        ]);
+        // $posts = Post::with('content' => function($query) { $query->where('status', '=', 'approved')})->get();
 
-        $environment = collect([
-            ['name' => 'Campaign 4', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
-            ['name' => 'Campaign 5', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
-            ['name' => 'Campaign 6', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
-        ]);
+        // $posts = Post::with(['content' => function ($query) {
+        //     dd($query);
+        //     $query->where('status', '=', 'approved');
 
-        $bullying = collect([
-            ['name' => 'Campaign 7', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
-            ['name' => 'Campaign 8', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
-            ['name' => 'Campaign 9', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
-        ]);
+        // }])->get();
+        // $campaigns = DB::table('signups')->select('campaign_id')->groupBy('campaign_id')->get();
+        // $campaignIds = collect($campaigns)->pluck('campaign_id')->toArray();
+        $ids = $this->campaignService->getAllCampaigns();
+
+        $params = [
+            'campaigns' => implode(',', $ids),
+            'count' => (int) count($ids), // Look into batchedCollection
+        ];
+
+        $phoenixCampaigns = $this->phoenix->getAllCampaigns($params);
+        $phoenixCampaigns = collect($phoenixCampaigns['data']);
+
+        $grouped = $phoenixCampaigns->groupBy(function($campaign) {
+            if ($campaign['staff_pick']) {
+                return 'Staff Pick';
+            }
+
+            $cause = $campaign['causes']['primary']['name'];
+
+            return $cause;
+        });
+
+        $grouped = $grouped->toArray();
+        // dd($grouped->toArray());
+
+        // $posts = Post::with('content')->get();
+        // // dd($posts);
+        // foreach ($posts as $post) {
+        //     dd($post);
+        // }
+
+
+
+        // dd($posts->content);
+
+        // $staffPicks = collect([
+        //     ['name' => 'Campaign 1', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
+        //     ['name' => 'Campaign 2', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
+        //     ['name' => 'Campaign 3', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
+        // ]);
+
+        // $environment = collect([
+        //     ['name' => 'Campaign 4', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
+        //     ['name' => 'Campaign 5', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
+        //     ['name' => 'Campaign 6', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
+        // ]);
+
+        // $bullying = collect([
+        //     ['name' => 'Campaign 7', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
+        //     ['name' => 'Campaign 8', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
+        //     ['name' => 'Campaign 9', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
+        // ]);
 
         return view('pages.campaign_overview')
-            ->with('state', [
-                'Staff Picks' => $staffPicks,
-                'Environment' => $environment,
-                'Bullying' => $bullying,
-            ]);
+            ->with('state', $grouped);
     }
 
     /**

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -2,25 +2,47 @@
 
 namespace Rogue\Http\Controllers;
 
-
 use Rogue\Models\Signup;
-use Rogue\Services\Registrar;
 use Rogue\Services\Phoenix;
+use Rogue\Services\Registrar;
 use Illuminate\Support\Facades\DB;
 use Rogue\Services\CampaignService;
 
 class CampaignsController extends Controller
 {
+    /**
+     * Registrar instance
+     *
+     * @var Rogue\Services\Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Phoenix instance
+     *
+     * @var Rogue\Services\Phoenix
+     */
     protected $phoenix;
 
+    /**
+     * Phoenix instance
+     *
+     * @var Rogue\Services\CampaignService
+     */
     protected $campaignService;
 
+    /**
+     * Constructor
+     *
+     * @param \Rogue\Services\Phoenix $phoenix
+     */
     public function __construct(Phoenix $phoenix)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
-        $this->registrar = new Registrar();
+
         $this->phoenix = $phoenix;
+        $this->registrar = new Registrar();
         $this->campaignService = new CampaignService;
     }
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -41,68 +41,13 @@ class CampaignsController extends Controller
         // THE DREAM:
         // $posts = Campaigns::withCount('signups.posts');
 
-        // $posts = Post::with('content' => function($query) { $query->where('status', '=', 'approved')})->get();
+        $ids = $this->campaignService->getCampaignIds();
 
-        // $posts = Post::with(['content' => function ($query) {
-        //     dd($query);
-        //     $query->where('status', '=', 'approved');
-
-        // }])->get();
-        // $campaigns = DB::table('signups')->select('campaign_id')->groupBy('campaign_id')->get();
-        // $campaignIds = collect($campaigns)->pluck('campaign_id')->toArray();
-        $ids = $this->campaignService->getAllCampaigns();
-
-        $params = [
-            'campaigns' => implode(',', $ids),
-            'count' => (int) count($ids), // Look into batchedCollection
-        ];
-
-        $phoenixCampaigns = $this->phoenix->getAllCampaigns($params);
-        $phoenixCampaigns = collect($phoenixCampaigns['data']);
-
-        $grouped = $phoenixCampaigns->groupBy(function($campaign) {
-            if ($campaign['staff_pick']) {
-                return 'Staff Pick';
-            }
-
-            $cause = $campaign['causes']['primary']['name'];
-
-            return $cause;
-        });
-
-        $grouped = $grouped->toArray();
-        // dd($grouped->toArray());
-
-        // $posts = Post::with('content')->get();
-        // // dd($posts);
-        // foreach ($posts as $post) {
-        //     dd($post);
-        // }
-
-
-
-        // dd($posts->content);
-
-        // $staffPicks = collect([
-        //     ['name' => 'Campaign 1', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
-        //     ['name' => 'Campaign 2', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
-        //     ['name' => 'Campaign 3', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
-        // ]);
-
-        // $environment = collect([
-        //     ['name' => 'Campaign 4', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
-        //     ['name' => 'Campaign 5', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
-        //     ['name' => 'Campaign 6', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
-        // ]);
-
-        // $bullying = collect([
-        //     ['name' => 'Campaign 7', 'approved' => 53, 'pending' => 32, 'rejected' => 34, 'deleted' => 3],
-        //     ['name' => 'Campaign 8', 'approved' => 54, 'pending' => 33, 'rejected' => 35, 'deleted' => 4],
-        //     ['name' => 'Campaign 9', 'approved' => 55, 'pending' => 34, 'rejected' => 36, 'deleted' => 5],
-        // ]);
+        $campaigns = $this->campaignService->findAll($ids);
+        $campaigns = $this->campaignService->groupByCause($campaigns);
 
         return view('pages.campaign_overview')
-            ->with('state', $grouped);
+            ->with('state', $campaigns);
     }
 
     /**

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -4,7 +4,6 @@ namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
-use Illuminate\Support\Facades\DB;
 use Rogue\Services\CampaignService;
 
 class CampaignsController extends Controller

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -6,7 +6,6 @@ namespace Rogue\Http\Controllers;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Rogue\Services\Phoenix;
-use Rogue\Models\Post;
 use Illuminate\Support\Facades\DB;
 use Rogue\Services\CampaignService;
 
@@ -30,18 +29,9 @@ class CampaignsController extends Controller
      */
     public function index()
     {
-        // $campaigns = DB::table('posts')
-        //         ->join('signups', 'signups.id', '=', 'posts.signup_id')
-        //         ->select('signups.campaign_id', DB::raw('count(posts.northstar_id)'))
-        //         ->groupBy('signups.campaign_id')
-        //         ->get();
-
-        // dd($campaigns);
-        //
-        // THE DREAM:
-        // $posts = Campaigns::withCount('signups.posts');
-
-        $ids = $this->campaignService->getCampaignIds();
+        // Get campaigns ids for all signups in rogue.
+        $campaigns = DB::table('signups')->select('campaign_id')->groupBy('campaign_id')->get();
+        $ids = collect($campaigns)->pluck('campaign_id')->toArray();
 
         $campaigns = $this->campaignService->findAll($ids);
         $campaigns = $this->campaignService->groupByCause($campaigns);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -11,7 +11,28 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
+    protected $fillable = ['event_id', 'signup_id', 'northstar_id'];
+
+    protected $primaryKey = ['event_id'];
+
+    // protected $with = ['content'];
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * Returns Post data
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function content()
+    {
+        return $this->morphTo('postable');
+    }
 
     /**
      * Each post has events.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -11,28 +11,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['event_id', 'signup_id', 'northstar_id'];
-
-    protected $primaryKey = ['event_id'];
-
-    // protected $with = ['content'];
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
-
-    /**
-     * Returns Post data
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
-     */
-    public function content()
-    {
-        return $this->morphTo('postable');
-    }
+    protected $fillable = ['id', 'signup_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
 
     /**
      * Each post has events.

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Services;
 
-use Rogue\Services\Phoenix;
 use Illuminate\Support\Facades\DB;
 use Rogue\Repositories\CacheRepository;
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -17,6 +17,8 @@ class CampaignService
 
     /**
      * Create new Registrar instance.
+     *
+     * @param Rogue\Services\Phoenix $phoenix
      */
     public function __construct(Phoenix $phoenix)
     {
@@ -93,7 +95,7 @@ class CampaignService
     }
 
     /**
-     * Get large number of users in batches from Northstar.
+     * Get large number of campaigns from Phoenix.
      *
      * @param  array  $ids
      * @param  int $size

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -150,6 +150,6 @@ class CampaignService
             return $key;
         });
 
-        return $grouped->toArray();
+        return $sorted->toArray();
     }
 }

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -2,9 +2,7 @@
 
 namespace Rogue\Services;
 
-use Rogue\Services\Phoenix;
 use Rogue\Repositories\CacheRepository;
-use Illuminate\Support\Facades\DB;
 
 class CampaignService
 {
@@ -37,7 +35,6 @@ class CampaignService
         return $campaign['data'];
     }
 
-
     /**
      * Finds a group of campagins in Rogue/Phoenix.
      *
@@ -67,20 +64,6 @@ class CampaignService
         }
 
         return null;
-    }
-
-    /**
-     * Returns an array of unique campaign IDs that we have signups for.
-     *
-     * @return array $ids
-     */
-    public function getCampaignIds()
-    {
-        $campaigns = DB::table('signups')->select('campaign_id')->groupBy('campaign_id')->get();
-
-        $ids = collect($campaigns)->pluck('campaign_id')->toArray();
-
-        return $ids;
     }
 
     /**
@@ -129,9 +112,16 @@ class CampaignService
         return collect($data);
     }
 
+    /**
+     * Group a collection of campaigns by cause space.
+     *
+     * @param  array  $ids
+     * @param  int $size
+     * @return \Illuminate\Support\Collection
+     */
     public function groupByCause($campaigns)
     {
-        $grouped = $campaigns->groupBy(function($campaign) {
+        $grouped = $campaigns->groupBy(function ($campaign) {
             if ($campaign['staff_pick']) {
                 return 'Staff Pick';
             }

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rogue\Services;
+
+use Rogue\Services\Phoenix;
+use Rogue\Repositories\CacheRepository;
+use Illuminate\Support\Facades\DB;
+
+class CampaignService
+{
+    /**
+     * Create new Registrar instance.
+     */
+    public function __construct()
+    {
+        $this->phoenix = new Phoenix;
+        $this->cache = new CacheRepository;
+    }
+
+    /**
+     * Finds a single campaign in Rogue. If the campaign is not found
+     * in the Cache, then we grab it directly from Phoenix and store in cache.
+     *
+     * @param  string $id
+     * @return object $user Northstar user object
+     */
+    public function find($id)
+    {
+        $campaign = $this->cache->retrieve($id);
+
+        if (! $campaign) {
+            $campaign = $this->phoenix->getCampaign($id);
+
+            $this->cache->store($campaign['data']['id'], $campaign['data']);
+        }
+
+        return $campaign;
+    }
+
+    /**
+     * Returns an array of unique campaign IDs that we have signups for.
+     *
+     * @return array $ids
+     */
+    public function getAllCampaigns()
+    {
+        $campaigns = DB::table('signups')->select('campaign_id')->groupBy('campaign_id')->get();
+
+        $ids = collect($campaigns)->pluck('campaign_id')->toArray();
+
+        return $ids;
+    }
+}

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Services;
 
+use Illuminate\Support\Facades\DB;
 use Rogue\Repositories\CacheRepository;
 
 class CampaignService
@@ -151,5 +152,14 @@ class CampaignService
         });
 
         return $sorted->toArray();
+    }
+
+    public function getCampaignIdsFromSignups()
+    {
+        $campaigns = DB::table('signups')->distinct()->select('campaign_id')->get();
+
+        $ids = collect($campaigns)->pluck('campaign_id')->toArray();
+
+        return $ids ? $ids : null;
     }
 }

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -126,9 +126,28 @@ class CampaignService
                 return 'Staff Pick';
             }
 
-            $cause = $campaign['causes']['primary']['name'];
+            if (! $campaign['causes']['primary']['name']) {
+                return 'No Cause';
+            }
+
+            $cause = ucfirst($campaign['causes']['primary']['name']);
 
             return $cause;
+        });
+
+        $sorted = $grouped->sortBy(function ($campaigns, $key) {
+            // Hacky solution to move the Staff Pick group to the top of the list,
+            // the No Cause group to the end of the list,
+            // and alphabetize everything inbetween.
+            if ($key === 'Staff Pick') {
+                return 'A';
+            }
+
+            if ($key === 'No Cause') {
+                return 'Z';
+            }
+
+            return $key;
         });
 
         return $grouped->toArray();

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -2,17 +2,25 @@
 
 namespace Rogue\Services;
 
+use Rogue\Services\Phoenix;
 use Illuminate\Support\Facades\DB;
 use Rogue\Repositories\CacheRepository;
 
 class CampaignService
 {
     /**
+     * Phoenix instance
+     *
+     * @var Rogue\Services\Phoenix
+     */
+    protected $phoenix;
+
+    /**
      * Create new Registrar instance.
      */
-    public function __construct()
+    public function __construct(Phoenix $phoenix)
     {
-        $this->phoenix = new Phoenix;
+        $this->phoenix = $phoenix;
         $this->cache = new CacheRepository;
     }
 
@@ -154,6 +162,11 @@ class CampaignService
         return $sorted->toArray();
     }
 
+    /**
+     * Get a distinct set of campaign ids from the signups table.
+     *
+     * @return array $ids
+     */
     public function getCampaignIdsFromSignups()
     {
         $campaigns = DB::table('signups')->distinct()->select('campaign_id')->get();

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -65,6 +65,7 @@ class Phoenix extends RestApiClient
 
         return is_null($response) ? null : $response;
     }
+
     /**
      * Send a GET request to return a campaign with the specified id.
      *

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -52,4 +52,29 @@ class Phoenix extends RestApiClient
 
         return $response;
     }
+
+    /**
+     * Send a GET request to return all campaigns matching a given query.
+     *
+     * @param  array  $params
+     * @return object|null
+     */
+    public function getAllCampaigns($params = [])
+    {
+        $response = $this->get('campaigns', $params);
+
+        return is_null($response) ? null : $response;
+    }
+    /**
+     * Send a GET request to return a campaign with the specified id.
+     *
+     * @param  string $id
+     * @return object|null
+     */
+    public function getCampaign($id)
+    {
+        $response = $this->get('campaigns/' . $id);
+
+        return is_null($response) ? null : $response;
+    }
 }

--- a/resources/assets/components/CampaignTable/index.js
+++ b/resources/assets/components/CampaignTable/index.js
@@ -10,7 +10,7 @@ class CampaignTable extends React.Component {
     return (
       <div className="table-responsive container__block">
         <h2>{cause}</h2>
-        <Table key={cause} className="table" headings={['Campaign Name', 'Approved', 'Pending', 'Rejected', 'Deleted']} data={this.props.campaigns} />
+        <Table key={cause} className="table" headings={['Campaign Name', 'Approved', 'Pending', 'Rejected']} data={this.props.campaigns} />
       </div>
     )
   }

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -8,7 +8,6 @@ class Row extends React.Component {
         <td className="table__cell">{this.props.approved}</td>
         <td className="table__cell">{this.props.pending}</td>
         <td className="table__cell">{this.props.rejected}</td>
-        <td className="table__cell">{this.props.deleted}</td>
       </tr>
     )
   }

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -1,17 +1,10 @@
 import React from 'react';
 
 class Row extends React.Component {
-
-  defaultProps: {
-      campaign: {
-        title: 'No Title',
-      }
-    };
-
   render() {
     return (
       <tr className="table__row">
-        <td className="table__cell"><a href="#">{this.props.campaign.title}</a></td>
+        <td className="table__cell"><a href="#">{this.props.campaign ? this.props.campaign.title : 'Campaign Not Found'}</a></td>
         <td className="table__cell">{this.props.approved}</td>
         <td className="table__cell">{this.props.pending}</td>
         <td className="table__cell">{this.props.rejected}</td>

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -1,14 +1,21 @@
 import React from 'react';
 
 class Row extends React.Component {
+
+  defaultProps: {
+      campaign: {
+        title: 'No Title',
+      }
+    };
+
   render() {
     return (
       <tr className="table__row">
-        <td className="table__cell"><a href="#">{this.props.campaign.name}</a></td>
-        <td className="table__cell">{this.props.campaign.approved}</td>
-        <td className="table__cell">{this.props.campaign.pending}</td>
-        <td className="table__cell">{this.props.campaign.rejected}</td>
-        <td className="table__cell">{this.props.campaign.deleted}</td>
+        <td className="table__cell"><a href="#">{this.props.campaign.title}</a></td>
+        <td className="table__cell">{this.props.approved}</td>
+        <td className="table__cell">{this.props.pending}</td>
+        <td className="table__cell">{this.props.rejected}</td>
+        <td className="table__cell">{this.props.deleted}</td>
       </tr>
     )
   }

--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -11,7 +11,7 @@ class Table extends React.Component {
     });
 
     const rows = this.props.data.map((content, index) => {
-      return <Row key={index} campaign={content} />;
+      return <Row key={index} campaign={content} approved='0' pending='0' rejected='0' deleted='0' />;
     });
 
     return (

--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -11,7 +11,7 @@ class Table extends React.Component {
     });
 
     const rows = this.props.data.map((content, index) => {
-      return <Row key={index} campaign={content} approved pending rejected deleted />;
+      return <Row key={index} campaign={content} approved pending rejected />;
     });
 
     return (

--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -11,7 +11,7 @@ class Table extends React.Component {
     });
 
     const rows = this.props.data.map((content, index) => {
-      return <Row key={index} campaign={content} approved='0' pending='0' rejected='0' deleted='0' />;
+      return <Row key={index} campaign={content} approved pending rejected deleted />;
     });
 
     return (


### PR DESCRIPTION
#### What's this PR do?

Creates a `CampaignService` that first looks for campaigns in cache, if it finds them then loads them from there, if it doesn't find them then it makes a request to phoenix for the campaign info. 

Grabs a set of campaign ids for each signup we have in rogue. Gets their full campaign object, groups them by cause, and passes it to the frontend to render overview tables. 

#### Any background context you want to provide?

We could probably think of better ways to grab the campaigns we are interested in. I will be looking into this when trying to figure out post counts based on status. For now, I am just grabbing them directly from the DB. 

The `CampaignService` class and the `Registrar` class are very similar and I would like to look into how to extract some of the shared logic. 

#### Relevant tickets
Fixes #151 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.