### PR TITLE
Overview aggregates

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -63,12 +63,9 @@ class CampaignsController extends Controller
     /**
      * Show particular campaign inbox.
      */
-    public function show($campaign_run_id)
+    public function show($campaignId)
     {
-        // Pull in all signups for the given run that have pending posts, and include their pending posts
-        $signups = Signup::whereHas('posts', function ($query) {
-            $query->where('status', 'pending');
-        })->where('campaign_run_id', $campaign_run_id)->with('posts')->get();
+        $signups = Signup::campaign($campaignId)->has('pending')->with('pending')->get();
 
         // For each post, get and include the user
         $signups->each(function ($item) {

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -43,29 +43,19 @@ class CampaignsController extends Controller
     public function index()
     {
         $ids = $this->campaignService->getCampaignIdsFromSignups();
+
         $campaigns = $this->campaignService->findAll($ids);
-        $campaignsWithCounts = $campaigns->map(function($campaign, $key) {
+
+        $campaigns = $campaigns->map(function($campaign, $key) {
             if ($campaign) {
-
-                $campaign['accepted_count'] = 0;
-                $campaign['pending_count'] = 0;
-                $campaign['rejected_count'] = 0;
-
-                $signups = Signup::has('posts')->where('campaign_id', '=', $campaign['id'])
-                    ->withCount(['accepted', 'pending', 'rejected'])->get();
-
-                $signups->each(function($signup) use ($campaign) {
-                    $campaign['accepted_count'] += $signup['accepted_count'];
-                    $campaign['pending_count'] += $signup['pending_count'];
-                    $campaign['rejected_count'] += $signup['rejected_count'];
-                });
+                $campaign = $this->campaignService->getCampaignPostStatusCounts($campaign);
             }
 
             return $campaign;
         });
 
-        $causes = $this->campaignService->groupByCause($campaignsWithCounts);
-        dd($causes);
+        $causes = $this->campaignService->groupByCause($campaigns);
+
         return view('pages.campaign_overview')
             ->with('state', $causes);
     }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -44,7 +44,8 @@ class CampaignsController extends Controller
     {
         $ids = $this->campaignService->getCampaignIdsFromSignups();
         $campaigns = $this->campaignService->findAll($ids);
-        $campaigns = $this->campaignService->getCampaignPostStatusCounts($campaigns);
+        $campaigns = $this->campaignService->appendStatusCountsToCampaigns($campaigns);
+
         $causes = $this->campaignService->groupByCause($campaigns);
 
         return view('pages.campaign_overview')

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -43,17 +43,8 @@ class CampaignsController extends Controller
     public function index()
     {
         $ids = $this->campaignService->getCampaignIdsFromSignups();
-
         $campaigns = $this->campaignService->findAll($ids);
-
-        $campaigns = $campaigns->map(function($campaign, $key) {
-            if ($campaign) {
-                $campaign = $this->campaignService->getCampaignPostStatusCounts($campaign);
-            }
-
-            return $campaign;
-        });
-
+        $campaigns = $this->campaignService->getCampaignPostStatusCounts($campaigns);
         $causes = $this->campaignService->groupByCause($campaigns);
 
         return view('pages.campaign_overview')
@@ -65,7 +56,7 @@ class CampaignsController extends Controller
      */
     public function show($campaignId)
     {
-        $signups = Signup::campaign($campaignId)->has('pending')->with('pending')->get();
+        $signups = Signup::campaign([$campaignId])->has('pending')->with('pending')->get();
 
         // For each post, get and include the user
         $signups->each(function ($item) {

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -21,7 +21,7 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('logout', 'Auth\AuthController@getLogout');
 
     Route::get('campaigns', 'CampaignsController@index');
-    Route::get('campaigns/{id}', 'CampaignsController@show');
+    Route::get('campaigns/{id}/inbox', 'CampaignsController@show');
 
     Route::get('users', 'UsersController@index');
 });

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -64,4 +64,37 @@ class Signup extends Model
     {
         return $this->hasMany(Post::class)->where('status', '=', 'accepted');
     }
+
+    /**
+     * Scope a query to only include signups for a particular campaign
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeCampaign($query, $id)
+    {
+        return $query->where('campaign_id', $id);
+    }
+
+    /**
+     * Scope a query to only include signups for a particular campaign
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithPosts($query, $status = '')
+    {
+        if ($status === 'pending') {
+            return $query->with('pending');
+        } else if ($status === 'accepted') {
+            return $query->with('accepted');
+        } else if ($status === 'rejected') {
+            return $query->with('rejected');
+        } else {
+            return $query->with('posts');
+        }
+    }
+
+    public function scopeIncludeStatusCounts($query)
+    {
+        return $query->withCount(['accepted', 'pending', 'rejected']);
+    }
 }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -70,9 +70,9 @@ class Signup extends Model
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeCampaign($query, $id)
+    public function scopeCampaign($query, $ids)
     {
-        return $query->where('campaign_id', $id);
+        return $query->wherein('campaign_id', $ids);
     }
 
     /**

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -40,4 +40,28 @@ class Signup extends Model
     {
         return $this->hasMany(Post::class);
     }
+
+    /**
+     * Get the 'pending' posts associated with this signup.
+     */
+    public function pending()
+    {
+        return $this->hasMany(Post::class)->where('status', '=', 'pending');
+    }
+
+    /**
+     * Get the 'accepted' posts associated with this signup.
+     */
+    public function accepted()
+    {
+        return $this->hasMany(Post::class)->where('status', '=', 'accepted');
+    }
+
+    /**
+     * Get the 'rejected' posts associated with this signup.
+     */
+    public function rejected()
+    {
+        return $this->hasMany(Post::class)->where('status', '=', 'accepted');
+    }
 }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -62,7 +62,7 @@ class Signup extends Model
      */
     public function rejected()
     {
-        return $this->hasMany(Post::class)->where('status', '=', 'accepted');
+        return $this->hasMany(Post::class)->where('status', '=', 'rejected');
     }
 
     /**

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -76,24 +76,11 @@ class Signup extends Model
     }
 
     /**
-     * Scope a query to only include signups for a particular campaign
+     * Scope a query to include a count of post statuses for a signup.
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWithPosts($query, $status = '')
-    {
-        if ($status === 'pending') {
-            return $query->with('pending');
-        } else if ($status === 'accepted') {
-            return $query->with('accepted');
-        } else if ($status === 'rejected') {
-            return $query->with('rejected');
-        } else {
-            return $query->with('posts');
-        }
-    }
-
-    public function scopeIncludeStatusCounts($query)
+    public function scopeIncludePostStatusCounts($query)
     {
         return $query->withCount(['accepted', 'pending', 'rejected']);
     }

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -188,7 +188,7 @@ class CampaignService
         $ids = array_filter(array_pluck($campaigns, 'id'));
 
         $campaignsWithCounts = DB::table('signups')
-                ->join('posts', 'signups.id', '=', 'posts.signup_id')
+                ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
                 ->select('signups.campaign_id',
                     DB::raw('SUM(case when posts.status = "accepted" then 1 else 0 end) as accepted_count'),
                     DB::raw('SUM(case when posts.status = "pending" then 1 else 0 end) as pending_count'),

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -110,7 +110,7 @@ class CampaignService
             $batch = array_slice($ids, $index, $size);
 
             $parameters['count'] = '5000';
-            $parameters['campaigns'] = implode(',', $batch);
+            $parameters['ids'] = implode(',', $batch);
 
             $campaigns = $this->phoenix->getAllCampaigns($parameters);
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -197,7 +197,7 @@ class CampaignService
                 ->groupBy('signups.campaign_id')
                 ->get();
 
-        return $campaignsWithCounts ? collect($campaignsWithCounts)->keyBy('campaign_id') : null;
+        return $campaignsWithCounts ? collect($campaignsWithCounts)->keyBy('campaign_id') : collect();
     }
 
     /**

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Services;
 
+use Rogue\Models\Signup;
 use Illuminate\Support\Facades\DB;
 use Rogue\Repositories\CacheRepository;
 
@@ -175,5 +176,21 @@ class CampaignService
         $ids = collect($campaigns)->pluck('campaign_id')->toArray();
 
         return $ids ? $ids : null;
+    }
+
+    /**
+     * Get an aggregate of how many pending, accepted, and reject posts there are for a campaign.
+     *
+     * @return array $campaign
+     */
+    public function getCampaignPostStatusCounts($campaign)
+    {
+        $signups = Signup::campaign($campaign['id'])->includePostStatusCounts()->get();
+
+        $campaign['accepted_count'] = $signups->sum('accepted_count');
+        $campaign['pending_count'] = $signups->sum('pending_count');
+        $campaign['rejected_count'] = $signups->sum('rejected_count');
+
+        return $campaign;
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8217630c258e6f62418819e0d9401ea4",
     "content-hash": "b6697ba2fb7b17a323b50ad5d85e7ec4",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.21.6",
+            "version": "3.25.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b51512a4ad4aa080ab963942a1e234265771fcde"
+                "reference": "d4f1104f5ac9c755875c5e6e9bade2c70708219a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b51512a4ad4aa080ab963942a1e234265771fcde",
-                "reference": "b51512a4ad4aa080ab963942a1e234265771fcde",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d4f1104f5ac9c755875c5e6e9bade2c70708219a",
+                "reference": "d4f1104f5ac9c755875c5e6e9bade2c70708219a",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
                 "guzzlehttp/promises": "~1.0",
-                "guzzlehttp/psr7": "~1.3.1",
+                "guzzlehttp/psr7": "^1.4.1",
                 "mtdowling/jmespath.php": "~2.2",
                 "php": ">=5.5"
             },
@@ -85,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-01-27 00:34:55"
+            "time": "2017-04-11T22:31:27+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -141,7 +140,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-01-18 06:57:07"
+            "time": "2016-01-18T06:57:07+00:00"
         },
         {
             "name": "classpreloader/classpreloader",
@@ -195,7 +194,7 @@
                 "class",
                 "preload"
             ],
-            "time": "2016-09-16 12:50:15"
+            "time": "2016-09-16T12:50:15+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -228,20 +227,20 @@
                 "MIT"
             ],
             "description": "implementation of xdg base directory specification for php",
-            "time": "2014-10-24 07:27:01"
+            "time": "2014-10-24T07:27:01+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.3.1",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "bd4461328621bde0ae6b1b2675fbc6aca4ceb558"
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bd4461328621bde0ae6b1b2675fbc6aca4ceb558",
-                "reference": "bd4461328621bde0ae6b1b2675fbc6aca4ceb558",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
                 "shasum": ""
             },
             "require": {
@@ -250,7 +249,7 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^5.6.1"
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "extra": {
@@ -296,7 +295,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2016-12-30 15:59:45"
+            "time": "2017-02-24T16:22:25+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -366,7 +365,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29 11:16:17"
+            "time": "2016-10-29T11:16:17+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -433,7 +432,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2017-01-03 10:49:41"
+            "time": "2017-01-03T10:49:41+00:00"
         },
         {
             "name": "doctrine/common",
@@ -506,20 +505,20 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2017-01-13 14:02:13"
+            "time": "2017-01-13T14:02:13+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.5.10",
+            "version": "v2.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "fc376f7a61498e18520cd6fa083752a4ca08072b"
+                "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/fc376f7a61498e18520cd6fa083752a4ca08072b",
-                "reference": "fc376f7a61498e18520cd6fa083752a4ca08072b",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/7b9e911f9d8b30d43b96853dab26898c710d8f44",
+                "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44",
                 "shasum": ""
             },
             "require": {
@@ -577,7 +576,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-01-23 23:17:10"
+            "time": "2017-02-08T12:53:47+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -644,7 +643,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -698,7 +697,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "dosomething/gateway",
@@ -748,7 +747,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2017-01-27 16:35:18"
+            "time": "2017-01-27T16:35:18+00:00"
         },
         {
             "name": "giggsey/libphonenumber-for-php",
@@ -810,20 +809,20 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2016-11-23 15:39:02"
+            "time": "2016-11-23T15:39:02+00:00"
         },
         {
             "name": "giggsey/locale",
-            "version": "1.1.1",
+            "version": "1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/Locale.git",
-                "reference": "8238764fa3f2c5bd8bdf981e2e019401d49229e3"
+                "reference": "e6eb1883c1452df7734a03fb183a2ec5175c16f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/Locale/zipball/8238764fa3f2c5bd8bdf981e2e019401d49229e3",
-                "reference": "8238764fa3f2c5bd8bdf981e2e019401d49229e3",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/e6eb1883c1452df7734a03fb183a2ec5175c16f2",
+                "reference": "e6eb1883c1452df7734a03fb183a2ec5175c16f2",
                 "shasum": ""
             },
             "require": {
@@ -859,25 +858,25 @@
                 }
             ],
             "description": "Locale functions required by libphonenumber-for-php",
-            "time": "2016-10-24 20:49:55"
+            "time": "2017-04-07T18:45:42+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.2",
+            "version": "6.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.3.1",
+                "guzzlehttp/psr7": "^1.4",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -921,7 +920,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08 15:01:37"
+            "time": "2017-02-28T22:50:30+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -972,20 +971,20 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20 10:07:11"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.3.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
                 "shasum": ""
             },
             "require": {
@@ -1021,29 +1020,36 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
-            "description": "PSR-7 message implementation",
+            "description": "PSR-7 message implementation that also provides common utility methods",
             "keywords": [
                 "http",
                 "message",
+                "request",
+                "response",
                 "stream",
-                "uri"
+                "uri",
+                "url"
             ],
-            "time": "2016-06-24 23:00:38"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "intervention/image",
-            "version": "2.3.10",
+            "version": "2.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "88911910dcbb7bf617f1370602ba1706489c8505"
+                "reference": "e8881fd99b9804b29e02d6d1c2c15ee459335cf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/88911910dcbb7bf617f1370602ba1706489c8505",
-                "reference": "88911910dcbb7bf617f1370602ba1706489c8505",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/e8881fd99b9804b29e02d6d1c2c15ee459335cf1",
+                "reference": "e8881fd99b9804b29e02d6d1c2c15ee459335cf1",
                 "shasum": ""
             },
             "require": {
@@ -1092,7 +1098,7 @@
                 "thumbnail",
                 "watermark"
             ],
-            "time": "2017-01-25 18:52:04"
+            "time": "2017-02-04T10:37:19+00:00"
         },
         {
             "name": "ircmaxell/random-lib",
@@ -1147,7 +1153,7 @@
                 "random-numbers",
                 "random-strings"
             ],
-            "time": "2016-09-07 15:52:06"
+            "time": "2016-09-07T15:52:06+00:00"
         },
         {
             "name": "ircmaxell/security-lib",
@@ -1193,7 +1199,7 @@
             ],
             "description": "A Base Security Library",
             "homepage": "https://github.com/ircmaxell/SecurityLib",
-            "time": "2015-03-20 14:31:23"
+            "time": "2015-03-20T14:31:23+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -1236,7 +1242,7 @@
                     "homepage": "http://www.acci.cz"
                 }
             ],
