### PR TITLE
Auth API middleware

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -83,21 +83,4 @@ class PostsController extends ApiController
             }
         }
     }
-
-    /**
-     * Delete a resource in storage
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($postId)
-    {
-        $postDeleted = $this->posts->destroy($postId);
-
-        if ($postDeleted) {
-            return response()->json(['code' => 200, 'message' => 'Post deleted.']);
-        } else {
-            return response()->json(['code' => 500, 'message' => 'There was an error deleting the post']);
-        }
-    }
 }

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -39,8 +39,6 @@ class PostsController extends ApiController
      */
     public function __construct(PostService $posts, SignupRepository $signups)
     {
-        $this->middleware('api');
-
         $this->posts = $posts;
         $this->signups = $signups;
 

--- a/app/Http/Controllers/Api/ReactionController.php
+++ b/app/Http/Controllers/Api/ReactionController.php
@@ -19,8 +19,6 @@ class ReactionController extends ApiController
      */
     public function __construct()
     {
-        $this->middleware('api');
-
         $this->transformer = new ReactionTransformer;
     }
 

--- a/app/Http/Controllers/Api/SignupsController.php
+++ b/app/Http/Controllers/Api/SignupsController.php
@@ -36,8 +36,6 @@ class SignupsController extends ApiController
      */
     public function __construct(SignupService $signups, PostService $posts)
     {
-        $this->middleware('api');
-
         $this->signups = $signups;
         $this->posts = $posts;
     }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rogue\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Rogue\Services\PostService;
+
+class PostController extends Controller
+{
+    /**
+     * The post service instance.
+     *
+     * @var Rogue\Services\PostService
+     */
+    protected $posts;
+
+    /**
+     * Create a controller instance.
+     *
+     * @param  PostContract  $posts
+     * @return void
+     */
+    public function __construct(PostService $posts)
+    {
+        $this->middleware('auth');
+        $this->middleware('role:admin,staff');
+
+        $this->posts = $posts;
+    }
+
+    /**
+     * Delete a resource in storage
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($postId)
+    {
+        $postDeleted = $this->posts->destroy($postId);
+
+        if ($postDeleted) {
+            return response()->json(['code' => 200, 'message' => 'Post deleted.']);
+        } else {
+            return response()->json(['code' => 500, 'message' => 'There was an error deleting the post']);
+        }
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Rogue\Services\PostService;
 
 class PostController extends Controller

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -47,7 +47,7 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['auth.api', 'log.received.r
 });
 
 // v2 routes
-Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api','log.received.request']], function () {
+Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api', 'log.received.request']], function () {
 
     // activity
     Route::get('activity', 'Api\ActivityController@index');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -26,7 +26,7 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('users', 'UsersController@index');
 
     // posts
-    Route::delete('posts/{id}', 'Api\PostsController@destroy');
+    Route::delete('posts/{id}', 'PostController@destroy');
 
     // reviews
     Route::put('reviews', 'ReviewsController@reviews');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -25,6 +25,9 @@ Route::group(['middleware' => 'web'], function () {
 
     Route::get('users', 'UsersController@index');
 
+    // posts
+    Route::delete('posts/{id}', 'Api\PostsController@destroy');
+
     // reviews
     Route::put('reviews', 'ReviewsController@reviews');
 
@@ -54,7 +57,6 @@ Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api', 'log.received.r
 
     // posts
     Route::post('posts', 'Api\PostsController@store');
-    Route::delete('posts/{id}', 'Api\PostsController@destroy');
 
     // reactions
     Route::post('reactions', 'Api\ReactionController@store');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -33,7 +33,7 @@ Route::group(['middleware' => 'web'], function () {
 });
 
 // Legacy API Routes
-Route::group(['prefix' => 'api/v1', 'middleware' => ['api', 'log.received.request']], function () {
+Route::group(['prefix' => 'api/v1', 'middleware' => ['auth.api', 'log.received.request']], function () {
     Route::get('/', function () {
         return 'Rogue API version 1';
     });
@@ -47,7 +47,7 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['api', 'log.received.reques
 });
 
 // v2 routes
-Route::group(['prefix' => 'api/v2', 'middleware' => ['log.received.request']], function () {
+Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api','log.received.request']], function () {
 
     // activity
     Route::get('activity', 'Api\ActivityController@index');

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -56,10 +56,10 @@ Example Response:
 }
 ```
 
-Delete a post. Posts get soft deleted from the database.
+Allows admins to delete a post. Posts get soft deleted from the database.
 
 ```
-DELETE /api/v2/posts/{post_id}
+DELETE posts/{post_id}
 ```
 
 Example Response:

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -110,7 +110,7 @@ class CampaignInbox extends React.Component {
 
     if (confirmed) {
       // Make API request to Rogue to update the quantity on the backend
-      let response = this.api.delete('api/v2/posts/'.concat(postId));
+      let response = this.api.delete('posts/'.concat(postId));
 
       response.then((result) => {
         // Update the state

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -1,12 +1,9 @@
 <?php
 
 use Rogue\Models\Post;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class PostApiTest extends TestCase
 {
-    use WithoutMiddleware;
-
     /*
      * Base URL for the Api.
      */
@@ -46,7 +43,7 @@ class PostApiTest extends TestCase
         // Mock sending image to AWS.
         Storage::shouldReceive('put')->andReturn(true);
 
-        $response = $this->json('POST', $this->postsApiUrl, $post);
+        $response = $this->authed()->json('POST', $this->postsApiUrl, $post);
 
         $this->assertResponseStatus(200);
 

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -60,28 +60,4 @@ class PostApiTest extends TestCase
             'quantity' => $post['quantity'],
         ]);
     }
