### PR TITLE
Hook up the delete button to the backend

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { flatMap, keyBy, map, sample, forEach } from 'lodash';
+import { flatMap, keyBy, map, sample, forEach, reject } from 'lodash';
 import { RestApiClient} from '@dosomething/gateway';
 
 import InboxItem from '../InboxItem';
@@ -28,6 +28,7 @@ class CampaignInbox extends React.Component {
     this.updateQuantity = this.updateQuantity.bind(this);
     this.showHistory = this.showHistory.bind(this);
     this.hideHistory = this.hideHistory.bind(this);
+    this.deletePost = this.deletePost.bind(this);
   }
 
   // Open the history modal of the given post
@@ -103,6 +104,28 @@ class CampaignInbox extends React.Component {
     this.hideHistory();
   }
 
+  deletePost(postId, event) {
+    event.preventDefault();
+    confirm('Are you sure you want to delete this?');
+
+    console.log('bout to delete this');
+    // Make API request to Rogue to update the quantity on the backend
+    let response = this.api.delete('api/v2/posts/'.concat(postId));
+
+    response.then((result) => {
+      // Update the state
+      this.setState((previousState) => {
+        var newState = {...previousState};
+
+        // Remove the deleted post from the state
+        newState.posts = reject(newState.posts, ['id', postId]);
+
+        // Return the new state
+        return newState;
+      });
+    });
+  }
+
   render() {
     const posts = this.state.posts;
     const campaign = this.props.campaign;
@@ -118,7 +141,7 @@ class CampaignInbox extends React.Component {
     if (posts.length !== 0) {
       return (
         <div className="container">
-          { map(posts, (post, key) => <InboxItem onUpdate={this.updatePost} showHistory={this.showHistory} key={key} details={{post: post, campaign: campaign}} />) }
+          { map(posts, (post, key) => <InboxItem onUpdate={this.updatePost} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign}} />) }
           <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign}}/> : null}
           </ModalContainer>

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -77,7 +77,7 @@ class InboxItem extends React.Component {
             <li><StatusButton type="rejected" setStatus={this.setStatus}/></li>
           </ul>
           <ul className="form-actions -inline">
-            <li><button className="button -tertiary">Delete</button></li>
+            <li><button className="button -tertiary" onClick={e => this.props.deletePost(post['id'], e)}>Delete</button></li>
           </ul>
           {post.status === 'accepted' ? <Tags /> : null}
           <h4>Meta</h4>


### PR DESCRIPTION
#### What's this PR do?
Hooked up the "delete" button to the backend so it makes a request to delete the post. Works the same way as opening the history modal, except instead of `showHistory` it calls `deletePost` when the button is clicked.
![deletepost](https://cloud.githubusercontent.com/assets/4240292/26211467/75e55042-3bc0-11e7-90e3-b785b8365c10.gif)


#### How should this be reviewed?
Click the delete button and see the post leave the page. If you refresh the page, the post should not reappear (meaning that it is really soft deleted in the db).

#### Relevant tickets
Fixes #262

#### Checklist
- [ ] Tested on staging.