-            "time": "2014-04-08 15:00:19"
+            "time": "2014-04-08T15:00:19+00:00"
         },
         {
             "name": "jakub-onderka/php-console-highlighter",
@@ -1280,7 +1286,7 @@
                     "homepage": "http://www.acci.cz/"
                 }
             ],
-            "time": "2015-04-20 18:58:01"
+            "time": "2015-04-20T18:58:01+00:00"
         },
         {
             "name": "jeremeamia/SuperClosure",
@@ -1338,7 +1344,7 @@
                 "serialize",
                 "tokenizer"
             ],
-            "time": "2016-12-07 09:37:55"
+            "time": "2016-12-07T09:37:55+00:00"
         },
         {
             "name": "laravel/framework",
@@ -1468,7 +1474,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-08-26 11:44:52"
+            "time": "2016-08-26T11:44:52+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -1526,20 +1532,20 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2016-10-31 20:09:32"
+            "time": "2016-10-31T20:09:32+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.34",
+            "version": "1.0.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "469ad53c13ea19a0e54e3e5d70f61227ddcc0299"
+                "reference": "78b5cc4feb61a882302df4fbaf63b7662e5e4ccd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/469ad53c13ea19a0e54e3e5d70f61227ddcc0299",
-                "reference": "469ad53c13ea19a0e54e3e5d70f61227ddcc0299",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/78b5cc4feb61a882302df4fbaf63b7662e5e4ccd",
+                "reference": "78b5cc4feb61a882302df4fbaf63b7662e5e4ccd",
                 "shasum": ""
             },
             "require": {
@@ -1609,7 +1615,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-01-30 17:41:17"
+            "time": "2017-03-22T15:43:14+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -1656,7 +1662,7 @@
                 }
             ],
             "description": "Flysystem adapter for the AWS S3 SDK v3.x",
