### PR TITLE
Update /reportbacks endpoint for reaction gallery work

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -51,6 +51,10 @@ class ReportbackController extends ApiController
 
                 $query = $query->where('campaign_id', '=', $campaign_id);
             }
+            // Exclude Posts if exclude param is present
+            if (array_key_exists('exclude', $request->filter)) {
+                $query =  $query->whereNotIn('posts.id', explode(',', $request->filter['exclude']));
+            }
         }
 
         // Eagerly load the count of all reactions on a post.

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -44,16 +44,18 @@ class ReportbackController extends ApiController
             ->where('status', '=', 'approved')
             ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id');
 
-        if (isset($request->filter)) {
-            // Only return Posts for the given campaign_id (if there is one)
-            if (array_key_exists('campaign_id', $request->filter)) {
-                $campaign_id = $request->filter['campaign_id'];
+        $filters = $request->query('filter');
 
-                $query = $query->where('campaign_id', '=', $campaign_id);
+        if (! empty($filters)) {
+            // Only return Posts for the given campaign_id (if there is one)
+            if (array_has($filters, 'campaign_id')) {
+                $query = $query->where('campaign_id', '=', $filters['campaign_id']);
             }
+
             // Exclude Posts if exclude param is present
-            if (array_key_exists('exclude', $request->filter)) {
-                $query = $query->whereNotIn('posts.id', explode(',', $request->filter['exclude']));
+            if (array_has($filters, 'exclude')) {
+                $query = $query->whereNotIn('posts.id', explode(',', $filters['exclude']));
+
             }
         }
 

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -53,7 +53,7 @@ class ReportbackController extends ApiController
             }
             // Exclude Posts if exclude param is present
             if (array_key_exists('exclude', $request->filter)) {
-                $query =  $query->whereNotIn('posts.id', explode(',', $request->filter['exclude']));
+                $query = $query->whereNotIn('posts.id', explode(',', $request->filter['exclude']));
             }
         }
 

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -55,7 +55,6 @@ class ReportbackController extends ApiController
             // Exclude Posts if exclude param is present
             if (array_has($filters, 'exclude')) {
                 $query = $query->whereNotIn('posts.id', explode(',', $filters['exclude']));
-
             }
         }
 

--- a/app/Http/Transformers/ReactionTransformer.php
+++ b/app/Http/Transformers/ReactionTransformer.php
@@ -23,10 +23,6 @@ class ReactionTransformer extends TransformerAbstract
                 'id' => 641,
                 'total' => 1,
             ],
-            'current_user' => [
-                'kudos_id' => 1,
-                'reacted' => 1,
-            ],
             'created_at' => $reaction->created_at->toIso8601String(),
             'updated_at' => $reaction->updated_at->toIso8601String(),
             'deleted_at' => is_null($reaction->deleted_at) ? null : $reaction->deleted_at->toIso8601String(),

--- a/app/Http/Transformers/ReactionTransformer.php
+++ b/app/Http/Transformers/ReactionTransformer.php
@@ -18,6 +18,15 @@ class ReactionTransformer extends TransformerAbstract
         return [
             'northstar_id' => $reaction->northstar_id,
             'post_id' => (string) $reaction->post_id,
+            'term' => [
+                'name' => 'heart',
+                'id' => 641,
+                'total' => 1,
+            ],
+            'current_user' => [
+                'kudos_id' => 1,
+                'reacted' => 1,
+            ],
             'created_at' => $reaction->created_at->toIso8601String(),
             'updated_at' => $reaction->updated_at->toIso8601String(),
             'deleted_at' => is_null($reaction->deleted_at) ? null : $reaction->deleted_at->toIso8601String(),

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -21,7 +21,6 @@ class ReportbackTransformer extends TransformerAbstract
             'id' => $post->id,
             'status' => $post->status,
             'caption' => $post->caption,
-            'event_id' => $post->events[0]->id,
             // Add link to review reportback item in Rogue here once that page exists
             // 'uri' => 'link_goes_here'
             'media' => [

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -38,8 +38,23 @@ class ReportbackTransformer extends TransformerAbstract
                 'flagged' => 'false',
             ],
             'kudos' => [
-                'total' => $post->reactions_count,
-                'liked_by_current_user' => count($post->reactions) >= 1,
+                // 'data' => [
+                    'total' => $post->reactions_count,
+                    // 'liked_by_current_user' => count($post->reactions) >= 1,
+                    'data' => [
+                        'current_user' => [
+                            'kudos_id' => 1,
+                            'reacted' => count($post->reactions) >= 1,
+                        ],
+                        'term' => [
+                            'name' => 'heart',
+                            'id' => 641,
+                            'total' => $post->reactions_count,
+                        ],
+                    ],
+                    // $this->item($post->reactions, new ReactionTransformer),
+
+                // ]
             ],
             'user' => $signup->northstar_id,
         ];

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -20,6 +20,7 @@ class ReportbackTransformer extends TransformerAbstract
             'id' => $post->id,
             'status' => $post->status,
             'caption' => $post->caption,
