### PR TITLE
Update activity seeder

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -22,6 +22,8 @@ use Rogue\Models\Reportback;
 // Post Factory
 $factory->define(Post::class, function (Generator $faker) {
     return [
+        'url' => 'https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg',
+        'caption' => $this->faker->sentence(),
         'status' => 'pending',
         'source' => 'phoenix-web',
         'remote_addr' => '10.0.2.2',

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -19,15 +19,6 @@ use Rogue\Models\Reportback;
 |
 */
 
-// Photo Factory
-$factory->define(Photo::class, function (Generator $faker) {
-    return [
-        'file_url' => 'https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg',
-        'edited_file_url' => null,
-        'caption' => $this->faker->sentence(),
-    ];
-});
-
 // Post Factory
 $factory->define(Post::class, function (Generator $faker) {
     return [

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -3,7 +3,6 @@
 use Faker\Generator;
 use Rogue\Models\Post;
 use Rogue\Models\User;
-use Rogue\Models\Photo;
 use Rogue\Models\Signup;
 use Rogue\Models\Reaction;
 use Rogue\Models\Reportback;

--- a/database/seeds/ActivitySeeder.php
+++ b/database/seeds/ActivitySeeder.php
@@ -16,18 +16,11 @@ class ActivitySeeder extends Seeder
     {
         // Create 20 signups and activity under those signups.
         factory(Signup::class, 20)->create()->each(function ($signup) {
-            // For each signup, create 3 photos and a post for each photo.
-            // @TODO - this will be temporary until everything lives in the posts table.
-            $photos = factory(Photo::class, 3)->create();
-
-            $photos->each(function ($item, $key) use ($signup) {
-                $post = factory(Post::class)->make([
-                    'signup_id' => $signup->id,
-                    'northstar_id' => $signup->northstar_id,
-                ]);
-
-                $item->post()->save($post);
-            });
+            // Create a signup for each post.
+            $post = factory(Post::class)->create([
+                'signup_id' => $signup->id,
+                'northstar_id' => $signup->northstar_id,
+            ]);
         });
     }
 }

--- a/database/seeds/ActivitySeeder.php
+++ b/database/seeds/ActivitySeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use Rogue\Models\Post;
-use Rogue\Models\Photo;
 use Rogue\Models\Signup;
 use Illuminate\Database\Seeder;
 


### PR DESCRIPTION
#### What's this PR do?
Now that we have removed the `photos` table, this PR removes the seeder logic to populate that table. 

Instead we create 20 signups and create one post for each one. 

#### How should this be reviewed?

Commit by commit

#### Any background context you want to provide?

We can certainly build on what exactly we want the seeded data to look like. For example, should we vary the amount of posts each signup has to make it more realistic? But that doesn't seem like a priority at the moment. 

#### Relevant tickets
Fixes #196 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.