### PR TITLE
Update /reviews endpoint and reviews test 

### DIFF
--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -10,11 +10,11 @@ use Rogue\Http\Transformers\PostTransformer;
 class ReviewsController extends ApiController
 {
     /**
-     * The photo service instance.
+     * The post service instance.
      *
      * @var Rogue\Services\PostService
      */
-    protected $posts;
+    protected $post;
 
     /**
      * @var \Rogue\Http\Transformers\PostTransformer
@@ -24,14 +24,14 @@ class ReviewsController extends ApiController
     /**
      * Create a controller instance.
      *
-     * @param  PostContract  $posts
+     * @param  PostContract $posts
      * @return void
      */
-    public function __construct(PostService $posts)
+    public function __construct(PostService $post)
     {
         $this->middleware('api');
 
-        $this->posts = $posts;
+        $this->post = $post;
 
         $this->postTransformer = new PostTransformer;
     }
@@ -45,7 +45,8 @@ class ReviewsController extends ApiController
      */
     public function reviews(ReviewsRequest $request)
     {
-        $reviewedPost = $this->posts->reviews($request->all());
+        dd('hi');
+        $reviewedPost = $this->post->reviews($request->all());
         $reviewedPostCode = $this->code($reviewedPost);
 
         $meta = [];

--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -3,7 +3,7 @@
 namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Post;
-use Rogue\Services\PostService;
+use Rogue\Repositories\PostRepository;
 use Rogue\Http\Requests\ReviewsRequest;
 use Rogue\Http\Transformers\PostTransformer;
 
@@ -12,7 +12,7 @@ class ReviewsController extends ApiController
     /**
      * The post service instance.
      *
-     * @var Rogue\Services\PostService
+     * @var Rogue\Repositories\PostRepository
      */
     protected $post;
 
@@ -27,7 +27,7 @@ class ReviewsController extends ApiController
      * @param  PostContract $posts
      * @return void
      */
-    public function __construct(PostService $post)
+    public function __construct(PostRepository $post)
     {
         $this->middleware('api');
 
@@ -46,16 +46,12 @@ class ReviewsController extends ApiController
     public function reviews(ReviewsRequest $request)
     {
         $review = $request->all();
-        $post = Post::where('id', $review['postable_id'])->first();
-        // "postable_id" => "2"
-        // "postable_type" => "Rogue\Models\Post"
-        // "status" => "test status"
-        // "admin_northstar_id" => "chloe"
+        $post = Post::where('id', $review['post_id'])->first();
         $review['signup_id'] = $post->signup_id;
         $review['northstar_id'] = $post->northstar_id;
-        // dd($post->review);
+        $review['old_status'] = $post->status;
 
-        $reviewedPost = $this->post->reviews($request->all());
+        $reviewedPost = $this->post->reviews($review);
         $reviewedPostCode = $this->code($reviewedPost);
 
         $meta = [];

--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -45,7 +45,16 @@ class ReviewsController extends ApiController
      */
     public function reviews(ReviewsRequest $request)
     {
-        dd('hi');
+        $review = $request->all();
+        $post = Post::where('id', $review['postable_id'])->first();
+        // "postable_id" => "2"
+        // "postable_type" => "Rogue\Models\Post"
+        // "status" => "test status"
+        // "admin_northstar_id" => "chloe"
+        $review['signup_id'] = $post->signup_id;
+        $review['northstar_id'] = $post->northstar_id;
+        dd($post->review);
+
         $reviewedPost = $this->post->reviews($request->all());
         $reviewedPostCode = $this->code($reviewedPost);
 

--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -53,7 +53,7 @@ class ReviewsController extends ApiController
         // "admin_northstar_id" => "chloe"
         $review['signup_id'] = $post->signup_id;
         $review['northstar_id'] = $post->northstar_id;
-        dd($post->review);
+        // dd($post->review);
 
         $reviewedPost = $this->post->reviews($request->all());
         $reviewedPostCode = $this->code($reviewedPost);

--- a/app/Http/Requests/ReviewsRequest.php
+++ b/app/Http/Requests/ReviewsRequest.php
@@ -22,8 +22,7 @@ class ReviewsRequest extends Request
     public function rules()
     {
         return [
-            'postable_id' => 'required',
-            'postable_type' => 'required',
+            'post_id' => 'required',
             'status' => 'required',
             'admin_northstar_id' => 'required',
         ];

--- a/app/Http/Requests/ReviewsRequest.php
+++ b/app/Http/Requests/ReviewsRequest.php
@@ -22,10 +22,10 @@ class ReviewsRequest extends Request
     public function rules()
     {
         return [
-            'rogue_event_id' => 'required',
+            'postable_id' => 'required',
+            'postable_type' => 'required',
             'status' => 'required',
-            'reviewer' => 'required',
-            'event_type' => 'required',
+            'admin_northstar_id' => 'required',
         ];
     }
 }

--- a/app/Http/Requests/ReviewsRequest.php
+++ b/app/Http/Requests/ReviewsRequest.php
@@ -23,7 +23,7 @@ class ReviewsRequest extends Request
     {
         return [
             'post_id' => 'required',
-            'status' => 'required',
+            'status' => 'in:pending,accepted,rejected',
             'admin_northstar_id' => 'required',
         ];
     }

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -11,7 +11,7 @@ class Review extends Model
      *
      * @var array
      */
-    protected $fillable = ['event_id', 'signup_id', 'northstar_id', 'admin_northstar_id', 'status', 'old_status', 'comment', 'postable_id', 'postable_type'];
+    protected $fillable = ['signup_id', 'northstar_id', 'admin_northstar_id', 'status', 'old_status', 'comment', 'post_id'];
 
     /**
      * Each review has events.

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Rogue\Providers;
 
 use Rogue\Models\Post;
-use Rogue\Models\Signup;
 use Rogue\Models\Review;
+use Rogue\Models\Signup;
 use Illuminate\Support\ServiceProvider;
 
 class ModelServiceProvider extends ServiceProvider

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -4,6 +4,7 @@ namespace Rogue\Providers;
 
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
+use Rogue\Models\Review;
 use Illuminate\Support\ServiceProvider;
 
 class ModelServiceProvider extends ServiceProvider
@@ -27,6 +28,13 @@ class ModelServiceProvider extends ServiceProvider
         Post::saved(function ($post) {
             $post->events()->create([
                 'content' => $post->toJson(),
+            ]);
+        });
+
+        // When Reviews are saved create an event for them.
+        Review::saved(function ($review) {
+            $review->events()->create([
+                'content' => $review->toJson(),
             ]);
         });
     }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -4,7 +4,7 @@ namespace Rogue\Repositories;
 
 use Rogue\Models\Post;
 use Rogue\Services\AWS;
-// use Rogue\Models\Review;
+use Rogue\Models\Review;
 use Rogue\Services\Registrar;
 use Intervention\Image\Facades\Image;
 
@@ -105,69 +105,66 @@ class PostRepository
     }
 
     /**
-     * Updates a photo(s)'s status after being reviewed.
-     * @todo - update with new logic once photos table is removed
-     * and everything lives on the post.
+     * Updates a post's status after being reviewed.
      *
      * @param array $data
      *
      * @return
      */
-    // public function reviews($data)
-    // {
-    //     $reviewedPhotos = [];
+    public function reviews($data)
+    {
+        // dd($data);
+        // $reviewedPhotos = [];
 
-    //     if (isset($data['rogue_event_id']) && ! empty($data['rogue_event_id'])) {
-    //         $post = Post::where(['event_id' => $data['rogue_event_id']])->first();
-    //         $photo = Photo::where(['id' => $post->postable_id])->first();
+        // if (isset($data['rogue_event_id']) && ! empty($data['rogue_event_id'])) {
+            $post = Post::where(['id' => $data['post_id']])->first();
+            // $photo = Photo::where(['id' => $post->postable_id])->first();
 
-    //         if ($data['status'] && ! empty($data['status'])) {
-    //             // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
-    //             $data['submission_type'] = 'admin';
+            // if ($data['status'] && ! empty($data['status'])) {
+                // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
+                // $data['submission_type'] = 'admin';
 
-    //             // Create the Event.
-    //             $event = Event::create([
-    //                 'signup_id' => $post->signup_id,
-    //                 'northstar_id' => $post->northstar_id,
-    //                 'event_type' => $data['event_type'],
-    //                 'submission_type' => $data['submission_type'],
-    //                 // When we start tracking when admins update the below, we'll need to update this endpoint and comment these in.
-    //                 // 'quantity' => ,
-    //                 // 'quantity_pending' => ,
-    //                 // 'why_participated' => ,
-    //                 // 'caption' => ,
-    //                 'status' => $data['status'],
-    //                 // 'source' => ,
-    //                 // 'remote_addr' => ,
-    //                 // 'reason' => ,
-    //             ]);
+                // Create the Event.
+                // $event = Event::create([
+                //     'signup_id' => $post->signup_id,
+                //     'northstar_id' => $post->northstar_id,
+                //     'event_type' => $data['event_type'],
+                //     'submission_type' => $data['submission_type'],
+                //     // When we start tracking when admins update the below, we'll need to update this endpoint and comment these in.
+                //     // 'quantity' => ,
+                //     // 'quantity_pending' => ,
+                //     // 'why_participated' => ,
+                //     // 'caption' => ,
+                //     'status' => $data['status'],
+                //     // 'source' => ,
+                //     // 'remote_addr' => ,
+                //     // 'reason' => ,
+                // ]);
+            dd($post->id);
 
-    //             // Create the Review.
-    //             Review::create([
-    //                 'event_id' => $event->id,
-    //                 'signup_id' => $post->signup_id,
-    //                 'northstar_id' => $post->northstar_id,
-    //                 'admin_northstar_id' => $data['reviewer'],
-    //                 'status' => $data['status'],
-    //                 'old_status' => $photo->status,
-    //                 'comment' => isset($data['comment']) ? $data['comment'] : null,
-    //                 'created_at' => $event->created_at,
-    //                 'updated_at' => $event->updated_at,
-    //                 'postable_id' => $post->postable_id,
-    //                 'postable_type' => $post->postable_type,
-    //             ]);
+                // Create the Review.
+                Review::create([
+                    // 'event_id' => $event->id,
+                    'signup_id' => $post->signup_id,
+                    'northstar_id' => $post->northstar_id,
+                    'admin_northstar_id' => $data['admin_northstar_id'],
+                    'status' => $data['status'],
+                    'old_status' => $post->status,
+                    'comment' => isset($data['comment']) ? $data['comment'] : null,
+                    'post_id' => $post->id,
+                ]);
 
-    //             $photo->status = $data['status'];
-    //             $photo->save();
-    //         } else {
-    //             return null;
-    //         }
-    //     } else {
-    //         return null;
-    //     }
+                $post->status = $data['status'];
+                $post->save();
+            // } else {
+            //     return null;
+            // }
+        // } else {
+            // return null;
+        // }
 
-    //     return $photo;
-    // }
+        return $post;
+    }
 
     /**
      * Crop an image

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -113,55 +113,21 @@ class PostRepository
      */
     public function reviews($data)
     {
-        // dd($data);
-        // $reviewedPhotos = [];
+        $post = Post::where(['id' => $data['post_id']])->first();
+        // Create the Review.
+        $review = Review::create([
+            'signup_id' => $post->signup_id,
+            'northstar_id' => $post->northstar_id,
+            'admin_northstar_id' => $data['admin_northstar_id'],
+            'status' => $data['status'],
+            'old_status' => $post->status,
+            'comment' => isset($data['comment']) ? $data['comment'] : null,
+            'post_id' => $post->id,
+        ]);
 
-        // if (isset($data['rogue_event_id']) && ! empty($data['rogue_event_id'])) {
-            $post = Post::where(['id' => $data['post_id']])->first();
-            // $photo = Photo::where(['id' => $post->postable_id])->first();
-
-            // if ($data['status'] && ! empty($data['status'])) {
-                // @TODO: update to add more details in the event e.g. admin who reviewed, admin's northstar id, etc.
-                // $data['submission_type'] = 'admin';
-
-                // Create the Event.
-                // $event = Event::create([
-                //     'signup_id' => $post->signup_id,
-                //     'northstar_id' => $post->northstar_id,
-                //     'event_type' => $data['event_type'],
-                //     'submission_type' => $data['submission_type'],
-                //     // When we start tracking when admins update the below, we'll need to update this endpoint and comment these in.
-                //     // 'quantity' => ,
-                //     // 'quantity_pending' => ,
-                //     // 'why_participated' => ,
-                //     // 'caption' => ,
-                //     'status' => $data['status'],
-                //     // 'source' => ,
-                //     // 'remote_addr' => ,
-                //     // 'reason' => ,
-                // ]);
-            dd($post->id);
-
-                // Create the Review.
-                Review::create([
-                    // 'event_id' => $event->id,
-                    'signup_id' => $post->signup_id,
-                    'northstar_id' => $post->northstar_id,
-                    'admin_northstar_id' => $data['admin_northstar_id'],
-                    'status' => $data['status'],
-                    'old_status' => $post->status,
-                    'comment' => isset($data['comment']) ? $data['comment'] : null,
-                    'post_id' => $post->id,
-                ]);
-
-                $post->status = $data['status'];
-                $post->save();
-            // } else {
-            //     return null;
-            // }
-        // } else {
-            // return null;
-        // }
+        // Update the status on the Post.
+        $post->status = $data['status'];
+        $post->save();
 
         return $post;
     }

--- a/database/migrations/2017_04_28_180204_update-reviews-table.php
+++ b/database/migrations/2017_04_28_180204_update-reviews-table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateReviewsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropColumn('postable_type');
+            $table->renameColumn('postable_id', 'post_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->string('postable_type')->comment('Type of the post that has been reviewed.');
+            $table->renameColumn('post_id', 'postable_type');
+        });
+    }
+}

--- a/database/migrations/2017_04_28_180204_update-reviews_table.php
+++ b/database/migrations/2017_04_28_180204_update-reviews_table.php
@@ -14,7 +14,8 @@ class UpdateReviewsTable extends Migration
     {
         Schema::table('reviews', function (Blueprint $table) {
             $table->dropColumn('postable_type');
-            $table->renameColumn('postable_id', 'post_id');
+            $table->dropColumn('postable_id');
+            $table->integer('post_id')->comment('Post Id of the post that has been reviewed');
         });
     }
 
@@ -27,7 +28,8 @@ class UpdateReviewsTable extends Migration
     {
         Schema::table('reviews', function (Blueprint $table) {
             $table->string('postable_type')->comment('Type of the post that has been reviewed.');
-            $table->renameColumn('post_id', 'postable_type');
+            $table->integer('postable_id')->comment('Postable Id the of the post that has been reviewed.');
+
         });
     }
 }

--- a/database/migrations/2017_04_28_180204_update-reviews_table.php
+++ b/database/migrations/2017_04_28_180204_update-reviews_table.php
@@ -15,7 +15,7 @@ class UpdateReviewsTable extends Migration
         Schema::table('reviews', function (Blueprint $table) {
             $table->dropColumn('postable_type');
             $table->dropColumn('postable_id');
-            $table->integer('post_id')->comment('Post Id of the post that has been reviewed');
+            $table->integer('post_id')->unsigned()->index()->comment('Post Id of the post that has been reviewed');
         });
     }
 
