### PR TITLE
adds tertiary button to delete a post 

### DIFF
--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -32,6 +32,8 @@ class InboxItem extends React.Component {
           <ul className="form-actions -inline">
             <li> <input className="button" value="Accepted"/></li>
             <li> <input className="button -secondary" value="Rejected"/></li>
+            <br/>
+            <li> <input className="button -tertiary" value="Delete"/></li>
           </ul>
           <h4>Meta</h4>
           <p>


### PR DESCRIPTION
#### What's this PR do?
- Adds a tertiary "Delete" button to delete a post so it's not stored in the database. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
The button should look like this (is it ok it's off center?):
![screen shot 2017-03-29 at 4 09 13 pm](https://cloud.githubusercontent.com/assets/9019452/24474355/5b079296-149a-11e7-89ec-95cafc1db03b.png)

Another option I think could be cool and be extra obvious to not click is the `-danger` button as seen in Aurora:
![screen shot 2017-03-29 at 4 07 41 pm](https://cloud.githubusercontent.com/assets/9019452/24474382/77660dfa-149a-11e7-8934-cb527687a987.png)

Would we prefer the `-danger` button instead? A couple thoughts:
- This is no longer in Forge - does this mean we don't want to use it anymore? 
- The `-danger` button has more clickable area than the `-tertiary` button. Since it's located right under the `ACCEPTED` button, it might cause more room for error, making it easier for an admin to accidentally hit `Delete` instead. 

#### Relevant tickets
Fixes #186 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.