### PR TITLE
Update reactions

### DIFF
--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -76,6 +76,6 @@ class ReactionController extends ApiController
      */
     private function getTotalReactions($postId)
     {
-        return count(Post::find($postId)->reactions());
+        return count(Post::find($postId)->reactions);
     }
 }

--- a/app/Http/Requests/ReactionRequest.php
+++ b/app/Http/Requests/ReactionRequest.php
@@ -22,9 +22,8 @@ class ReactionRequest extends Request
     public function rules()
     {
         return [
-            'reactionable_id' => 'required|int',
-            'reactionable_type' => 'required|in:photo',
             'northstar_id' => 'required',
+            'post_id' => 'required',
         ];
     }
 }

--- a/app/Http/Transformers/ReactionTransformer.php
+++ b/app/Http/Transformers/ReactionTransformer.php
@@ -16,10 +16,8 @@ class ReactionTransformer extends TransformerAbstract
     public function transform(Reaction $reaction)
     {
         return [
-            'reaction_id' => (string) $reaction->id,
             'northstar_id' => $reaction->northstar_id,
-            'reactionable_id' => (string) $reaction->reactionable_id,
-            'reactionable_type' => $reaction->reactionable_type,
+            'post_id' => (string) $reaction->post_id,
             'created_at' => $reaction->created_at,
             'updated_at' => $reaction->updated_at,
             'deleted_at' => $reaction->deleted_at,

--- a/app/Http/Transformers/ReactionTransformer.php
+++ b/app/Http/Transformers/ReactionTransformer.php
@@ -18,9 +18,9 @@ class ReactionTransformer extends TransformerAbstract
         return [
             'northstar_id' => $reaction->northstar_id,
             'post_id' => (string) $reaction->post_id,
-            'created_at' => $reaction->created_at,
-            'updated_at' => $reaction->updated_at,
-            'deleted_at' => $reaction->deleted_at,
+            'created_at' => $reaction->created_at->toIso8601String(),
+            'updated_at' => $reaction->updated_at->toIso8601String(),
+            'deleted_at' => is_null($reaction->deleted_at) ? null : $reaction->deleted_at->toIso8601String(),
         ];
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -36,4 +36,12 @@ class Post extends Model
     {
         return $this->hasOne(Review::class);
     }
+
+    /**
+     * Get the reactions associated with this post.
+     */
+    public function reactions()
+    {
+        return $this->hasMany(Reaction::class);
+    }
 }

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -21,7 +21,7 @@ class Reaction extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'reactionable_id', 'reactionable_type'];
+    protected $fillable = ['id', 'northstar_id', 'post_id'];
 
     /**
      * Each reaction has events.
@@ -32,10 +32,10 @@ class Reaction extends Model
     }
 
     /**
-     * Get all of the owning reactionable models.
+     * Each reaction belongs to a post.
      */
-    public function reactionable()
+    public function post()
     {
-        return $this->morphTo();
+        return $this->belongsTo(Post::class);
     }
 }

--- a/database/migrations/2017_03_31_133505_UpdateReactionsTable.php
+++ b/database/migrations/2017_03_31_133505_UpdateReactionsTable.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateReactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reactions', function (Blueprint $table) {
+            $table->dropColumn('reactionable_id');
+            $table->dropColumn('reactionable_type');
+            $table->integer('post_id')->after('northstar_id')->unsigned();
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reactions', function (Blueprint $table) {
+            $table->morphs('reactionable');
+            $table->dropForeign('reactions_post_id_foreign');
+            $table->dropColumn('post_id');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

This updates the `reactions` table so that we can define a one-to-many relationship between a post and reactions. 

This removes the morphed columns and adds a `post_id` column so that we can define the relationship on the model.

This updates the `ReactionsController` so that the logic works with this new schema. 

#### How should this be reviewed?

Commit. by. commit. 

@chloealee definitely looking for your thoughts here since you worked most on this stuff. I think this makes the aggregate logic easier. 

Also note: All tests are borked at the moment. Will be focusing on those in #197 

#### Relevant tickets
Fixes #166 

