### PR TITLE
First part to save review of post in the database

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "babel": {
     "presets": [
-      "es2015",
-      "react"
+      "@dosomething/babel-config"
     ]
   },
   "dependencies": {
     "@dosomething/forge": "^6.7.4",
+    "@dosomething/gateway": "^1.0.2",
     "classnames": "^2.2.5",
     "dosomething-modal": "^0.3.0",
     "lodash": "^4.17.4",
@@ -21,6 +21,7 @@
     "react-dom": "^15.4.2"
   },
   "devDependencies": {
+    "@dosomething/babel-config": "^1.0.0",
     "@dosomething/webpack-config": "^1.1.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -1,20 +1,47 @@
 import React from 'react';
 import { flatMap } from 'lodash';
-import { map, sample } from 'lodash';
+import { keyBy, map, sample } from 'lodash';
+import { RestApiClient} from '@dosomething/gateway';
 
 import InboxItem from '../InboxItem';
 
 class CampaignInbox extends React.Component {
-  render() {
-    const signups = this.props['signups'];
-    const campaign = this.props['campaign'];
+  constructor(props) {
+    super(props);
 
-    const posts = flatMap(signups, signup => {
+    const posts = keyBy(flatMap(props.signups, signup => {
       return signup.posts.map(post => {
         post.signup = signup;
         return post;
       });
+    }), 'id');
+
+    this.state = {
+      posts: posts
+    };
+
+    this.api = new RestApiClient;
+    this.updatePost = this.updatePost.bind(this);
+  }
+
+  updatePost(postId, fields) {
+    // @TODO: Make API request to Rogue.
+    // let response = this.api.post(`v2/reviews`, fields);
+
+    this.setState((previousState) => {
+      const newState = {...previousState};
+      newState.posts[postId].status = fields.status;
+
+      // @TODO: Update this based on the response from API!
+      // newState.posts[postId] = response.data;
+
+      return newState;
     });
+  }
+
+  render() {
+    const posts = this.state.posts;
+    const campaign = this.props.campaign;
 
     const nothingHere = [
       'https://media.giphy.com/media/3og0IT9dAZyMz3lXNe/giphy.gif',
@@ -27,7 +54,7 @@ class CampaignInbox extends React.Component {
     if (posts.length !== 0) {
       return (
         <div className="container">
-          { map(posts, (post, key) => <InboxItem key={key} details={{post: post, campaign: campaign}} />) }
+          { map(posts, (post, key) => <InboxItem onUpdate={this.updatePost} key={key} details={{post: post, campaign: campaign}} />) }
         </div>
       )
     } else {

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -10,16 +10,12 @@ class InboxItem extends React.Component {
   constructor () {
     super();
 
-    this.state = {
-      status: 'pending',
-    };
-
     this.setStatus = this.setStatus.bind(this);
   }
 
   // @todo - define this on the StatusButton component that can set some sort of global state.
   setStatus(status) {
-    this.setState({ status });
+    this.props.onUpdate(this.props.details.post.id, { status: status })
   }
 
   getOtherPosts(post) {
@@ -82,7 +78,7 @@ class InboxItem extends React.Component {
           <ul className="form-actions -inline">
             <li><button className="button -tertiary">Delete</button></li>
           </ul>
-          {this.state.status === 'accepted' ? <Tags /> : null}
+          {post.status === 'accepted' ? <Tags /> : null}
           <h4>Meta</h4>
           <p>
             Post ID: {post['id']} <br/>


### PR DESCRIPTION
#### What's this PR do?
- Adds @dosomething/babel-config package.
- Brings individual post state to top level of campaign inbox.
- Adds pseudo code to set up RestApiClient and make call to `/reactions` endpoint.

#### How should this be reviewed?
- Click `Accepted` or `Rejected` button in campaign inbox page. 
 - In React dev tools, you should be able to see updated status for each post: 
![screen shot 2017-05-02 at 4 25 51 pm](https://cloud.githubusercontent.com/assets/9019452/25637742/12f1e932-2f54-11e7-883d-350545fdbb11.png)


#### Any background context you want to provide?
First part to organize data to review a post and save it in the database (setting up the state so we know what state is and can refresh the page).

#### Relevant tickets
Refs #242 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.