### PR TITLE
Auto-Orient photo

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -44,9 +44,9 @@ class PostRepository
     {
         if (isset($data['file'])) {
             // Auto-orient the photo by default based on exif data.
-            $img = Image::make($data['file'])->orientate();
+            $image = Image::make($data['file'])->orientate();
 
-            $fileUrl = $this->aws->storeImage((string) $img->encode('data-url'), $signupId);
+            $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
 
             $editedImage = $this->crop($data, $signupId);
         } else {


### PR DESCRIPTION
#### What's this PR do?

Orient an uploaded file using [Intervention Image's `Orientate()`](http://image.intervention.io/api/orientate) method before storing to s3. 

#### Any background context you want to provide?

Full disclosure, I am not sure this is needed. I have uploaded various photos via the `/posts` api endpoint, including a photo that was tagged as rotating incorrectly before, and it seems to working fine in rogue. 

However, this should safe guard us if something is weird. 

Also, this is very hard to test. I haven't been able to fine a photo that is uploading/displaying incorrectly so it is hard to tell if this is working as expected. 

#### Relevant tickets
Fixes #220 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.