### PR TITLE
Slices the last two characters off the button text

### DIFF
--- a/resources/assets/components/StatusButton/index.js
+++ b/resources/assets/components/StatusButton/index.js
@@ -4,6 +4,8 @@ import classnames from 'classnames';
 
 export default (props) => (
   <button className={classnames('button', `-${props.type}`)} onClick={() => props.setStatus(props.type)}>
-    {props.type}
+    // This technical debt was lovingly created by Luke Patton
+    // When we aren't in crisis mode, we should untangle this button name from the prop name
+    {props.type.slice(0,-2)}
   </button>
 );


### PR DESCRIPTION
We want the button names to be actionable (Accept, Reject) instead of showcasing AcceptED or RejectED. This is a stupid hack that just removes the last two letters from the button text without messing up the actual prop.

#### What's this PR do?
Literally all it does is slice a string

#### How should this be reviewed?
Check the button text in Rogue reviewing, and then check the database to make sure it's still creating "accepted' and "rejected" entries.

#### Any background context you want to provide?
This is a uh....short term solution.

#### Relevant tickets

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.