-
-    /**
-     * Test that posts get soft deleted when hiting the DELETE endpoint.
-     *
-     * @return void
-     */
-    public function testDeletingAPost()
-    {
-        $post = factory(Post::class)->create();
-
-        $this->json('DELETE', $this->postsApiUrl . '/' . $post->id);
-
-        $this->assertResponseStatus(200);
-
-        // Check that the post record is still in the database
-        // Also, check that you can't find it with a `deleted_at` column as null.
-        $this->seeInDatabase('posts', [
-                'id' => $post->id,
-                'url' => null,
-            ])->notSeeInDatabase('posts', [
-                'id' => $post->id,
-                'deleted_at' => null,
-            ]);
-    }
 }

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -5,6 +5,8 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class PostApiTest extends TestCase
 {
+    use WithoutMiddleware;
+
     /*
      * Base URL for the Api.
      */

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Rogue\Models\User;
+use Rogue\Models\Post;
+
+class PostTest extends TestCase
+{
+    /**
+     * Test that posts get soft deleted when hiting the DELETE endpoint.
+     *
+     * @return void
+     */
+    public function testDeletingAPost()
+    {
+        $user = factory(User::class)->make([
+            'role' => 'admin',
+        ]);
+
+        $this->be($user);
+
+        $post = factory(Post::class)->create();
+
+        $this->json('DELETE', 'posts/' . $post->id);
+
+        $this->assertResponseStatus(200);
+
+        // Check that the post record is still in the database
+        // Also, check that you can't find it with a `deleted_at` column as null.
+        $this->seeInDatabase('posts', [
+                'id' => $post->id,
+                'url' => null,
+            ])->notSeeInDatabase('posts', [
+                'id' => $post->id,
+                'deleted_at' => null,
+            ]);
+    }
+
+    /**
+     * Test that non-admins can't delete posts.
+     *
+     * @return void
+     */
+    public function testUnauthenticatedUserDeletingAPost()
+    {
+        $user = factory(User::class)->make();
+
+        $this->be($user);
+
+        $post = factory(Post::class)->create();
+
+        $this->json('DELETE', 'posts/' . $post->id);
+
+        $this->assertResponseStatus(403);
+    }
+}

--- a/tests/ReactionsApiTest.php
+++ b/tests/ReactionsApiTest.php
@@ -2,12 +2,9 @@
 
 use Rogue\Models\Post;
 use Faker\Generator;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class ReactionsApiTest extends TestCase
 {
-    use WithoutMiddleware;
-
     /*
      * Base URL for the Api.
      */
@@ -29,7 +26,7 @@ class ReactionsApiTest extends TestCase
         $northstarId = $this->faker->uuid;
 
         // Create a reaction.
-        $this->json('POST', $this->reactionsApiUrl, [
+        $this->authed()->json('POST', $this->reactionsApiUrl, [
             'northstar_id' => $northstarId,
             'post_id' => $post->id,
         ]);
@@ -44,7 +41,7 @@ class ReactionsApiTest extends TestCase
         ]);
 
         // React (unlike) again to the same photo with the same user.
-         $this->json('POST', $this->reactionsApiUrl, [
+         $this->authed()->json('POST', $this->reactionsApiUrl, [
             'northstar_id' => $northstarId,
             'post_id' => $post->id,
         ]);
@@ -73,7 +70,7 @@ class ReactionsApiTest extends TestCase
         $post = factory(Post::class)->create();
 
         // Create a reaction.
-        $this->json('POST', $this->reactionsApiUrl, [
+        $this->authed()->json('POST', $this->reactionsApiUrl, [
             'northstar_id' => $this->faker->uuid,
             'post_id' => $post->id,
         ]);
@@ -88,7 +85,7 @@ class ReactionsApiTest extends TestCase
         ]);
 
         // A second user reacts to the same photo.
-        $this->json('POST', $this->reactionsApiUrl, [
+        $this->authed()->json('POST', $this->reactionsApiUrl, [
             'northstar_id' => $this->faker->uuid,
             'post_id' => $post->id,
         ]);

--- a/tests/ReactionsApiTest.php
+++ b/tests/ReactionsApiTest.php
@@ -2,9 +2,12 @@
 
 use Rogue\Models\Post;
 use Faker\Generator;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class ReactionsApiTest extends TestCase
 {
+    use WithoutMiddleware;
+
     /*
      * Base URL for the Api.
      */

--- a/tests/SignupApiTest.php
+++ b/tests/SignupApiTest.php
@@ -1,11 +1,7 @@
 <?php
 
-use Illuminate\Foundation\Testing\WithoutMiddleware;
-
 class SignupApiTest extends TestCase
 {
-    use WithoutMiddleware;
-
     /*
      * Base URL for the Api.
      */
@@ -29,7 +25,7 @@ class SignupApiTest extends TestCase
         ];
 
         // Send the signup and make sure the response has the data we expect
-        $response = $this->json('POST', $this->signupsApiUrl, $signup)
+        $response = $this->authed()->json('POST', $this->signupsApiUrl, $signup)
         				 ->seeJson([
                             'northstar_id' => $signup['northstar_id'],
                             'campaign_id' => $signup['campaign_id'],

--- a/tests/SignupApiTest.php
+++ b/tests/SignupApiTest.php
@@ -4,6 +4,8 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class SignupApiTest extends TestCase
 {
+    use WithoutMiddleware;
+
     /*
      * Base URL for the Api.
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,4 +78,13 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
         $test = true;
         return new \Illuminate\Http\UploadedFile($path, $original_name, $mime_type, $error, $test);
     }
+
+    public function authed()
+    {
+        $header = $this->transformHeadersToServerVars(['X-DS-Rogue-API-Key' => env('ROGUE_API_KEY')]);
+
+        $this->serverVariables = array_merge($this->serverVariables, $header);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
#### What's this PR do?

So, apparently we already had `AuthenticatAPI` middleware but we just were not using it. This PR:

* Uses the `auth.api` middleware on all the api routes. We were using the `api` middleware but this wasn't defined and did nothing. 
* moves the posts `DELETE` endpoint to the web route group and splits out it's functionality into it's own `PostController` that authenticates the request and deletes the post
* Updates tests accordingly 

#### How should this be reviewed?
commit by commit should work!

#### Relevant tickets
Fixes #236 

