### PR TITLE
Let admins update quantity

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -26,10 +26,12 @@ class CampaignInbox extends React.Component {
 
     this.api = new RestApiClient;
     this.updatePost = this.updatePost.bind(this);
+    this.updateQuantity = this.updateQuantity.bind(this);
     this.showHistory = this.showHistory.bind(this);
     this.hideHistory = this.hideHistory.bind(this);
   }
 
+  // Open the history modal of the given post
   showHistory(postId, event) {
     event.preventDefault()
 
@@ -39,6 +41,7 @@ class CampaignInbox extends React.Component {
     });
   }
 
+  // Close the open history modal
   hideHistory(event) {
     event.preventDefault()
 
@@ -84,19 +87,26 @@ class CampaignInbox extends React.Component {
     // @TODO: need to update state for all posts under this SIGNUP
 
     // Make API request to Rogue.
-    // let response = this.api.post('api/v2/posts', fields);
-
     // Update the state
-    // this.setState((previousState) => {
-    //   const newState = {...previousState};
+    this.setState((previousState) => {
+      const newState = {...previousState};
+      console.log('state stuff:');
+      console.log(newState.posts[post.id].status);
+
+      let response = this.api.post('api/v2/posts', fields);
+
+      response.then(function(result) {
+        console.log(newState.posts[post.id].quantity);
+        newState.posts[post.id].quantity = result.quantity;
+      });
 
     //  @TODO update quant in signup of all other posts with the same signup_id - how?
 
-    //   return newState;
-    // });
+      return newState;
+    });
 
     // Close the modal (this doesn't work yet)
-    (e) => this.hideHistory(e);
+    // (e) => this.hideHistory(e);
   }
 
   render() {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -65,12 +65,13 @@ class CampaignInbox extends React.Component {
     });
   }
 
