### PR TITLE
Show all posts underneath the current post

### DIFF
--- a/resources/assets/components/InboxItem/InboxTile.js
+++ b/resources/assets/components/InboxItem/InboxTile.js
@@ -1,21 +1,14 @@
 import React from 'react';
+import { getImageUrlFromProp } from '../../helpers';
 
 class InboxTile extends React.Component {
-  displayImage(photo_url) {
-    if (photo_url == "default") {
-      return "https://pics.onsizzle.com/bork-2411135.png";
-    }
-    else {
-      return photo_url;
-    }
-  }
 
   render() {
     const post = this.props.details;
 
     return (
       <li>
-        <img src={this.displayImage(post['url'])}/>
+        <img src={getImageUrlFromProp(post)}/>
       </li>
     )
   }

--- a/resources/assets/components/InboxItem/InboxTile.js
+++ b/resources/assets/components/InboxItem/InboxTile.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+class InboxTile extends React.Component {
+  displayImage(photo_url) {
+    if (photo_url == "default") {
+      return "https://pics.onsizzle.com/bork-2411135.png";
+    }
+    else {
+      return photo_url;
+    }
+  }
+
+  render() {
+    const post = this.props.details;
+
+    return (
+      <li>
+        <img src={this.displayImage(post['url'])}/>
+      </li>
+    )
+  }
+}
+
+export default InboxTile;

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { calculateAge } from '../../helpers';
+import { calculateAge, getImageUrlFromProp } from '../../helpers';
 import { remove, map, clone } from 'lodash';
 
 import Tags from '../Tags';
@@ -18,15 +18,6 @@ class InboxItem extends React.Component {
     this.setState({
       status: 'accepted',
     });
-  }
-
-  displayImage(photo_url) {
-    if (photo_url == "default") {
-      return "https://pics.onsizzle.com/bork-2411135.png";
-    }
-    else {
-      return photo_url;
-    }
   }
 
   getOtherPosts(post) {
@@ -50,7 +41,7 @@ class InboxItem extends React.Component {
     return (
       <div className="container__row">
         <div className="container__block -half">
-          <img src={this.displayImage(post['url'])}/>
+          <img src={getImageUrlFromProp(post)}/>
           <ul className="gallery -quartet">
           { map(this.getOtherPosts(post), (post, key) => <InboxTile key={key} details={post} />) }
           </ul>

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import { map } from 'lodash';
 import { calculateAge } from '../../helpers';
+import { remove } from 'lodash';
+import { map } from 'lodash';
 
 import Tags from '../Tags';
+import InboxTile from './InboxTile';
 
 class InboxItem extends React.Component {
   constructor () {
@@ -28,6 +30,21 @@ class InboxItem extends React.Component {
     }
   }
 
+  getOtherPosts(post) {
+    const post_id = post['id'];
+    console.log(post_id);
+    // get array of posts
+    var other_posts = post['signup']['posts'];
+
+    // find index that has that post_id
+    const big_post = _.remove(other_posts, function(current_post) {
+      return current_post['id'] == post_id;
+    });
+
+    // return the rest of the original array
+    return other_posts;
+  }
+
   render() {
     const post = this.props.details;
 
@@ -35,6 +52,9 @@ class InboxItem extends React.Component {
       <div className="container__row">
         <div className="container__block -half">
           <img src={this.displayImage(post['url'])}/>
+          <ul className="gallery -quartet">
+          { map(this.getOtherPosts(post), (post, key) => <InboxTile key={key} details={post} />) }
+          </ul>
         </div>
         <div className="container__block -half">
           <h2>{post['user']['first_name']} {post['user']['last_name']}, {calculateAge(post['user']['birthdate'])}</h2>

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { calculateAge } from '../../helpers';
-import { remove } from 'lodash';
-import { map } from 'lodash';
+import { remove, map, clone } from 'lodash';
 
 import Tags from '../Tags';
 import InboxTile from './InboxTile';
@@ -32,12 +31,12 @@ class InboxItem extends React.Component {
 
   getOtherPosts(post) {
     const post_id = post['id'];
-    console.log(post_id);
-    // get array of posts
-    var other_posts = post['signup']['posts'];
 
-    // find index that has that post_id
-    const big_post = _.remove(other_posts, function(current_post) {
+    // get array of posts
+    const other_posts = clone(post['signup']['posts']);
+
+    // find index that has that post_id and remove
+    const big_post = remove(other_posts, function(current_post) {
       return current_post['id'] == post_id;
     });
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -18,3 +18,14 @@ export function calculateAge(date) {
 
 	return age;
 };
+
+export function getImageUrlFromProp(photoProp) {
+	const photo_url = photoProp['url'];
+
+	if (photo_url == "default") {
+	  return "https://pics.onsizzle.com/bork-2411135.png";
+	}
+	else {
+	  return photo_url;
+	}
+};


### PR DESCRIPTION
#### What's this PR do?
On the inbox page, underneath a post, we now show all the other posts under that signup. They are tiny and adorable. I made a new component called `InboxTile` and they are all arranged in to a [quartet gallery](http://forge.dosomething.org/#gallery-quartet).

![image](https://cloud.githubusercontent.com/assets/4240292/24879562/5291d6d4-1e05-11e7-8884-0593023c35cc.png)

#### How should this be reviewed?
Does it visually look right and does the way I handled the data make sense?

#### Relevant tickets
Fixes #211

#### Checklist
- [ ] Tested on staging.