### PR TITLE
Pagination For Phoenix Gallery 

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -9,7 +9,6 @@ use League\Fractal\Serializer\DataArraySerializer;
 use Rogue\Http\Controllers\Traits\FiltersRequests;
 use Rogue\Http\Controllers\Controller as BaseController;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
-use Rogue\Http\Transformers\PaginatorForPhoenixAshesGallery;
 
 class ApiController extends BaseController
 {
@@ -71,12 +70,7 @@ class ApiController extends BaseController
 
         $manager = new Manager;
 
-        // If this is a request to /reportbacks, send to PaginatorForPhoenixAshesGallery to match response expected for pagination in Phoenix Ashes Gallery.
-        if ($endpoint === 'reportbacks') {
-            $manager->setSerializer(new PaginatorForPhoenixAshesGallery);
-        } else {
-            $manager->setSerializer(new DataArraySerializer);
-        }
+        $manager->setSerializer(new DataArraySerializer);
 
         if (isset($include)) {
             $manager->parseIncludes($include);

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -74,8 +74,7 @@ class ApiController extends BaseController
         // If this is a request to /reportbacks, send to PaginatorForPhoenixAshesGallery to match response expected for pagination in Phoenix Ashes Gallery.
         if ($endpoint === 'reportbacks') {
             $manager->setSerializer(new PaginatorForPhoenixAshesGallery);
-        }
-        else {
+        } else {
             $manager->setSerializer(new DataArraySerializer);
         }
 

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -64,7 +64,7 @@ class ApiController extends BaseController
      * @param  array  $meta
      * @return \Illuminate\Http\JsonResponse
      */
-    public function transform($data, $code = 200, $meta = [], $include = null, $endpoint = null)
+    public function transform($data, $code = 200, $meta = [], $include = null)
     {
         $data->setMeta($meta);
 
@@ -118,14 +118,10 @@ class ApiController extends BaseController
 
         $resource->setMeta($meta);
 
-        $urlWithoutQueryString = explode('?', $request->fullUrl())[0];
-        $urlParts = explode('/', $urlWithoutQueryString);
-        $endpoint = end($urlParts);
-
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
         $include = isset($request->include) ? $request->include : null;
 
-        return $this->transform($resource, $code, [], $include, $endpoint);
+        return $this->transform($resource, $code, [], $include);
     }
 }

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -4,14 +4,12 @@ namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Post;
 use League\Fractal\Manager;
-use League\Fractal\Resource\Collection;
 use Illuminate\Http\Request;
 use Rogue\Models\Reportback;
 use Rogue\Services\ReportbackService;
 use Rogue\Http\Requests\ReportbackRequest;
 use Rogue\Http\Transformers\ReportbackTransformer;
 use Rogue\Http\Transformers\PaginatorForPhoenixAshesGallery;
-
 
 class ReportbackController extends ApiController
 {

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -3,11 +3,15 @@
 namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Post;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
 use Illuminate\Http\Request;
 use Rogue\Models\Reportback;
 use Rogue\Services\ReportbackService;
 use Rogue\Http\Requests\ReportbackRequest;
 use Rogue\Http\Transformers\ReportbackTransformer;
+use Rogue\Http\Transformers\PaginatorForPhoenixAshesGallery;
+
 
 class ReportbackController extends ApiController
 {
@@ -129,5 +133,30 @@ class ReportbackController extends ApiController
         $meta = [];
 
         return $this->collection($items, $code, $meta, $this->itemTransformer);
+    }
+
+    /**
+     * Manage and finalize the data transformation.
+     *
+     * @param  \League\Fractal\Resource\Item|\League\Fractal\Resource\Collection  $data
+     * @param  int  $code
+     * @param  array  $meta
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function transform($data, $code = 200, $meta = [], $include = null, $endpoint = null)
+    {
+        $data->setMeta($meta);
+
+        $manager = new Manager;
+
+        $manager->setSerializer(new PaginatorForPhoenixAshesGallery);
+
+        if (isset($include)) {
+            $manager->parseIncludes($include);
+        }
+
+        $response = $manager->createData($data)->toArray();
+
+        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
     }
 }

--- a/app/Http/Transformers/PaginatorForPhoenixAshesGallery.php
+++ b/app/Http/Transformers/PaginatorForPhoenixAshesGallery.php
@@ -5,10 +5,8 @@ namespace Rogue\Http\Transformers;
 use League\Fractal\Serializer\ArraySerializer;
 use League\Fractal\Pagination\PaginatorInterface;
 
-
 class PaginatorForPhoenixAshesGallery extends ArraySerializer
 {
-
     /**
      * Serialize a collection.
      *

--- a/app/Http/Transformers/PaginatorForPhoenixAshesGallery.php
+++ b/app/Http/Transformers/PaginatorForPhoenixAshesGallery.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rogue\Http\Transformers;
+
+use League\Fractal\Serializer\ArraySerializer;
+use League\Fractal\Pagination\PaginatorInterface;
+
+
+class PaginatorForPhoenixAshesGallery extends ArraySerializer
+{
+
+    /**
+     * Serialize a collection.
+     *
+     * @param string $resourceKey
+     * @param array  $data
+     *
+     * @return array
+     */
+    public function collection($resourceKey, array $data)
+    {
+        return ['data' => $data];
+    }
+
+    /**
+     * Serialize the paginator.
+     *
+     * @param PaginatorInterface $paginator
+     *
+     * @return array
+     */
+    public function paginator(PaginatorInterface $paginator)
+    {
+        $currentPage = (int) $paginator->getCurrentPage();
+        $lastPage = (int) $paginator->getLastPage();
+
+        $pagination = [
+            'total' => (int) $paginator->getTotal(),
+            'count' => (int) $paginator->getCount(),
+            'per_page' => (int) $paginator->getPerPage(),
+            'current_page' => $currentPage,
+            'total_pages' => $lastPage,
+        ];
+
+        $pagination['links'] = [];
+
+        if ($currentPage > 1) {
+            $pagination['links']['previous_uri'] = $paginator->getUrl($currentPage - 1);
+        }
+
+        if ($currentPage < $lastPage) {
+            $pagination['links']['next_uri'] = $paginator->getUrl($currentPage + 1);
+        }
+
+        return ['pagination' => $pagination];
+    }
+}

--- a/documentation/endpoints/reportbacks.md
+++ b/documentation/endpoints/reportbacks.md
@@ -140,7 +140,7 @@ Example Response:
       "current_page": 1,
       "total_pages": 8,
       "links": {
-        "next": "http://rogue.dev:8000/api/v1/reportbacks?limit=3&page=2"
+        "next_uri": "http://rogue.dev:8000/api/v1/reportbacks?limit=3&page=2"
       }
     }
   }


### PR DESCRIPTION
#### What's this PR do?
Adds customization in order for Rogue to power the gallery and more closely mimic Phoenix's `/reportbacks` response. 
- In the response, Phoenix expects `next_uri` instead of just `uri` for the `/reportbacks` endpoint - this adds this just to this endpoint. 

#### How should this be reviewed?
Hit `/reportbacks` and check out the pagination. It should look like this: 
```
 "meta": {
    "pagination": {
      "total": 24,
      "count": 4,
      "per_page": 20,
      "current_page": 2,
      "total_pages": 2,
      "links": {
        "previous_uri": "http://rogue.dev:8000/api/v1/reportbacks?as_user=5589c991a59dbfa93d8b45ae&page=1"
      }
    }
  }
```

#### Any background context you want to provide?
Relates to work here: https://github.com/DoSomething/phoenix/pull/7356

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.