### PR TITLE
removes withReactionCount model function

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -49,20 +49,6 @@ class Post extends Model
     }
 
     /**
-     * Query for total reactions for a post.
-     *
-     * @param int $postableId
-     * @param int $postableType
-     * @return int total count
-     */
-    public static function withReactionCount($postableId, $postableType)
-    {
-        return self::withCount(['reactions' => function ($query) use ($postableId, $postableType) {
-            $query->where(['postable_id' => $postableId, 'postable_type' => $postableType]);
-        }])->get();
-    }
-
-    /**
      * Each post has one review.
      */
     public function review()


### PR DESCRIPTION
#### What's this PR do?
Somehow, I accidentally pushed up the `withReactionCount` model function in Post.php. This removes this code that we don't use. 

#### How should this be reviewed?
👀 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.