### PR TITLE
/reportbacks - Use new schema and return correct post id

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -39,8 +39,10 @@ class ReportbackController extends ApiController
 
         // 1. Join with signups so we can access the signup data and filter by campaign
         // 2. Only return approved Posts
+        // 3. Select all the fields that we will be using
         $query = $query->join('signups', 'signups.id', '=', 'posts.signup_id')
-            ->where('status', '=', 'approved');
+            ->where('status', '=', 'approved')
+            ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id');
 
         // Only return Posts for the given campaign_id (if there is one)
         if (isset($request->filter)) {

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -17,13 +17,13 @@ class ReportbackTransformer extends TransformerAbstract
     {
         $signup = $post->signup;
         $result = [
-            'id' => $post->postable_id,
+            'id' => $post->id,
             'status' => $post->status,
             'caption' => $post->caption,
             // Add link to review reportback item in Rogue here once that page exists
             // 'uri' => 'link_goes_here'
             'media' => [
-                'uri' => $post->file_url,
+                'uri' => $post->url,
                 'type' => 'image',
             ],
             'created_at' => $post->created_at->toIso8601String(),


### PR DESCRIPTION
#### What's this PR do?
Added a `select` statement to our query to make sure the `id` column is the `post` id, which meant that I also needed to include every other field that we need.

Also grabs the `url` instead of `file_url` since the column is `url` now.

#### How should this be reviewed?
Make sure you have the right `id`s in the right places. Make sure the `url` is not `null`.

#### Any background context you want to provide?
Because we were joining `signups` and `posts` on `signups.id` = `posts.signup_id`, the `id` that ended up in the response belonged to the `signup`. 

#### Relevant tickets
Fixes #204

#### Checklist
- [ ] Documentation added for new features/changed endpoints. - This is already what the docs reflect
- [ ] Tested on staging.
