### PR TITLE
Total reaciton count query

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -32,11 +32,24 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query, which we can either filter (below)
         // or paginate to retrieve all signup records.
-        $query = $this->newQuery(Signup::class);
+        // $query = $this->newQuery(Signup::class);
+        $query = Signup::withCount('post')
 
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Signup::$indexes);
 
         return $this->paginatedCollection($query, $request);
     }
+
+
+    /**
+     * Query for total reactions for a photo.
+     *
+     * @param int $reactionableId
+     * @return int total count
+     */
+    // public static function withReactionCount($reactionableId)
+    // {
+    //     return self::where('id', $reactionableId)->withCount('reactions')->first();
+    // }
 }

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -3,6 +3,7 @@
 namespace Rogue\Http\Transformers;
 
 use Rogue\Models\Post;
+use Rogue\Models\Photo;
 use League\Fractal\TransformerAbstract;
 
 class PostTransformer extends TransformerAbstract
@@ -15,8 +16,6 @@ class PostTransformer extends TransformerAbstract
      */
     public function transform(Post $post)
     {
-
-        dd(Post::withReactionCount($post->postable_id));
         return [
             'postable_id' => $post->postable_id,
             'post_event_id' => $post->event_id,
@@ -29,7 +28,7 @@ class PostTransformer extends TransformerAbstract
                 ],
                 'caption' => $post->content->caption,
                 'status' => $post->content->status,
-                'total_reactions' => count($post->content->reactions),
+                'total_reactions' => Photo::withReactionCount($post->postable_id)->reactions_count,
                 'remote_addr' => $post->content->remote_addr,
                 'post_source' => $post->content->source,
                 'created_at' => $post->content->created_at->toIso8601String(),

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -15,6 +15,8 @@ class PostTransformer extends TransformerAbstract
      */
     public function transform(Post $post)
     {
+
+        dd(Post::withReactionCount($post->postable_id));
         return [
             'postable_id' => $post->postable_id,
             'post_event_id' => $post->event_id,

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -28,7 +28,7 @@ class PostTransformer extends TransformerAbstract
                 ],
                 'caption' => $post->content->caption,
                 'status' => $post->content->status,
-                'total_reactions' => Photo::withReactionCount($post->postable_id)->reactions_count,
+                'total_reactions' => count($post->content->reactions),
                 'remote_addr' => $post->content->remote_addr,
                 'post_source' => $post->content->source,
                 'created_at' => $post->content->created_at->toIso8601String(),

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -32,15 +32,4 @@ class Photo extends Model
     {
         return $this->morphMany(Reaction::class, 'reactionable');
     }
-
-    /**
-     * Query for total reactions for a photo.
-     *
-     * @param int $reactionableId
-     * @return int total count
-     */
-    public static function withReactionCount($reactionableId)
-    {
-        return self::where('id', $reactionableId)->withCount('reactions')->first();
-    }
 }

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -33,5 +33,14 @@ class Photo extends Model
         return $this->morphMany(Reaction::class, 'reactionable');
     }
 
-    // @TODO: Make a withReactionCount model function that uses ::withCount
+    /**
+     * Query for total reactions for a photo.
+     *
+     * @param int $reactionableId
+     * @return int total count
+     */
+    public static function withReactionCount($reactionableId)
+    {
+        return self::where('id', $reactionableId)->withCount('reactions')->first();
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -49,20 +49,6 @@ class Post extends Model
     }
 
     /**
-     * Query for total reactions for a post.
-     *
-     * @param int $postableId
-     * @param int $postableType
-     * @return int total count
-     */
-    public static function withReactionCount($postableId, $postableType)
-    {
-        return self::withCount(['reactions' => function ($query) use ($postableId, $postableType) {
-            $query->where(['postable_id' => $postableId, 'postable_type' => $postableType]);
-        }])->get();
-    }
-
-    /**
      * Each post has one review.
      */
     public function review()


### PR DESCRIPTION
#### What's this PR do?
- Deletes `withReactionCount` model function from Post.php
- Adds `withReactionCount` model function to Photo.php 
  - Updates to use this model function in the PostTransformer to enhance the performance of the query

#### How should this be reviewed?
- `GET /activity` and `POST /reactions` endpoint should still work and return `total_reactions`

#### Any background context you want to provide?
Using this new model function, you can see that less queries are being made (no separate reaction query): 
![screen shot 2017-03-16 at 4 00 33 pm](https://cloud.githubusercontent.com/assets/9019452/24016315/0ca215f0-0a62-11e7-92d6-19bea49e19c3.png)

compared to [before](https://cloud.githubusercontent.com/assets/9019452/23964198/13662d6e-098a-11e7-805b-4348eb25d2e7.png). 


#### Relevant tickets
Fixes #161 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.