### PR TITLE
New event logic

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -12,7 +12,7 @@ use Rogue\Http\Transformers\PostTransformer;
 class PostsController extends ApiController
 {
     /**
-     * The photo service instance.
+     * The post service instance.
      *
      * @var Rogue\Services\PostService
      */
@@ -43,7 +43,6 @@ class PostsController extends ApiController
         $this->posts = $posts;
         $this->signups = $signups;
 
-        // Now we have one PostTransformer to handle returning a Post to the API request.
         $this->transformer = new PostTransformer;
     }
 
@@ -57,9 +56,6 @@ class PostsController extends ApiController
     public function store(PostRequest $request)
     {
         $transactionId = incrementTransactionId($request);
-
-        // @TODO - Remove. This is temporary. Just hardcoding some params in the request that the client would normally pass. But we assume everything is a photo post from a user at the moment.
-        $request['submission_type'] = 'user';
 
         $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
 

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -4,12 +4,6 @@ namespace Rogue\Http\Requests;
 
 class PostRequest extends Request
 {
-    protected $rules = [
-        'northstar_id' => 'required|string',
-        'campaign_id' => 'required|int',
-        'campaign_run_id' => 'required|int',
-    ];
-
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -27,47 +21,15 @@ class PostRequest extends Request
      */
     public function rules()
     {
-        if (! isset($this->request->event_type)) {
-            return [
-                'event_type' => 'required|in:post_photo,review_photo',
-            ];
-        }
-
-        return $this->getRules($this->request);
-    }
-
-    /**
-     * Determines the validation ruleset to use for a particular type of post.
-     *
-     * @param  object $request
-     * @return array|null
-     */
-    protected function getRules($request)
-    {
-        switch ($request->event_type) {
-            case 'post_photo':
-                return array_merge($this->rules, $this->getPhotoRules());
-
-                break;
-
-            default:
-                break;
-        }
-    }
-
-    /**
-     * Defines the ruleset for photo posts.
-     *
-     * @return array
-     */
-    protected function getPhotoRules()
-    {
         return [
+            'northstar_id' => 'required|string',
+            'campaign_id' => 'required|int',
+            'campaign_run_id' => 'required|int',
             'caption' => 'string',
             'status' => 'pending',
             'source' => 'string',
             'remote_addr' => 'ip',
-            'file' => 'string', // @TODO - should do some better validation around files.
+            // 'file' => 'string', // @TODO - should do some better validation around files.
         ];
     }
 }

--- a/app/Http/Transformers/PhotoTransformer.php
+++ b/app/Http/Transformers/PhotoTransformer.php
@@ -1,6 +1,7 @@
 <?php
 
 // @TODO - to be removed when we get rid of this table.
+
 namespace Rogue\Http\Transformers;
 
 use Rogue\Models\Photo;
@@ -26,7 +27,7 @@ class PhotoTransformer extends TransformerAbstract
     public function transform(Photo $photo)
     {
         return [
-            'id' => $photo->id
+            'id' => $photo->id,
             'signup_id' => $photo->post->signup_id,
             'northstar_id' => $photo->post->northstar_id,
             'campaign_id' => $photo->post->signup->campaign_id,

--- a/app/Http/Transformers/PhotoTransformer.php
+++ b/app/Http/Transformers/PhotoTransformer.php
@@ -1,5 +1,6 @@
 <?php
 
+// @TODO - to be removed when we get rid of this table.
 namespace Rogue\Http\Transformers;
 
 use Rogue\Models\Photo;
@@ -25,12 +26,12 @@ class PhotoTransformer extends TransformerAbstract
     public function transform(Photo $photo)
     {
         return [
-            'event_id' => $photo->post->event_id,
+            'id' => $photo->id
             'signup_id' => $photo->post->signup_id,
             'northstar_id' => $photo->post->northstar_id,
             'campaign_id' => $photo->post->signup->campaign_id,
             'campaign_run_id' => $photo->post->signup->campaign_run_id,
-            'post' => [
+            'content' => [
                 'type' => 'photo',
                 'media' => [
                     'url' => $photo->file_url,

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -16,13 +16,14 @@ class PostTransformer extends TransformerAbstract
     public function transform(Post $post)
     {
         return [
+            'id' => $post->id,
+            'signup_id' => $post->signup_id,
+            'northstar_id' => $post->northstar_id,
             'postable_id' => $post->postable_id,
-            'post_event_id' => $post->event_id,
-            'submission_type' => $post->event->submission_type,
             'postable_type' => $post->postable_type,
             'status' => $post->status,
-            'remote_addr' => $post->remote_addr,
             'post_source' => $post->source,
+            'remote_addr' => $post->remote_addr,
             'content' => [
                 'media' => [
                     'url' => $post->content->file_url,

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -16,7 +16,6 @@ class SignupTransformer extends TransformerAbstract
      */
     protected $defaultIncludes = [
         'posts',
-        'events',
     ];
 
     /**
@@ -38,8 +37,6 @@ class SignupTransformer extends TransformerAbstract
     {
         return [
             'signup_id' => $signup->id,
-            'signup_event_id' => $signup->event_id,
-            'submission_type' => $signup->events->first()->submission_type,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
@@ -63,19 +60,6 @@ class SignupTransformer extends TransformerAbstract
         $post = $signup->posts;
 
         return $this->collection($post, new PostTransformer);
-    }
-
-    /**
-     * Include the event
-     *
-     * @param \Rogue\Models\Signup $signup
-     * @return \League\Fractal\Resource\Item
-     */
-    public function includeEvents(Signup $signup)
-    {
-        $event = $signup->events;
-
-        return $this->collection($event, new EventTransformer);
     }
 
     /**

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Http\Transformers;
 
-use Rogue\Models\Event;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use League\Fractal\TransformerAbstract;

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
      *
      * @var array
      */
-    protected $fillable = [];
+    protected $fillable = ['eventable_id', 'eventable_type', 'content'];
 
     public function eventable()
     {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -11,16 +11,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['event_id', 'signup_id', 'northstar_id', 'status', 'source', 'remote_addr'];
-
-    protected $primaryKey = ['event_id'];
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
+    protected $fillable = ['id', 'signup_id', 'northstar_id', 'postable_id', 'postable_type', 'status', 'source', 'remote_addr'];
 
     /**
      * Returns Post data

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -30,14 +30,4 @@ class ModelServiceProvider extends ServiceProvider
             ]);
         });
     }
-
-    /**
-     * Register the application services.
-     *
-     * @return void
-     */
-    public function register()
-    {
-
-    }
 }

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rogue\Providers;
+
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+use Illuminate\Support\ServiceProvider;
+
+class ModelServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Signup::created(function ($signup) {
+            $signup->events()->create([
+                'content' => $signup->toJson(),
+            ]);
+        });
+
+        Post::created(function ($post) {
+            $post->events()->create([
+                'content' => $post->toJson(),
+            ]);
+        });
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+
+    }
+}

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -15,12 +15,15 @@ class ModelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // When Signups are saved create an event for them.
         Signup::saved(function ($signup) {
             $signup->events()->create([
+                // @TODO - Should this just be the attributes that have changed? Or the whole thing?
                 'content' => $signup->toJson(),
             ]);
         });
 
+        // When Posts are saved create an event for them.
         Post::saved(function ($post) {
             $post->events()->create([
                 'content' => $post->toJson(),

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -15,13 +15,13 @@ class ModelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Signup::created(function ($signup) {
+        Signup::saved(function ($signup) {
             $signup->events()->create([
                 'content' => $signup->toJson(),
             ]);
         });
 
-        Post::created(function ($post) {
+        Post::saved(function ($post) {
             $post->events()->create([
                 'content' => $post->toJson(),
             ]);

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -30,4 +30,14 @@ class ModelServiceProvider extends ServiceProvider
             ]);
         });
     }
+
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
 }

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -87,6 +87,12 @@ class PhotoRepository
             $post->updated_at = $data['created_at'];
 
             $post->save(['timestamps' => false]);
+
+
+            $post->events->first()->created_at = $data['created_at'];
+            $post->events->first()->updated_at = $data['created_at'];
+
+            $post->events->first()->save(['timestamps' => false]);
         } else {
             // @TODO: keep this after the migration
             $post->content()->associate($photo);

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -35,7 +35,7 @@ class PhotoRepository
     }
 
     /**
-     * Create an event.
+     * Create a Photo.
      *
      * @param  array $data
      * @param  int $signupId
@@ -107,7 +107,8 @@ class PhotoRepository
     public function update($signup, $data)
     {
         $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
-        // Triggeres model event that logs the updated signup.
+
+        // Triggers model event that logs the updated signup in the events table.
         $signup->save();
 
         // If there is a file, create a new photo post.

--- a/app/Repositories/PhotoRepository.php
+++ b/app/Repositories/PhotoRepository.php
@@ -88,7 +88,6 @@ class PhotoRepository
 
             $post->save(['timestamps' => false]);
 
-
             $post->events->first()->created_at = $data['created_at'];
             $post->events->first()->updated_at = $data['created_at'];
 

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -15,30 +15,29 @@ class SignupRepository
     public function create($data)
     {
         // Create the signup
-        $signup = Signup::create([
-            'northstar_id' => $data['northstar_id'],
-            'campaign_id' => $data['campaign_id'],
-            'campaign_run_id' => $data['campaign_run_id'],
-            'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
-            'quantity_pending' => isset($data['quantity_pending']) ? $data['quantity_pending'] : null,
-            'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
-            'source' => isset($data['source']) ? $data['source'] : null,
-        ]);
+        $signup = new Signup;
 
-        // Let Laravel take care of the timestamps unless they are specified in the request
-        // @TODO: keep only the else after the migration
+        $signup->northstar_id = $data['northstar_id'];
+        $signup->campaign_id = $data['campaign_id'];
+        $signup->campaign_run_id = $data['campaign_run_id'];
+        $signup->quantity = isset($data['quantity']) ? $data['quantity'] : null;
+        $signup->quantity_pending = isset($data['quantity_pending']) ? $data['quantity_pending'] : null;
+        $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
+        $signup->source = isset($data['source']) ? $data['source'] : null;
+
         if (isset($data['created_at'])) {
-            // Set the created_at time
+            // Manually set created and updated times for the signup
             $signup->created_at = $data['created_at'];
-
-            // Set the updated time if provided, if not, assume no updates
-            if (isset($data['updated_at'])) {
-                $signup->updated_at = $data['updated_at'];
-            } else {
-                $signup->updated_at = $data['created_at'];
-            }
-
+            $signup->updated_at = isset($data['updated_at']) ? $data['updated_at'] : $data['created_at'];
             $signup->save(['timestamps' => false]);
+
+            // Manually update the signup event timestamp.
+            $event = $signup->events->first();
+            $event->created_at = $data['created_at'];
+            $event->updated_at = isset($data['updated_at']) ? $data['updated_at'] : $data['created_at'];
+            $event->save(['timestamps' => false]);
+        } else {
+            $signup->save();
         }
 
         return $signup;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -15,16 +15,8 @@ class SignupRepository
      */
     public function create($data)
     {
-        // Add these values to pass to the Event
-        $data['event_type'] = 'signup';
-        $data['submission_type'] = 'user';
-
-        // Create the signup event
-        $event = Event::create($data);
-
         // Create the signup
-        $signup = $event->signup()->create([
-            'event_id' => $event->id,
+        $signup = Signup::create([
             'northstar_id' => $data['northstar_id'],
             'campaign_id' => $data['campaign_id'],
             'campaign_run_id' => $data['campaign_run_id'],
@@ -37,28 +29,17 @@ class SignupRepository
         // Let Laravel take care of the timestamps unless they are specified in the request
         // @TODO: keep only the else after the migration
         if (isset($data['created_at'])) {
-            // Associate the event with the signup
-            $event->signup_id = $signup->id;
-
             // Set the created_at time
             $signup->created_at = $data['created_at'];
-            $event->created_at = $data['created_at'];
 
             // Set the updated time if provided, if not, assume no updates
             if (isset($data['updated_at'])) {
                 $signup->updated_at = $data['updated_at'];
-                $event->updated_at = $data['updated_at'];
             } else {
                 $signup->updated_at = $data['created_at'];
-                $event->updated_at = $data['created_at'];
             }
 
             $signup->save(['timestamps' => false]);
-            $event->save(['timestamps' => false]);
-        } else {
-            // Now that the signup exists, set the signup_id on the signup event
-            $event->signup_id = $signup->id;
-            $event->save();
         }
 
         return $signup;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Repositories;
 
-use Rogue\Models\Event;
 use Rogue\Models\Signup;
 
 class SignupRepository

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -16,6 +16,7 @@ class PostService
 
     public function  __construct()
     {
+        // @TODO - when we remove the photos table this will also be removed an favor a PostRepository.
         $this->repository = app('Rogue\Repositories\PhotoRepository');
     }
 
@@ -36,9 +37,9 @@ class PostService
 
         // POST reportback back to Phoenix, unless told not to.
         // If request fails, record in failed_jobs table.
-        // if (! isset($data['do_not_forward'])) {
-        //     dispatch(new SendPostToPhoenix($post));
-        // }
+        if (! isset($data['do_not_forward'])) {
+            dispatch(new SendPostToPhoenix($post));
+        }
 
         return $post;
     }
@@ -70,9 +71,9 @@ class PostService
 
         // Post reportback back to Phoenix, unless told not to.
         // If request fails, record in failed_jobs table.
-        // if (! isset($data['do_not_forward'])) {
-        //     dispatch(new SendPostToPhoenix($post, isset($data['file'])));
-        // }
+        if (! isset($data['do_not_forward'])) {
+            dispatch(new SendPostToPhoenix($post, isset($data['file'])));
+        }
 
         return $post;
     }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -4,7 +4,6 @@ namespace Rogue\Services;
 
 use Rogue\Models\Post;
 use Rogue\Jobs\SendPostToPhoenix;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PostService
 {
@@ -14,7 +13,7 @@ class PostService
      */
     protected $repository;
 
-    public function  __construct()
+    public function __construct()
     {
         // @TODO - when we remove the photos table this will also be removed an favor a PostRepository.
         $this->repository = app('Rogue\Repositories\PhotoRepository');

--- a/config/app.php
+++ b/config/app.php
@@ -166,6 +166,7 @@ return [
         Rogue\Providers\AuthServiceProvider::class,
         Rogue\Providers\EventServiceProvider::class,
         Rogue\Providers\RouteServiceProvider::class,
+        Rogue\Providers\ModelServiceProvider::class,
     ],
 
     /*

--- a/tests/ActivityApiTest.php
+++ b/tests/ActivityApiTest.php
@@ -62,9 +62,6 @@ class ActivityApiTest extends TestCase
     public function testActivityIndexWithCampaignIdQuery()
     {
         $signup = factory(Signup::class)->create();
-        $event = Event::all()->first();
-        $event->signup_id = $signup->id;
-        $event->save();
 
         $this->json('GET', $this->activityApiUrl . '?filter[campaign_id]=' . $signup->campaign_id);
 
@@ -88,9 +85,6 @@ class ActivityApiTest extends TestCase
     public function testActivityIndexWithCampaignRunIdQuery()
     {
         $signup = factory(Signup::class)->create();
-        $event = Event::all()->first();
-        $event->signup_id = $signup->id;
-        $event->save();
 
         $this->json('GET', $this->activityApiUrl . '?filter[campaign_run_id]=' . $signup->campaign_run_id);
 

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -44,7 +44,6 @@ class PostApiTest extends TestCase
             'crop_width'       => 100,
             'crop_height'      => 100,
             'crop_rotate'      => 90,
-            'event_type'       => 'post_photo',
         ];
 
 
@@ -56,11 +55,6 @@ class PostApiTest extends TestCase
         $this->assertResponseStatus(200);
 
         $response = $this->decodeResponseJson();
-
-        // Make sure we created a reportback item for the reportback.
-        $this->seeInDatabase('events', [
-            'caption' => $response['data']['content']['caption'],
-        ]);
 
         // Make sure the file_url is saved to the database.
         $this->seeInDatabase('photos', ['file_url' => $response['data']['content']['media']['url']]);

--- a/tests/SignupApiTest.php
+++ b/tests/SignupApiTest.php
@@ -33,23 +33,18 @@ class SignupApiTest extends TestCase
         // Send the signup and make sure the response has the data we expect
         $response = $this->json('POST', $this->signupsApiUrl, $signup)
         				 ->seeJson([
-        				 	'northstar_id' => $signup['northstar_id'],
-        				 	'campaign_id' => $signup['campaign_id'],
-        				 	'campaign_run_id' => $signup['campaign_run_id'],
-        				 	'source' => 'the-fox-den',
-        				 	'quantity' => null,
-        				 	'why_participated' => null,
-        					]);
+                            'northstar_id' => $signup['northstar_id'],
+                            'campaign_id' => $signup['campaign_id'],
+                            'campaign_run_id' => $signup['campaign_run_id'],
+                            'signup_source' => 'the-fox-den',
+                            'quantity' => null,
+                            'why_participated' => null,
+                        ]);
 
         // Make sure we get the 201 Created response
         $this->assertResponseStatus(201);
 
         $response = $this->decodeResponseJson();
-
-        // Make sure the signup event got created
-        $this->seeInDatabase('events', [
-            'northstar_id' => $response['data']['northstar_id'],
-        ]);
 
         // Make sure the signup got created
         $this->seeInDatabase('signups', [


### PR DESCRIPTION
#### What's this PR do?

Moves out all the manual event creation logic out of the `SignupRepository` and `PhotoRepository`  and moves it into a service provider that automatically creates events when the model is saved (which is triggered on creation and update).

Updates tests to work with this new logic/event schema. NOTE: reviews tests still fail but wanted to work on that separately to keep this contained. 


#### How should this be reviewed?

This can probably be reviewed commit by commit. It's a little hairy to read because there was a lot of deletions. 

We also need a lot of testing on this to make sure everything still works as expected. The testing will be easier when this is deployed on QA.

#### Relevant tickets
Fixes #167 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.