-            "time": "2016-06-21 21:34:35"
+            "time": "2016-06-21T21:34:35+00:00"
         },
         {
             "name": "league/fractal",
@@ -1719,7 +1725,7 @@
                 "league",
                 "rest"
             ],
-            "time": "2015-10-07 14:48:58"
+            "time": "2015-10-07T14:48:58+00:00"
         },
         {
             "name": "league/oauth2-client",
@@ -1782,7 +1788,7 @@
                 "oauth2",
                 "single sign on"
             ],
-            "time": "2016-07-28 13:20:43"
+            "time": "2016-07-28T13:20:43+00:00"
         },
         {
             "name": "maknz/slack",
@@ -1831,7 +1837,7 @@
                 "laravel",
                 "slack"
             ],
-            "time": "2015-06-03 03:35:16"
+            "time": "2015-06-03T03:35:16+00:00"
         },
         {
             "name": "maknz/slack-laravel",
@@ -1872,20 +1878,20 @@
                 "laravel",
                 "slack"
             ],
-            "time": "2016-06-25 06:08:23"
+            "time": "2016-06-25T06:08:23+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "1.22.0",
+            "version": "1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558"
+                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558",
-                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
                 "shasum": ""
             },
             "require": {
@@ -1950,7 +1956,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-11-26 00:15:39"
+            "time": "2017-03-13T07:08:03+00:00"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -1994,7 +2000,7 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2017-01-23 04:29:33"
+            "time": "2017-01-23T04:29:33+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -2049,7 +2055,7 @@
                 "json",
                 "jsonpath"
             ],
