### PR TITLE
Apply status to post once reviewed

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Middleware;
 
+use Closure;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as BaseVerifier;
 
 class VerifyCsrfToken extends BaseVerifier
@@ -14,4 +15,14 @@ class VerifyCsrfToken extends BaseVerifier
     protected $except = [
         //
     ];
+
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        $response->headers->set('Access-Control-Allow-Origin' , '*');
+        $response->headers->set('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE');
+        $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Accept, Authorization, X-Requested-With, Application');
+
+        return $response;
+    }
 }

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -19,7 +19,7 @@ class VerifyCsrfToken extends BaseVerifier
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        $response->headers->set('Access-Control-Allow-Origin' , '*');
+        $response->headers->set('Access-Control-Allow-Origin', '*');
         $response->headers->set('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE');
         $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Accept, Authorization, X-Requested-With, Application');
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -3,6 +3,10 @@ This is the Rogue API, it is used to capture activity from members.
 All `POST` and `PUT` endpoints require an api key (`X-DS-Rogue-API-Key`) in the header to be submitted with the request. 
 
 ## Endpoints
+#### Reviews
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`PUT /api/v2/reviews`                         | [Update a post's status when admin reviews the post](endpoints/reviews.md#reviews)
 
 ### v1
 #### Reportbacks
@@ -31,11 +35,6 @@ Endpoint                                       | Functionality
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `POST /api/v2/reactions`                       | [Create or update a reaction](endpoints/reactions.md#reactions)
-
-#### Reviews
-Endpoint                                       | Functionality                                           
----------------------------------------------- | --------------------------------------------------------
-`POST /api/v2/reviews`                         | [Update a post or multiple posts' status when admin reviews](endpoints/reviews.md#reviews)
 
 #### Signups
 Endpoint                                       | Functionality                                           

--- a/documentation/endpoints/reviews.md
+++ b/documentation/endpoints/reviews.md
@@ -1,9 +1,9 @@
 ## Reviews
 
-Update a post or multiple posts' status when an admin reviews.
+Update a post's status when an admin reviews the post.
 
 ```
-PUT /api/v2/reviews
+PUT /reviews
 ```
 
   - **post_id**: (string) required.

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -26,17 +26,17 @@ class CampaignInbox extends React.Component {
 
   updatePost(postId, fields) {
     fields.post_id = postId;
-    let response = this.api.put('reviews', fields);
-      console.log(response);
-      console.log('hi');
+
     this.setState((previousState) => {
       const newState = {...previousState};
       newState.posts[postId].status = fields.status;
 
-      // @TODO: Update this based on the response from API!
-      newState.posts[postId] = response.data;
+      let response = this.api.put('reviews', fields);
 
-      console.log('made it!');
+      response.then(function(result) {
+        newState.posts[postId].status = result.data.status;
+      });
+
       return newState;
     });
   }

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -25,10 +25,10 @@ class CampaignInbox extends React.Component {
   }
 
   updatePost(postId, fields) {
-    // @TODO: Make API request to Rogue.
     fields.post_id = postId;
     let response = this.api.put('reviews', fields);
-
+      console.log(response);
+      console.log('hi');
     this.setState((previousState) => {
       const newState = {...previousState};
       newState.posts[postId].status = fields.status;
@@ -36,6 +36,7 @@ class CampaignInbox extends React.Component {
       // @TODO: Update this based on the response from API!
       newState.posts[postId] = response.data;
 
+      console.log('made it!');
       return newState;
     });
   }

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -26,9 +26,8 @@ class CampaignInbox extends React.Component {
 
   updatePost(postId, fields) {
     // @TODO: Make API request to Rogue.
-    // right now, fields only returns status. We need to add post_id (which we have in postId)
-    // and admin_northstar_id.
-    let response = this.api.put('api/v2/reviews', fields);
+    fields.post_id = postId;
+    let response = this.api.put('reviews', fields);
 
     this.setState((previousState) => {
       const newState = {...previousState};

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -17,8 +17,6 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPost()
     {
-        $this->expectsJobs(Rogue\Jobs\SendPostToPhoenix::class);
-
         // Create test Post. Temporarily use the current test reportback data
         // array as the requests are the same.
         // Create an uploaded file.


### PR DESCRIPTION
#### What's this PR do?
- Passes CSFR token in request
- Updates `/reviews` documentation
- Makes API call to `/reviews` when a post is reviewed to update the post's status and create a review in the reviews table 
- Irrelevant to this issue but saw that the `PostApiTest` was broken because we are no longer sending Posts to Phoenix. Got rid of that mocked job to make sure all tests are still passing! 

#### How should this be reviewed?
- Go to a campaign inbox page. 
- Accept a post and see in the database that the post's status has been updated and a review has been created. 
- On the same post, reject the post - you should again see the post status has been updated and a new review has been created. 
- Make sure all tests still pass. 

#### Any background context you want to provide?
Just a note - we have functionality to send a comment to the `/reviews` endpoint and enter in the reviews table but nothing yet on the front end for an admin to add a comment when reviewing. @ngjo not sure if we want to make a card for this for the way future? 

#### Relevant tickets
Fixes #242 
Fixes #251 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.