### PR TITLE
drops unique key in reactions table for northstar_user

### DIFF
--- a/database/migrations/2017_04_27_183942_drop_unique_northstar_id_index_reactions_table.php
+++ b/database/migrations/2017_04_27_183942_drop_unique_northstar_id_index_reactions_table.php
@@ -12,8 +12,7 @@ class DropUniqueNorthstarIdIndexReactionsTable extends Migration
      */
     public function up()
     {
-        Schema::table('reactions', function(Blueprint $table)
-        {
+        Schema::table('reactions', function (Blueprint $table) {
             $table->dropUnique('kudos_file_id_drupal_id_northstar_id_taxonomy_id_unique');
         });
     }
@@ -25,8 +24,7 @@ class DropUniqueNorthstarIdIndexReactionsTable extends Migration
      */
     public function down()
     {
-        Schema::table('reactions', function(Blueprint $table)
-        {
+        Schema::table('reactions', function (Blueprint $table) {
             $table->unique('kudos_file_id_drupal_id_northstar_id_taxonomy_id_unique');
         });
     }

--- a/database/migrations/2017_04_27_183942_drop_unique_northstar_id_index_reactions_table.php
+++ b/database/migrations/2017_04_27_183942_drop_unique_northstar_id_index_reactions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropUniqueNorthstarIdIndexReactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reactions', function(Blueprint $table)
+        {
+            $table->dropUnique('kudos_file_id_drupal_id_northstar_id_taxonomy_id_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reactions', function(Blueprint $table)
+        {
+            $table->unique('kudos_file_id_drupal_id_northstar_id_taxonomy_id_unique');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Drops the unique key in the `reactions` table for the `northstar_user` column.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
When we renamed the table from `kudos` to `reactions` we forgot to drop indexes (more info. [here](https://dosomething.slack.com/?redir=%2Farchives%2FC0YGXUE01%2Fp1493318041448517))

We need to fix this for Reactions to work when Rogue is powering the Phoenix-Ashes gallery to allow a user to react to more than one post. https://github.com/DoSomething/phoenix/pull/7366

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.