-  updateQuantity(postId, fields) {
+  updateQuantity(post, newQuantity) {
     console.log('updating quantity');
-    console.log(postId);
-    // @TODO: Make API request to Rogue.
-    // right now, fields only returns status. We need to add post_id (which we have in postId)
-    // and admin_northstar_id.
+    console.log(post);
+    console.log(newQuantity);
+
+    
+    // Make API request to Rogue.
     // let response = this.api.put('api/v2/posts', fields);
 
     // this.setState((previousState) => {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -41,7 +41,9 @@ class CampaignInbox extends React.Component {
   }
 
   // Close the open history modal
-  hideHistory() {
+  hideHistory(event) {
+    event.preventDefault()
+
     this.setState({
       displayHistoryModal: false,
       historyModalId: null,
@@ -96,7 +98,7 @@ class CampaignInbox extends React.Component {
     });
 
     // Close the modal
-    this.hideHistory();
+    this.hideHistory(event);
   }
 
   render() {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -66,23 +66,37 @@ class CampaignInbox extends React.Component {
   }
 
   updateQuantity(post, newQuantity) {
+    // @TODO: remove these before merging
     console.log('updating quantity');
     console.log(post);
     console.log(newQuantity);
 
-    
-    // Make API request to Rogue.
-    // let response = this.api.put('api/v2/posts', fields);
+    // Fields to send to /posts
+    const fields = {
+      northstar_id: post.user.id,
+      campaign_id: post.signup.campaign_id,
+      campaign_run_id: post.signup.campaign_run_id,
+      quantity: newQuantity,
+    };
 
+    console.log(fields); //@TODO: remove this
+
+    // @TODO: need to update state for all posts under this SIGNUP
+
+    // Make API request to Rogue.
+    // let response = this.api.post('api/v2/posts', fields);
+
+    // Update the state
     // this.setState((previousState) => {
     //   const newState = {...previousState};
-    //   newState.posts[postId].status = fields.status;
 
-    //   // @TODO: Update this based on the response from API!
-    //   newState.posts[postId] = response.data;
+    //  @TODO update quant in signup of all other posts with the same signup_id - how?
 
     //   return newState;
     // });
+
+    // Close the modal (this doesn't work yet)
+    (e) => this.hideHistory(e);
   }
 
   render() {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -42,7 +42,9 @@ class CampaignInbox extends React.Component {
 
   // Close the open history modal
   hideHistory(event) {
-    event.preventDefault()
+    if (event) {
+      event.preventDefault();
+    }
 
     this.setState({
       displayHistoryModal: false,
@@ -98,7 +100,7 @@ class CampaignInbox extends React.Component {
     });
 
     // Close the modal
-    this.hideHistory(event);
+    this.hideHistory();
   }
 
   render() {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -90,7 +90,7 @@ class CampaignInbox extends React.Component {
         // Update the quantity for each post under this signup
         forEach (newState.posts, (value) => {
           if (value.signup_id == signupChanged) {
-            value.signup.quantity = newQuantity;
+            value.signup.quantity = result.quantity;
           }
         });
 

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -65,6 +65,25 @@ class CampaignInbox extends React.Component {
     });
   }
 
+  updateQuantity(postId, fields) {
+    console.log('updating quantity');
+    console.log(postId);
+    // @TODO: Make API request to Rogue.
+    // right now, fields only returns status. We need to add post_id (which we have in postId)
+    // and admin_northstar_id.
+    // let response = this.api.put('api/v2/posts', fields);
+
+    // this.setState((previousState) => {
+    //   const newState = {...previousState};
+    //   newState.posts[postId].status = fields.status;
+
+    //   // @TODO: Update this based on the response from API!
+    //   newState.posts[postId] = response.data;
+
+    //   return newState;
+    // });
+  }
+
   render() {
     const posts = this.state.posts;
     const campaign = this.props.campaign;
@@ -82,7 +101,7 @@ class CampaignInbox extends React.Component {
         <div className="container">
           { map(posts, (post, key) => <InboxItem onUpdate={this.updatePost} showHistory={this.showHistory} key={key} details={{post: post, campaign: campaign}} />) }
           <ModalContainer>
-            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign}}/> : null}
+            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign}}/> : null}
           </ModalContainer>
         </div>
       )

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -25,7 +25,7 @@ class HistoryModal extends React.Component {
 					<h3>Reportback History</h3>
 					<p>table of all the history goes here 📖</p>
 				</div>
-				<a className="button -history">Save</a>
+				<a className="button -history" onClick={() => this.props.onUpdate(post)}>Save</a>
 			</div>
 		);
 	}

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -18,14 +18,14 @@ class HistoryModal extends React.Component {
 					<div className="container__block -half">
 						<h4>New Quantity</h4>
 						<div className="form-item">
-							<input type="text" className="text-field" placeholder="Enter # here"></input>
+							<input ref={(input) => this.newQuantity = input} type="text" className="text-field" placeholder="Enter # here"/>
 						</div>
 					</div>
 
 					<h3>Reportback History</h3>
 					<p>table of all the history goes here 📖</p>
 				</div>
-				<a className="button -history" onClick={() => this.props.onUpdate(post)}>Save</a>
+				<a className="button -history" onClick={() => this.props.onUpdate(post, this.newQuantity.value)}>Save</a>
 			</div>
 		);
 	}


### PR DESCRIPTION
#### What's this PR do?
This is a magical time. When an admin opens the history modal, they can update the quantity and hit "Save" to see the quantity update on the post (and all other posts under that same signup). Gif ⬇️ 
![update_quantity](https://cloud.githubusercontent.com/assets/4240292/26074309/420604b2-397f-11e7-8db3-b71a78060a87.gif)

Questions:
1. @sbsmith86 mentioned that we should disable the save button until the admin has entered something into the new quantity form. I think this is a good idea, but I'm not sure if that's out of scope for this or not?
2. We should probably have some validation on the form so admins can't enter "platypus" for quantity because currently they are able to. Is that in scope?
![image](https://cloud.githubusercontent.com/assets/4240292/26073074/a8bb2d62-397b-11e7-89f3-773735c9d9b3.png)
3. I believe in grooming on Wednesday we will talk about how to deal with logging events of admins updating quantity and sending the admin's Northstar ID to `/posts`.
4. On the card it says to write tests for this, but as far as I can tell those would be frontend tests which I don't think we have any of yet. Did we want to start that now?

#### How should this be reviewed?
Make sure I didn't mess up any javascript/react conventions and that nothing is hacky 😬 

#### Checklist
- [ ] Tested on staging.