@@ -29,7 +29,7 @@ class UpdateReviewsTable extends Migration
         Schema::table('reviews', function (Blueprint $table) {
             $table->string('postable_type')->comment('Type of the post that has been reviewed.');
             $table->integer('postable_id')->comment('Postable Id the of the post that has been reviewed.');
-
+            $table->dropColumn('post_id');
         });
     }
 }

--- a/documentation/endpoints/reviews.md
+++ b/documentation/endpoints/reviews.md
@@ -6,36 +6,32 @@ Update a post or multiple posts' status when an admin reviews.
 PUT /api/v2/reviews
 ```
 
-  - **rogue_event_id**: (string) required.
-    The reportback item's Rogue event id (id column in Rogue's event table).
+  - **post_id**: (string) required.
+    The id of the post that has been reviewed.
   - **status**: (string) required.
     The status of the post. 
-  - **reviewer**: (string) required.
+  - **admin_northstar_id**: (string) required.
     The reviewer's northstar id. 
-  - **event_type**: (string) required.
-    The event type of the review. 
+  - **comment**: (string)
+    A comment that the reviewer has made. 
 
 Example Response:
 
 ```
 {
   "data": {
-    "postable_id": 352,
-    "post_event_id": 816,
-    "submission_type": "user",
-    "postable_type": "Rogue\\Models\\Photo",
-    "content": {
-      "media": {
-        "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487193185.jpeg",
-        "edited_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_18-1487193185.jpeg"
-      },
-      "caption": "new1",
-      "status": "pending",
-      "remote_addr": "207.110.19.130",
-      "post_source": "runscope",
-      "created_at": "2017-02-15T21:13:05+0000",
-      "updated_at": "2017-03-03T22:15:01+0000"
-    }
+    "id": 1,
+    "signup_id": 1,
+    "northstar_id": "1234",
+    "media": {
+      "url": "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg",
+      "caption": "Est blanditiis ab quo sequi quis."
+    },
+    "status": "approved",
+    "source": "phoenix-web",
+    "remote_addr": "10.0.2.2",
+    "created_at": "2017-04-28T20:14:49+00:00",
+    "updated_at": "2017-04-28T20:22:23+00:00"
   }
 }
 ```

--- a/tests/ReviewsApiTest.php
+++ b/tests/ReviewsApiTest.php
@@ -26,7 +26,7 @@ class ReviewsApiTest extends TestCase
 
         $review = [
             'post_id' => $post->id,
-            'status' => $this->faker->word(),
+            'status' => 'accepted',
             'admin_northstar_id' => str_random(24),
         ];
 

--- a/tests/ReviewsApiTest.php
+++ b/tests/ReviewsApiTest.php
@@ -37,9 +37,9 @@ class ReviewsApiTest extends TestCase
         $response = $this->decodeResponseJson();
 
         // Make sure we created a event for the review.
-        // $this->seeInDatabase('events', [
-        //     'status' => $response['data']['content']['status'],
-        // ]);
+        $this->seeInDatabase('events', [
+            'created_at' => $response['data']['created_at'],
+        ]);
 
         // Make sure a review is created.
         $this->seeInDatabase('reviews', [

--- a/tests/ReviewsApiTest.php
+++ b/tests/ReviewsApiTest.php
@@ -25,7 +25,7 @@ class ReviewsApiTest extends TestCase
         $post = factory(Post::class)->create();
 
         $review = [
-            'post_id' => $post->_id,
+            'post_id' => $post->id,
             'status' => $this->faker->word(),
             'admin_northstar_id' => str_random(24),
         ];

--- a/tests/ReviewsApiTest.php
+++ b/tests/ReviewsApiTest.php
@@ -13,54 +13,42 @@ class ReviewsApiTest extends TestCase
     protected $reviewsApiUrl = 'api/v2/reviews';
 
     /**
-     * @todo - The reviews endpoint needs to be updated to work
-     * with the new schema and this test will have to be rewritten
-     * when that happens.
-     *
-     * Test that a PUT request to /reviews updates the status and creates a new event and review.
+     * Test that a PUT request to /reviews updates the post's status and creates a new event and review.
      *
      * PUT /reviews
      * @return void
      */
-    // public function testUpdatingASingleReview()
-    // {
-    //     // Create a photo.
-    //     $photo = factory(Photo::class)->create();
+    public function testUpdatingASingleReview()
+    {
 
-    //     // Create a post and associate the photo with it.
-    //     $post = factory(Post::class)->create([
-    //         'postable_id' => $photo->id,
-    //         'postable_type' => 'photo',
-    //     ]);
-    //     $post->content()->associate($photo);
-    //     $post->save();
+        // Create a post.
+        $post = factory(Post::class)->create();
 
-    //     $review = [
-    //         'rogue_event_id' => $post->event_id,
-    //         'status' => $this->faker->word(),
-    //         'event_type' => 'review_photo',
-    //         'reviewer' => str_random(24),
-    //     ];
+        $review = [
+            'post_id' => $post->_id,
+            'status' => $this->faker->word(),
+            'admin_northstar_id' => str_random(24),
+        ];
 
-    //     $this->json('PUT', $this->reviewsApiUrl, $review);
+        $this->json('PUT', $this->reviewsApiUrl, $review);
 
-    //     $this->assertResponseStatus(201);
+        $this->assertResponseStatus(201);
 
-    //     $response = $this->decodeResponseJson();
+        $response = $this->decodeResponseJson();
 
-    //     // Make sure we created a event for the review.
-    //     $this->seeInDatabase('events', [
-    //         'status' => $response['data']['content']['status'],
-    //     ]);
+        // Make sure we created a event for the review.
+        // $this->seeInDatabase('events', [
+        //     'status' => $response['data']['content']['status'],
+        // ]);
 
-    //     // Make sure a review is created.
-    //     $this->seeInDatabase('reviews', [
-    //         'postable_id' => $response['data']['postable_id'],
-    //     ]);
+        // Make sure a review is created.
+        $this->seeInDatabase('reviews', [
+            'post_id' => $response['data']['id'],
+        ]);
 
-    //     // Make sure the status is updated.
-    //     $this->seeInDatabase('photos', [
-    //         'status' => $response['data']['content']['status'],
-    //     ]);
-    // }
+        // Make sure the status is updated.
+        $this->seeInDatabase('posts', [
+            'status' => $response['data']['status'],
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
Updates `/reviews` endpoint and reviews tests. 

#### How should this be reviewed?
-Hit the `/reviews` endpoint
  - The post you reviewed should have the updated status in the `posts` table.
  - The information should be added in the `reviews` table with all expected info. 
  - Two events should be logged - one for the review and one for updated post. 
- Run `vendor/bin/phpunit --filter=Reviews` to make sure all tests are passing and/or `vendor/bin/phpunit` to make sure all tests are still passing! 

#### Relevant tickets
Fixes #171 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.