-            "time": "2016-12-03 22:08:25"
+            "time": "2016-12-03T22:08:25+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -2102,7 +2108,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16 07:55:07"
+            "time": "2017-01-16T07:55:07+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2153,20 +2159,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-09-16 12:04:44"
+            "time": "2016-09-16T12:04:44+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.4.1",
+            "version": "v1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
+                "reference": "965cdeb01fdcab7653253aa81d40441d261f1e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
-                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/965cdeb01fdcab7653253aa81d40441d261f1e66",
+                "reference": "965cdeb01fdcab7653253aa81d40441d261f1e66",
                 "shasum": ""
             },
             "require": {
@@ -2201,7 +2207,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-03-18 20:34:03"
+            "time": "2017-03-13T16:22:52+00:00"
         },
         {
             "name": "predis/predis",
@@ -2251,7 +2257,7 @@
                 "predis",
                 "redis"
             ],
-            "time": "2016-06-16 16:22:20"
+            "time": "2016-06-16T16:22:20+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2301,7 +2307,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2348,7 +2354,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "psy/psysh",
@@ -2420,7 +2426,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2016-03-09 05:03:14"
+            "time": "2016-03-09T05:03:14+00:00"
         },
         {
             "name": "spatie/db-dumper",
@@ -2470,26 +2476,26 @@
                 "mysqldump",
                 "spatie"
             ],
