### PR TITLE
Allow backdating signup updates

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -91,10 +91,22 @@ class PostRepository
      */
     public function update($signup, $data)
     {
-        $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
+        if (array_key_exists('updated_at', $data)) {
+            $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated', 'updated_at']));
 
-        // Triggers model event that logs the updated signup in the events table.
-        $signup->save();
+            $signup->save(['timestamps' => false]);
+
+            $event = $signup->events->last();
+            $event->created_at = $data['updated_at'];
+            $event->updated_at = $data['updated_at'];
+            $event->save(['timestamps' => false]);
+        }
+        else {
+            $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
+
+            // Triggers model event that logs the updated signup in the events table.
+            $signup->save();
+        }
 
         // If there is a file, create a new post.
         if (array_key_exists('file', $data)) {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -100,8 +100,7 @@ class PostRepository
             $event->created_at = $data['updated_at'];
             $event->updated_at = $data['updated_at'];
             $event->save(['timestamps' => false]);
-        }
-        else {
+        } else {
             $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
 
             // Triggers model event that logs the updated signup in the events table.


### PR DESCRIPTION
#### What's this PR do?
Allow capability to backdate updates to signups, meaning when the quantity or why gets updated. These updates will be coming in through the keeper upper script so we will want to preserve the original signups for this type of update. It only backdates the signup if it comes in with an `updated_at` parameter.

#### How should this be reviewed?
I made sure the events stuff all still worked properly, but that's the part I'd be most worried about I think.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.