### PR TITLE
Some /posts fixes that are needed for keeper upper and also life

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -26,9 +26,9 @@ class PostRequest extends Request
             'campaign_id' => 'required|int',
             'campaign_run_id' => 'required|int',
             'caption' => 'string',
-            'status' => 'pending',
+            // 'status' => 'pending',
             'source' => 'string',
-            'remote_addr' => 'ip',
+            // 'remote_addr' => 'ip',
             // 'file' => 'string', // @TODO - should do some better validation around files.
         ];
     }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -26,9 +26,9 @@ class PostRequest extends Request
             'campaign_id' => 'required|int',
             'campaign_run_id' => 'required|int',
             'caption' => 'string',
-            // 'status' => 'pending',
+            'status' => 'in:pending,accepted,rejected',
             'source' => 'string',
-            // 'remote_addr' => 'ip',
+            'remote_addr' => 'string',
             // 'file' => 'string', // @TODO - should do some better validation around files.
         ];
     }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -97,7 +97,7 @@ class PostRepository
         $signup->save();
 
         // If there is a file, create a new post.
-        if (! empty($data['file'])) {
+        if (array_key_exists('file', $data)) {
             return $this->create($data, $signup->id);
         }
 


### PR DESCRIPTION
#### What's this PR do?
1. Updated 2 validation rules:
    - `status` - fixed it to make sure that the status is any of `pending`, `accepted`, `rejected`
        - caveat: potentially in the future when posts come in, they will all be `pending`, so we may want to remove this rule and have Rogue automatically assign `pending` to incoming posts
    - `remote_addr` - updated to make sure it is a string, since it is sometimes a list of IPs 

2. When checking for an image, we can't just check if `data['file']` is empty, because broken images will come over with that value as `null`, so we get false negatives using `empty`. Instead, check if the `$data` array has a key `file` to see if the requester tried to send a file at all.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
These fixes were necessary for the keeper upper script.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.