-            "time": "2016-06-14 13:23:01"
+            "time": "2016-06-14T13:23:01+00:00"
         },
         {
             "name": "spatie/laravel-backup",
-            "version": "3.10.2",
+            "version": "3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-backup.git",
-                "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf"
+                "reference": "2382532ce52e3929ccb0e930539d14dfd09d22eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
-                "reference": "1f9f0c55d7643aba7257aef2b2b867f2716ddfaf",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/2382532ce52e3929ccb0e930539d14dfd09d22eb",
+                "reference": "2382532ce52e3929ccb0e930539d14dfd09d22eb",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "~5.1.0|~5.2.0|~5.3.0",
-                "illuminate/filesystem": "~5.1.20|~5.2.0|~5.3.0",
-                "illuminate/support": "~5.1.0|~5.2.0|~5.3.0",
+                "illuminate/console": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+                "illuminate/filesystem": "~5.1.20|~5.2.0|~5.3.0|~5.4.0",
+                "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
                 "league/flysystem": "^1.0.8",
                 "php": "^5.5|^7.0",
                 "spatie/db-dumper": "^1.3",
@@ -2533,20 +2539,20 @@
                 "laravel-backup",
                 "spatie"
             ],
-            "time": "2016-08-24 12:02:50"
+            "time": "2017-02-18T09:54:12+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.5",
+            "version": "v5.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "cd142238a339459b10da3d8234220963f392540c"
+                "reference": "81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/cd142238a339459b10da3d8234220963f392540c",
-                "reference": "cd142238a339459b10da3d8234220963f392540c",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e",
+                "reference": "81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e",
                 "shasum": ""
             },
             "require": {
@@ -2587,7 +2593,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2016-12-29 10:02:40"
+            "time": "2017-02-13T07:52:53+00:00"
         },
         {
             "name": "symfony/console",
@@ -2647,7 +2653,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/debug",
@@ -2704,20 +2710,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.2.2",
+            "version": "v3.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "9137eb3a3328e413212826d63eeeb0217836e2b6"
+                "reference": "154bb1ef7b0e42ccc792bd53edbce18ed73440ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9137eb3a3328e413212826d63eeeb0217836e2b6",
-                "reference": "9137eb3a3328e413212826d63eeeb0217836e2b6",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/154bb1ef7b0e42ccc792bd53edbce18ed73440ca",
+                "reference": "154bb1ef7b0e42ccc792bd53edbce18ed73440ca",
                 "shasum": ""
             },
             "require": {
@@ -2764,7 +2770,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02 20:32:22"
+            "time": "2017-04-04T07:26:27+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2813,7 +2819,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -2866,7 +2872,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-17 13:54:30"
+            "time": "2016-07-17T13:54:30+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -2948,7 +2954,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 09:10:37"
+            "time": "2016-07-30T09:10:37+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3007,7 +3013,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -3063,7 +3069,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-util",
@@ -3115,7 +3121,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/process",
@@ -3164,7 +3170,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 11:13:34"
+            "time": "2016-07-28T11:13:34+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -3224,7 +3230,7 @@
                 "http-message",
                 "psr-7"
             ],