+            'event_id' => $post->events[0]->id,
             // Add link to review reportback item in Rogue here once that page exists
             // 'uri' => 'link_goes_here'
             'media' => [
@@ -37,7 +38,7 @@ class ReportbackTransformer extends TransformerAbstract
             ],
             'kudos' => [
                 // @TODO: Include reaction information here!
-                'data' => [],
+                'total' => 5,
             ],
         ];
 

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -16,6 +16,7 @@ class ReportbackTransformer extends TransformerAbstract
     public function transform(Post $post)
     {
         $signup = $post->signup;
+
         $result = [
             'id' => $post->id,
             'status' => $post->status,
@@ -37,7 +38,8 @@ class ReportbackTransformer extends TransformerAbstract
                 'flagged' => 'false',
             ],
             'kudos' => [
-                'total' => count($post->reactions),
+                'total' => $post->reactions_count,
+                'liked_by_current_user' => count($post->reactions) >= 1,
             ],
             'user' => $signup->northstar_id,
         ];

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -38,9 +38,7 @@ class ReportbackTransformer extends TransformerAbstract
                 'flagged' => 'false',
             ],
             'kudos' => [
-                // 'data' => [
                     'total' => $post->reactions_count,
-                    // 'liked_by_current_user' => count($post->reactions) >= 1,
                     'data' => [
                         'current_user' => [
                             'kudos_id' => 1,
@@ -52,9 +50,6 @@ class ReportbackTransformer extends TransformerAbstract
                             'total' => $post->reactions_count,
                         ],
                     ],
-                    // $this->item($post->reactions, new ReactionTransformer),
-
-                // ]
             ],
             'user' => $signup->northstar_id,
         ];

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -37,8 +37,7 @@ class ReportbackTransformer extends TransformerAbstract
                 'flagged' => 'false',
             ],
             'kudos' => [
-                // @TODO: Include reaction information here!
-                'total' => 5,
+                'total' => count($post->reactions),
             ],
         ];
 

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -39,6 +39,7 @@ class ReportbackTransformer extends TransformerAbstract
             'kudos' => [
                 'total' => count($post->reactions),
             ],
+            'user' => $signup->northstar_id,
         ];
 
         return $result;

--- a/documentation/endpoints/reactions.md
+++ b/documentation/endpoints/reactions.md
@@ -7,18 +7,15 @@ POST /api/v2/reactions
 ```
   - **northstar_id**: (int) required
     The northstar id of the user who "liked" or "unliked" the reportback item. 
-  - **reactionable_id**: (int) required 
+  - **post_id**: (int) required 
     The post that the reaction belongs to. 
-  - **reactionable_type**: (string) required
-    The post type that the reaction belongs to.
     
 Example Request
 ```
 curl http://rogue.dev:8000/api/v2/reactions
  -d '{
   "northstar_id":1234,
