### PR TITLE
Pass user info to the front end and display it

### DIFF
--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -11,6 +11,14 @@ class InboxItem extends React.Component {
     }
   }
 
+  calculateAge(date) {
+    const birthdate = new Date(date);
+    const today = Date.now();
+    const age = Math.floor((today - birthdate) / 31536000000);
+
+    return age;
+  }
+
   render() {
     const post = this.props.details;
 
@@ -20,6 +28,9 @@ class InboxItem extends React.Component {
           <img src={this.displayImage(post['postable']['file_url'])}/>
         </div>
         <div className="container__block -half">
+          <h2>{post['user']['first_name']} {post['user']['last_name']}, {this.calculateAge(post['user']['birthdate'])}</h2>
+          <p><em>{post['user']['email']}</em></p>
+          <p><em>{post['user']['mobile']}</em></p>
           <p><strong>Quantity: </strong> {post['signup']['quantity']}</p>
           <h4>Photo Caption</h4>
           <p>{post['postable']['caption']}</p>

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { map } from 'lodash';
+import { calculateAge } from '../../helpers';
 
 class InboxItem extends React.Component {
   displayImage(photo_url) {
@@ -11,14 +12,6 @@ class InboxItem extends React.Component {
     }
   }
 
-  calculateAge(date) {
-    const birthdate = new Date(date);
-    const today = Date.now();
-    const age = Math.floor((today - birthdate) / 31536000000);
-
-    return age;
-  }
-
   render() {
     const post = this.props.details;
 
@@ -28,7 +21,7 @@ class InboxItem extends React.Component {
           <img src={this.displayImage(post['postable']['file_url'])}/>
         </div>
         <div className="container__block -half">
-          <h2>{post['user']['first_name']} {post['user']['last_name']}, {this.calculateAge(post['user']['birthdate'])}</h2>
+          <h2>{post['user']['first_name']} {post['user']['last_name']}, {calculateAge(post['user']['birthdate'])}</h2>
           <p><em>{post['user']['email']}</em></p>
           <p><em>{post['user']['mobile']}</em></p>
           <p><strong>Quantity: </strong> {post['signup']['quantity']}</p>

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -10,3 +10,11 @@ export function ready(fn) {
     document.addEventListener('DOMContentLoaded', fn);
   }
 }
+
+export function calculateAge(date) {
+	const birthdate = new Date(date);
+	const today = Date.now();
+	const age = Math.floor((today - birthdate) / 31536000000);
+
+	return age;
+};


### PR DESCRIPTION
#### What's this PR do?
Pulls the user information at the same time that we get the signup and posts for a certain campaign run. The user info is nested under each post. Then, the following are displayed on the front end:
- `first_name`
- `last_name`
- age (there is a helper to calculate this from the `birthdate` returned by Northstar)
- `email`
- `mobile` phone number

It looks like this (my account doesn't have a mobile number so there is a blank where the phone number would be):
![image](https://cloud.githubusercontent.com/assets/4240292/24425197/4880607c-13d1-11e7-807a-49560795dd7f.png)

#### How should this be reviewed?
👀  See if it looks okay and if I am calculating age correctly.

#### Any background context you want to provide?
There's nothing being conditionally displayed right now, so if a member doesn't have a mobile number stored with us, there is still a blank space for it instead of shifting everything up.

#### Relevant tickets
Fixes #183

#### Checklist
- [ ] Tested on staging.