-            "time": "2016-09-14 18:37:20"
+            "time": "2016-09-14T18:37:20+00:00"
         },
         {
             "name": "symfony/routing",
@@ -3299,7 +3305,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/translation",
@@ -3363,7 +3369,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -3426,7 +3432,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-07-26 08:03:56"
+            "time": "2016-07-26T08:03:56+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -3476,20 +3482,20 @@
                 "env",
                 "environment"
             ],
-            "time": "2016-09-01 10:05:43"
+            "time": "2016-09-01T10:05:43+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.3.10",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "83e8d98b9915de76c659ce27d683c02a0f99fa90"
+                "reference": "b03f285a333f51e58c95cce54109a4a9ed691436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/83e8d98b9915de76c659ce27d683c02a0f99fa90",
-                "reference": "83e8d98b9915de76c659ce27d683c02a0f99fa90",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/b03f285a333f51e58c95cce54109a4a9ed691436",
+                "reference": "b03f285a333f51e58c95cce54109a4a9ed691436",
                 "shasum": ""
             },
             "require": {
@@ -3497,17 +3503,19 @@
                 "psr/http-message": "~1.0"
             },
             "provide": {
-                "psr/http-message-implementation": "~1.0.0"
+                "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
                 "phpunit/phpunit": "^4.6 || ^5.5",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev",
-                    "dev-develop": "1.4-dev"
+                    "dev-master": "1.4-dev",
+                    "dev-develop": "1.5-dev"
                 }
             },
             "autoload": {
@@ -3526,7 +3534,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-23 04:53:24"
+            "time": "2017-04-06T16:18:34+00:00"
         }
     ],
     "packages-dev": [
@@ -3582,7 +3590,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -3630,7 +3638,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29 12:21:54"
+            "time": "2016-04-29T12:21:54+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -3675,20 +3683,20 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11 14:41:42"
+            "time": "2015-05-11T14:41:42+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.7",
+            "version": "0.9.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
-                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371"
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/4de7969f4664da3cef1ccd83866c9f59378c3371",
-                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
+                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
                 "shasum": ""
             },
             "require": {
@@ -3740,7 +3748,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-12-19 14:50:55"
+            "time": "2017-02-28T12:52:32+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3794,7 +3802,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3839,7 +3847,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3886,31 +3894,31 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0|^2.0"
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0",
+                "phpspec/phpspec": "^2.5|^3.2",
                 "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
@@ -3949,7 +3957,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4011,7 +4019,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4058,7 +4066,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4099,29 +4107,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -4143,20 +4156,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -4192,20 +4205,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.34",
+            "version": "4.8.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7eb45205d27edd94bd2b3614085ea158bd1e2bca"
+                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7eb45205d27edd94bd2b3614085ea158bd1e2bca",
-                "reference": "7eb45205d27edd94bd2b3614085ea158bd1e2bca",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
                 "shasum": ""
             },
             "require": {
@@ -4264,7 +4277,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-01-26 16:15:36"
+            "time": "2017-02-06T05:18:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -4320,7 +4333,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -4384,7 +4397,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -4436,7 +4449,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4486,7 +4499,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4553,7 +4566,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -4604,20 +4617,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -4657,7 +4670,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4692,7 +4705,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -4745,7 +4758,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -4801,20 +4814,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.2",
+            "version": "v3.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "50eadbd7926e31842893c957eca362b21592a97d"
+                "reference": "62b4cdb99d52cb1ff253c465eb1532a80cebb621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/50eadbd7926e31842893c957eca362b21592a97d",
-                "reference": "50eadbd7926e31842893c957eca362b21592a97d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/62b4cdb99d52cb1ff253c465eb1532a80cebb621",
+                "reference": "62b4cdb99d52cb1ff253c465eb1532a80cebb621",
                 "shasum": ""
             },
             "require": {
@@ -4856,7 +4869,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-03 13:51:32"
+            "time": "2017-03-20T09:45:15+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4906,7 +4919,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -30,6 +30,7 @@ class CampaignInbox extends React.Component {
         </div>
       )
     } else {
+      // @todo - make this into an actual component.
       return (
         <div className="container">
           <h2 className="-padded">No Posts to review!</h2>

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { flatMap } from 'lodash';
-import { map } from 'lodash';
+import { map, sample } from 'lodash';
 
 import InboxItem from '../InboxItem';
 
@@ -15,11 +15,31 @@ class CampaignInbox extends React.Component {
       });
     });
 