-  "reactionable_id":1,
-  "reactionable_type":"photo",
+  "post_id":1,
   }'
   --header "Accept: application/json"
 ```
@@ -26,29 +23,11 @@ Example Response
 ```
 {
   "data": {
-    "reaction_id": "29",
     "northstar_id": "1234",
-    "reactionable_id": "1",
-    "reactionable_type": "photo",
-    "created_at": {
-      "date": "2017-03-14 20:58:07.000000",
-      "timezone_type": 3,
-      "timezone": "UTC"
-    },
-    "updated_at": {
-      "date": "2017-03-15 15:23:43.000000",
-      "timezone_type": 3,
-      "timezone": "UTC"
-    },
-    "deleted_at": {
-      "date": "2017-03-15 15:26:57.000000",
-      "timezone_type": 3,
-      "timezone": "UTC"
-    }
+    "post_id": "1",
+    "created_at": "2017-04-03T20:17:04+00:00",
+    "updated_at": "2017-04-03T20:17:04+00:00",
+    "deleted_at": null,
   },
-  "meta": {
-    "action": "unliked",
-    "total_reactions": 2
-  }
 }
 ```

--- a/documentation/endpoints/reportbacks.md
+++ b/documentation/endpoints/reportbacks.md
@@ -15,60 +15,133 @@ GET /api/v1/reportbacks
   - e.g. `/reportbacks?page=2`
 - **campaign_id** _(integer)_
   - The nid to filter the response by.
-  - e.g. `/activity?filter[campaign_id]=47`
+  - e.g. `/reportbacks?filter[campaign_id]=47`
+- **exclude** _(integer)_
+  - The post id(s) to exclude in response. 
+  - e.g. `/reportbacks?filter[exclude]=2,3,4`
+- **as_user** _(string)_
+  - The logged in user to display if they have reacted to the post or not.
+  - e.g. `/reportbacks?as_user=1234`
 
 Example Response:
 
 ```
 {
+{
   "data": [
+    {
+      "id": 2,
+      "status": "approved",
+      "caption": "post 2",
+      "event_id": 4,
+      "media": {
+        "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/1-676c9c02029df581d3668ae869d937b8-1491250786.jpeg",
+        "type": "image"
+      },
+      "created_at": "2017-04-03T20:19:47+00:00",
+      "reportback": {
+        "id": 1,
+        "created_at": "2017-04-03T20:17:04+00:00",
+        "updated_at": "2017-04-03T20:17:04+00:00",
+        "quantity": 300,
+        "why_participated": "Because",
+        "flagged": "false"
+      },
+      "kudos": {
+        "total": 0,
+        "data": {
+          "current_user": {
+            "kudos_id": 1,
+            "reacted": false
+          },
+          "term": {
+            "name": "heart",
+            "id": 641,
+            "total": 0
+          }
+        }
+      },
+      "user": "1234"
+    },
+    {
+      "id": 3,
+      "status": "approved",
+      "caption": "post 3",
+      "event_id": 6,
+      "media": {
+        "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/1-676c9c02029df581d3668ae869d937b8-1491250872.jpeg",
+        "type": "image"
+      },
+      "created_at": "2017-04-03T20:21:13+00:00",
+      "reportback": {
+        "id": 1,
+        "created_at": "2017-04-03T20:17:04+00:00",
+        "updated_at": "2017-04-03T20:17:04+00:00",
+        "quantity": 300,
+        "why_participated": "Because",
+        "flagged": "false"
+      },
+      "kudos": {
+        "total": 1,
+        "data": {
+          "current_user": {
+            "kudos_id": 1,
+            "reacted": true
+          },
+          "term": {
+            "name": "heart",
+            "id": 641,
+            "total": 1
+          }
+        }
+      },
+      "user": "1234"
+    },
     {
       "id": 4,
       "status": "approved",
-      "caption": "Ipsam fugit magnam impedit sit quia quo.",
-      "uri": "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg",
+      "caption": "post 4",
+      "event_id": 8,
       "media": {
-        "uri": "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg",
+        "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/1-676c9c02029df581d3668ae869d937b8-1491250890.jpeg",
         "type": "image"
       },
-      "created_at": "2017-03-28T14:33:32+00:00",
+      "created_at": "2017-04-03T20:21:31+00:00",
       "reportback": {
-        "id": 2,
-        "created_at": "2017-03-28T14:33:32+00:00",
-        "updated_at": "2017-03-28T14:33:32+00:00",
-        "quantity": null,
-        "why_participated": "Vel excepturi soluta aut natus ut.",
+        "id": 1,
+        "created_at": "2017-04-03T20:17:04+00:00",
+        "updated_at": "2017-04-03T20:17:04+00:00",
+        "quantity": 300,
+        "why_participated": "Because",
         "flagged": "false"
-      }
-    },
-    {
-      "id": 6,
-      "status": "approved",
-      "caption": "Nostrum et nemo totam quia occaecati.",
-      "uri": "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg",
-      "media": {
-        "uri": "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg",
-        "type": "image"
       },
-      "created_at": "2017-03-28T14:33:32+00:00",
-      "reportback": {
-        "id": 2,
-        "created_at": "2017-03-28T14:33:32+00:00",
-        "updated_at": "2017-03-28T14:33:32+00:00",
-        "quantity": null,
-        "why_participated": "Vel excepturi soluta aut natus ut.",
-        "flagged": "false"
-      }
+      "kudos": {
+        "total": 0,
+        "data": {
+          "current_user": {
+            "kudos_id": 1,
+            "reacted": false
+          },
+          "term": {
+            "name": "heart",
+            "id": 641,
+            "total": 0
+          }
+        }
+      },
+      "user": "1234"
     }
   ],
   "meta": {
     "pagination": {
-      "total": 2,
-      "count": 2,
-      "per_page": 20,
+      "total": 24,
+      "count": 3,
+      "per_page": 3,
       "current_page": 1,
-      "total_pages": 1,
-      "links": []
+      "total_pages": 8,
+      "links": {
+        "next": "http://rogue.dev:8000/api/v1/reportbacks?limit=3&page=2"
+      }
     }
   }
 }


### PR DESCRIPTION
#### What's this PR do?
Updated `GET /reportbacks` endpoint to activate reaction buttons in gallery for posts that the logged in user has liked. In order to do so, the `/reportbacks`endpoint now includes:
- adds `as_user` param to return if the logged in user has liked the post or not.
- `reacted` in response to be `true` or `false` if logged in user has reacted to post.
- adds `exclude` param to exclude posts in response.
- updates documentation

#### How should this be reviewed?
Response from this endpoint should now look as follows and you should be able to use `filter=[exclude]`:
```
{
  "data": [
    {
      "id": 2,
      "status": "approved",
      "caption": "post 2",
      "event_id": 4,
      "media": {
        "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/1-676c9c02029df581d3668ae869d937b8-1491250786.jpeg",
        "type": "image"
      },
      "created_at": "2017-04-03T20:19:47+00:00",
      "reportback": {
        "id": 1,
        "created_at": "2017-04-03T20:17:04+00:00",
        "updated_at": "2017-04-03T20:17:04+00:00",
        "quantity": 300,
        "why_participated": "Because",
        "flagged": "false"
      },
      "kudos": {
        "total": 0,
        "data": {
          "current_user": {
            "kudos_id": 1,
            "reacted": false
          },
          "term": {
            "name": "heart",
            "id": 641,
            "total": 0
          }
        }
      },
      "user": "5589c991a59dbfa93d8b45ae"
    },
    {
      "id": 3,
      "status": "approved",
      "caption": "post 3",
      "event_id": 6,
      "media": {
        "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/1-676c9c02029df581d3668ae869d937b8-1491250872.jpeg",
        "type": "image"
      },
      "created_at": "2017-04-03T20:21:13+00:00",
      "reportback": {
        "id": 1,
        "created_at": "2017-04-03T20:17:04+00:00",
        "updated_at": "2017-04-03T20:17:04+00:00",
        "quantity": 300,
        "why_participated": "Because",
        "flagged": "false"
      },
      "kudos": {
        "total": 1,
        "data": {
          "current_user": {
            "kudos_id": 1,
            "reacted": true
          },
          "term": {
            "name": "heart",
            "id": 641,
            "total": 1
          }
        }
      },
      "user": "5589c991a59dbfa93d8b45ae"
    },
    {
      "id": 4,
      "status": "approved",
      "caption": "post 4",
      "event_id": 8,
      "media": {
        "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/1-676c9c02029df581d3668ae869d937b8-1491250890.jpeg",
        "type": "image"
      },
      "created_at": "2017-04-03T20:21:31+00:00",
      "reportback": {
        "id": 1,
        "created_at": "2017-04-03T20:17:04+00:00",
        "updated_at": "2017-04-03T20:17:04+00:00",
        "quantity": 300,
        "why_participated": "Because",
        "flagged": "false"
      },
      "kudos": {
        "total": 0,
        "data": {
          "current_user": {
            "kudos_id": 1,
            "reacted": false
          },
          "term": {
            "name": "heart",
            "id": 641,
            "total": 0
          }
        }
      },
      "user": "5589c991a59dbfa93d8b45ae"
    }
  ],
  "meta": {
    "pagination": {
      "total": 24,
      "count": 3,
      "per_page": 3,
      "current_page": 1,
      "total_pages": 8,
      "links": {
        "next": "http://rogue.dev:8000/api/v1/reportbacks?limit=3&page=2"
      }
    }
  }
}
```

#### Any background context you want to provide?
This is needed for [this PR](https://github.com/DoSomething/phoenix/pull/7356) on the Phoenix ashes side.

#### Relevant tickets
Fixes #207 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.