### PR TITLE
Confirm intent to delete before deleting

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -106,24 +106,25 @@ class CampaignInbox extends React.Component {
 
   deletePost(postId, event) {
     event.preventDefault();
-    confirm('Are you sure you want to delete this?');
+    const confirmed = confirm('Are you sure you want to delete this?');
 
-    console.log('bout to delete this');
-    // Make API request to Rogue to update the quantity on the backend
-    let response = this.api.delete('api/v2/posts/'.concat(postId));
+    if (confirmed) {
+      // Make API request to Rogue to update the quantity on the backend
+      let response = this.api.delete('api/v2/posts/'.concat(postId));
 
-    response.then((result) => {
-      // Update the state
-      this.setState((previousState) => {
-        var newState = {...previousState};
+      response.then((result) => {
+        // Update the state
+        this.setState((previousState) => {
+          var newState = {...previousState};
 
-        // Remove the deleted post from the state
-        newState.posts = reject(newState.posts, ['id', postId]);
+          // Remove the deleted post from the state
+          newState.posts = reject(newState.posts, ['id', postId]);
 
-        // Return the new state
-        return newState;
+          // Return the new state
+          return newState;
+        });
       });
-    });
+    }
   }
 
   render() {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -106,7 +106,7 @@ class CampaignInbox extends React.Component {
 
   deletePost(postId, event) {
     event.preventDefault();
-    const confirmed = confirm('Are you sure you want to delete this?');
+    const confirmed = confirm('🚨🔥🚨Are you sure you want to delete this?🚨🔥🚨');
 
     if (confirmed) {
       // Make API request to Rogue to update the quantity on the backend


### PR DESCRIPTION
#### What's this PR do?
Adds logic to only send the request to delete the post if the admin confirms that they want to delete it.

![deleteconfirm - updated](https://cloud.githubusercontent.com/assets/4240292/26219548/69722a02-3bdd-11e7-9e08-b760bbfad7cd.gif)

#### How should this be reviewed?
Could anyone accidentally delete a post without hitting "OK" in the confirmation pop-up?

#### Relevant tickets
[Trello card](https://trello.com/c/ui1DljOC/335-2-as-a-rogue-user-i-want-to-be-asked-to-confirm-deleting-the-post-so-that-my-actions-are-questioned)

#### Checklist
- [ ] Tested on staging.