-    return (
-      <div className="container">
-        { map(posts, (post, key) => <InboxItem key={key} details={post} />) }
-      </div>
-    )
+    const nothingHere = [
+      'https://media.giphy.com/media/3og0IT9dAZyMz3lXNe/giphy.gif',
+      'https://media.giphy.com/media/Lny6Rw04nsOOc/giphy.gif',
+      'https://media.giphy.com/media/YdhvjTeL83pNS/giphy.gif',
+      'https://media.giphy.com/media/26ufnwz3wDUli7GU0/giphy.gif',
+      'https://media.giphy.com/media/lYHbL5QY52Kcw/giphy.gif',
+    ];
+
+    if (posts.length !== 0) {
+      return (
+        <div className="container">
+          { map(posts, (post, key) => <InboxItem key={key} details={post} />) }
+        </div>
+      )
+    } else {
+      return (
+        <div className="container">
+          <h2 className="-padded">No Posts to review!</h2>
+          <div className="container">
+            <img src={sample(nothingHere)} />
+          </div>
+        </div>
+      )
+    }
+
   }
 }
 

--- a/resources/assets/components/CampaignTable/index.js
+++ b/resources/assets/components/CampaignTable/index.js
@@ -10,7 +10,7 @@ class CampaignTable extends React.Component {
     return (
       <div className="table-responsive container__block">
         <h2>{cause}</h2>
-        <Table key={cause} className="table" headings={['Campaign Name', 'Approved', 'Pending', 'Rejected']} data={this.props.campaigns} />
+        <Table key={cause} className="table" headings={['Campaign Name', 'Pending', 'Approved', 'Rejected']} data={this.props.campaigns} />
       </div>
     )
   }

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -7,7 +7,7 @@ class Row extends React.Component {
 
     return (
       <tr className="table__row">
-        <td className="table__cell"><a href="#">{campaign ? campaign.title : 'Campaign Not Found'}</a></td>
+        <td className="table__cell"><a href={inboxUrl}>{campaign ? campaign.title : 'Campaign Not Found'}</a></td>
         <td className="table__cell"><a href={inboxUrl}>{this.props.pending}</a></td>
         <td className="table__cell">{this.props.approved}</td>
         <td className="table__cell">{this.props.rejected}</td>

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -5,7 +5,7 @@ class Row extends React.Component {
     return (
       <tr className="table__row">
         <td className="table__cell"><a href="#">{this.props.campaign ? this.props.campaign.title : 'Campaign Not Found'}</a></td>
-        <td className="table__cell">{this.props.approved}</td>
+        <td className="table__cell"><a href={`/campaign/${this.props.campaign_id}`}>{this.props.approved}</a></td>
         <td className="table__cell">{this.props.pending}</td>
         <td className="table__cell">{this.props.rejected}</td>
       </tr>

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -2,10 +2,13 @@ import React from 'react';
 
 class Row extends React.Component {
   render() {
+    const { campaign } = this.props;
+    const inboxUrl = this.props.campaign_id ? `/campaigns/${this.props.campaign_id}/inbox` : '/campaigns';
+
     return (
       <tr className="table__row">
-        <td className="table__cell"><a href="#">{this.props.campaign ? this.props.campaign.title : 'Campaign Not Found'}</a></td>
-        <td className="table__cell"><a href={`/campaigns/${this.props.campaign_id}/inbox`}>{this.props.pending}</a></td>
+        <td className="table__cell"><a href="#">{campaign ? campaign.title : 'Campaign Not Found'}</a></td>
+        <td className="table__cell"><a href={inboxUrl}>{this.props.pending}</a></td>
         <td className="table__cell">{this.props.approved}</td>
         <td className="table__cell">{this.props.rejected}</td>
       </tr>

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -5,8 +5,8 @@ class Row extends React.Component {
     return (
       <tr className="table__row">
         <td className="table__cell"><a href="#">{this.props.campaign ? this.props.campaign.title : 'Campaign Not Found'}</a></td>
-        <td className="table__cell"><a href={`/campaign/${this.props.campaign_id}`}>{this.props.approved}</a></td>
-        <td className="table__cell">{this.props.pending}</td>
+        <td className="table__cell"><a href={`/campaigns/${this.props.campaign_id}/inbox`}>{this.props.pending}</a></td>
+        <td className="table__cell">{this.props.approved}</td>
         <td className="table__cell">{this.props.rejected}</td>
       </tr>
     )

--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -11,7 +11,7 @@ class Table extends React.Component {
     });
 
     const rows = this.props.data.map((content, index) => {
-      return <Row key={index} campaign={content} approved={content ? content.accepted_count : 0} pending={content ? content.pending_count : 0} rejected={content ? content.rejected_count : 0} />;
+      return <Row key={index} campaign={content} campaign_id={content ? content.id : ''} approved={content ? content.accepted_count : 0} pending={content ? content.pending_count : 0} rejected={content ? content.rejected_count : 0} />;
     });
 
     return (

--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -11,7 +11,7 @@ class Table extends React.Component {
     });
 
     const rows = this.props.data.map((content, index) => {
-      return <Row key={index} campaign={content} approved pending rejected />;
+      return <Row key={index} campaign={content} approved={content ? content.accepted_count : 0} pending={content ? content.pending_count : 0} rejected={content ? content.rejected_count : 0} />;
     });
 
     return (

--- a/resources/views/layouts/nav.blade.php
+++ b/resources/views/layouts/nav.blade.php
@@ -4,8 +4,8 @@
         @if (Auth::user())
             <ul class="navigation__primary">
                 <li>
-                    <a href="#">
-                        <strong class="navigation__title">One Fish</strong>
+                    <a href="/campaigns">
+                        <strong class="navigation__title">Campaign Overview</strong>
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
#### What's this PR do?

Adds the number of pending, accepted, and rejected posts there are for each campaign on the campaign overview page. 

* Creates new relationships on `Signup` to define relationships to posts with a particular status.
* Adds some local query scopes to `Signup` to define some commonly used queries including one that will include the number of accepted, rejected, and pending posts on each signup retrieved.
* Adds a method on the `CampaignService` that sums up the status counts for a campaign
* Passes this info to the frontend and display it.
* Links the pending count to the inbox page
  - *Note on this* - dealing with campaign runs was becoming increasingly difficult. For one, we only get the current run from the phoenix API so we would have to do some work on that end to get all runs back. Two, when we get the current run, we get it per language and each of those could have different run ids. In order to simplify this, as a first past, we decided to show post counts _per campaign_ instead. So the inbox page has been updated to reflect that change, and we show pending posts per `campaign_id` instead of per run id. 


![image](https://cloud.githubusercontent.com/assets/1700409/25045221/2ead4d24-20f9-11e7-8a69-9eb0ffa3469a.png)


#### How should this be reviewed?

I think you should be safe to do this commit by commit. Or start looking at the `Signup` model and the relationships defined there, then look at how they are used in `CampaignService` and `CampaignController`

#### Relevant tickets
Fixes #217 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.