### PR TITLE
Quantity pending

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -28,9 +28,6 @@ class PostTransformer extends TransformerAbstract
             'remote_addr' => $post->remote_addr,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
-            // 'reactions' => [
-            //     'total' => count($post->reactions),
-            // ]
         ];
     }
 }

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -34,13 +34,23 @@ class SignupTransformer extends TransformerAbstract
      */
     public function transform(Signup $signup)
     {
+        // @TODO - This is temporary. We have migrated data that has stored quanity in the
+        // quanity_pending column on the signup. However, since then we updated the business
+        // logic to store everything in the quanity column and not use the quanity_pending
+        // column at all. We only want to return what is in the quanity_pending column
+        // if is the only place quanity is stored.
+        if (! is_null($signup->quantity_pending) && is_null($signup->quantity)) {
+            $quantity = $signup->quantity_pending;
+        } else {
+            $quantity = $signup->quantity;
+        }
+
         return [
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
-            'quantity' => $signup->quantity,
-            'quantity_pending' => $signup->quantity_pending,
+            'quantity' => $quantity,
             'why_participated' => $signup->why_participated,
             'signup_source' => $signup->source,
             'created_at' => $signup->created_at->toIso8601String(),

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -91,7 +91,7 @@ class PostRepository
      */
     public function update($signup, $data)
     {
-        $signup->fill(array_only($data, ['quantity_pending', 'why_participated']));
+        $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
 
         // Triggers model event that logs the updated signup in the events table.
         $signup->save();

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -180,7 +180,7 @@ class PostRepository
         $cropValues = array_only($data, $this->cropProperties);
 
         if (count($cropValues) > 0) {
-            $editedImage = edit_image($img, $cropValues);
+            $editedImage = edit_image($data['file'], $cropValues);
 
             return $this->aws->storeImage($editedImage, 'edited_' . $signupId);
         }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -65,7 +65,7 @@ class PostService
         // @TODO: This will is only temporary and will be removed!
         // If this is a signup update, get the most recent post.
         // If there is a quantity_pending, this is a signup.
-        if ($post->quantity_pending) {
+        if ($post->quantity || $post->quantity_pending) {
             $signupId = $post->id;
             // Find the post with this signup id.
             $post = Post::where('signup_id', $signupId)->first();

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -62,15 +62,6 @@ class PostService
     {
         $post = $this->repository->update($signup, $data);
 
-        // @TODO: This will is only temporary and will be removed!
-        // If this is a signup update, get the most recent post.
-        // If there is a quantity_pending, this is a signup.
-        if ($post->quantity || $post->quantity_pending) {
-            $signupId = $post->id;
-            // Find the post with this signup id.
-            $post = Post::where('signup_id', $signupId)->first();
-        }
-
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -15,7 +15,7 @@ class PostApiTest extends TestCase
      * @group creatingAPhoto
      * @return void
      */
-    public function testCreatingAPhoto()
+    public function testCreatingAPost()
     {
         $this->expectsJobs(Rogue\Jobs\SendPostToPhoenix::class);
 
@@ -54,5 +54,10 @@ class PostApiTest extends TestCase
 
         // Make sure the file_url is saved to the database.
         $this->seeInDatabase('posts', ['url' => $response['data']['media']['url']]);
+
+        $this->seeInDatabase('signups', [
+            'id' => $response['data']['signup_id'],
+            'quantity' => $post['quantity'],
+        ]);
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use DoSomething\Gateway\Northstar;
+use Rogue\Services\CampaignService;
 use Rogue\Models\User;
 
 class UserTest extends TestCase
@@ -16,6 +17,13 @@ class UserTest extends TestCase
         $user = factory(User::class)->make([
             'role' => 'admin',
         ]);
+
+        $mock = $this->mock(CampaignService::class)
+            ->shouldReceive('getCampaignIdsFromSignups')->andReturn([])
+            ->shouldReceive('findAll')
+            ->shouldReceive('appendStatusCountsToCampaigns')
+            ->shouldReceive('groupByCause')
+            ->andReturn('true');
 
         $this->actingAs($user)
             ->visit('/campaigns')


### PR DESCRIPTION
#### What's this PR do?

Makes some updates in the code base so that `quantity` is stored in the `quantity` column on the `signups` table. 

#### Any background context you want to provide?

We have two columns on the `signups` table: `quantity` and `quantity_pending`. We originally discussed storing quantity in the "pending" column until an admin reviewed it but that was proving more complicated and also wasn't inline with recent thinking. So we are only going to utilize the `quantity` column for now. Anything previously stored in `quantity_pending` will be migrated to `quantity` at a later time. 

#### Relevant tickets
Fixes #177 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.