### PR TITLE
Signup timestamp updates when posts, reviews, or reactions are made. 

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -18,6 +18,13 @@ class Post extends Model
     protected $dates = ['deleted_at'];
 
     /**
+     * All of the relationships to be touched.
+     *
+     * @var array
+     */
+    protected $touches = ['signup'];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -21,7 +21,7 @@ class Reaction extends Model
      *
      * @var array
      */
-    protected $touches = ['post', 'signup'];
+    protected $touches = ['post'];
 
     /**
      * The attributes that are mass assignable.
@@ -44,10 +44,5 @@ class Reaction extends Model
     public function post()
     {
         return $this->belongsTo(Post::class);
-    }
-
-    public function signup()
-    {
-        return $this->post->signup();
     }
 }

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -17,6 +17,13 @@ class Reaction extends Model
     protected $dates = ['deleted_at'];
 
     /**
+     * All of the relationships to be touched.
+     *
+     * @var array
+     */
+    protected $touches = ['post'];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -21,7 +21,7 @@ class Reaction extends Model
      *
      * @var array
      */
-    protected $touches = ['post'];
+    protected $touches = ['post', 'signup'];
 
     /**
      * The attributes that are mass assignable.
@@ -44,5 +44,10 @@ class Reaction extends Model
     public function post()
     {
         return $this->belongsTo(Post::class);
+    }
+
+    public function signup()
+    {
+        return $this->post->signup();
     }
 }

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -18,7 +18,7 @@ class Review extends Model
      *
      * @var array
      */
-    protected $touches = ['post', 'signup'];
+    protected $touches = ['post'];
 
     /**
      * Each review has events.
@@ -34,10 +34,5 @@ class Review extends Model
     public function post()
     {
         return $this->belongsTo(Post::class);
-    }
-
-    public function signup()
-    {
-        return $this->post->signup();
     }
 }

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -18,7 +18,7 @@ class Review extends Model
      *
      * @var array
      */
-    protected $touches = ['post'];
+    protected $touches = ['post', 'signup'];
 
     /**
      * Each review has events.
@@ -34,5 +34,10 @@ class Review extends Model
     public function post()
     {
         return $this->belongsTo(Post::class);
+    }
+
+    public function signup()
+    {
+        return $this->post->signup();
     }
 }

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -14,6 +14,13 @@ class Review extends Model
     protected $fillable = ['signup_id', 'northstar_id', 'admin_northstar_id', 'status', 'old_status', 'comment', 'post_id'];
 
     /**
+     * All of the relationships to be touched.
+     *
+     * @var array
+     */
+    protected $touches = ['post'];
+
+    /**
      * Each review has events.
      */
     public function events()

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -62,7 +62,7 @@ $factory->define(Reportback::class, function (Generator $faker) {
 $factory->define(Reaction::class, function (Generator $faker) {
     return [
         'northstar_id' => str_random(24),
-        'reportback_item_id' => $faker->randomNumber(7),
+        'post_id' => $faker->randomNumber(7),
     ];
 });
 

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -2,6 +2,7 @@
 
 use Rogue\Models\User;
 use Rogue\Models\Post;
+use Rogue\Models\Signup;
 
 class PostTest extends TestCase
 {
@@ -51,5 +52,31 @@ class PostTest extends TestCase
         $this->json('DELETE', 'posts/' . $post->id);
 
         $this->assertResponseStatus(403);
+    }
+
+    /**
+     * Test that a signup's updated_at updates when a post is updated.
+     *
+     * @return void
+     */
+    public function testUpdatingSignupTimestampWhenPostIsUpdated()
+    {
+        // Create a signup and a post, and associate them to each other.
+        $signup = factory(Signup::class)->create();
+        $post = factory(Post::class)->create();
+        $post->signup()->associate($signup);
+
+        // Wait 1 second before updating the caption to make sure the created_at and updated_at times are different.
+        sleep(2);
+
+        // Update the caption of the post.
+        $post->caption = 'new caption';
+        $post->save();
+
+        // Re-grab the updated signup from the database.
+        $updatedSignup = Signup::where('id', $signup->id)->first();
+
+        // Make sure the signup and post's updated_at matches.
+        $this->assertEquals($post->updated_at, $updatedSignup->updated_at);
     }
 }

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -67,7 +67,7 @@ class PostTest extends TestCase
         $post->signup()->associate($signup);
 
         // Wait 1 second before updating the caption to make sure the created_at and updated_at times are different.
-        sleep(2);
+        sleep(1);
 
         // Update the caption of the post.
         $post->caption = 'new caption';

--- a/tests/ReactionsApiTest.php
+++ b/tests/ReactionsApiTest.php
@@ -113,6 +113,7 @@ class ReactionsApiTest extends TestCase
         $signup = factory(Signup::class)->create();
         $post = factory(Post::class)->create();
         $post->signup()->associate($signup);
+        $post->save();
 
         // Wait 1 second before making a reaction to make sure the created_at and updated_at times are different.
         sleep(1);

--- a/tests/ReactionsApiTest.php
+++ b/tests/ReactionsApiTest.php
@@ -2,6 +2,7 @@
 
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
+use Rogue\Models\Reaction;
 use Faker\Generator;
 
 class ReactionsApiTest extends TestCase
@@ -117,8 +118,7 @@ class ReactionsApiTest extends TestCase
         sleep(1);
 
         // Create a reaction for the post.
-        $this->authed()->json('POST', $this->reactionsApiUrl, [
-            'northstar_id' => $this->faker->uuid,
+        $reaction = factory(Reaction::class)->create([
             'post_id' => $post->id,
         ]);
 
@@ -127,7 +127,7 @@ class ReactionsApiTest extends TestCase
         $updatedPost = Post::where('id', $post->id)->first();
 
         // Make sure the signup and post's updated_at matches the reaction created_at time.
-        $this->assertEquals($post->reactions[0]->created_at, $updatedSignup->updated_at);
-        $this->assertEquals($post->reactions[0]->created_at, $updatedPost->updated_at);
+        $this->assertEquals($reaction->created_at, $updatedSignup->updated_at);
+        $this->assertEquals($reaction->created_at, $updatedPost->updated_at);
     }
 }

--- a/tests/ReviewsTest.php
+++ b/tests/ReviewsTest.php
@@ -95,6 +95,7 @@ class ReviewsTest extends TestCase
         $signup = factory(Signup::class)->create();
         $post = factory(Post::class)->create();
         $post->signup()->associate($signup);
+        $post->save();
 
         // Wait 1 second before making a review to make sure the created_at and updated_at times are different.
         sleep(1);
@@ -110,7 +111,6 @@ class ReviewsTest extends TestCase
         // Re-grab the updated signup and post from the database.
         $updatedSignup = Signup::where('id', $signup->id)->first();
         $updatedPost = Post::where('id', $post->id)->first();
-        dd($updatedPost);
 
         // Make sure the signup and post's updated_at matches the reaction created_at time.
         $this->assertEquals($post->review->created_at, $updatedSignup->updated_at);

--- a/tests/ReviewsTest.php
+++ b/tests/ReviewsTest.php
@@ -96,10 +96,10 @@ class ReviewsTest extends TestCase
         $post = factory(Post::class)->create();
         $post->signup()->associate($signup);
 
-        // Wait 1 second before making a reaction to make sure the created_at and updated_at times are different.
+        // Wait 1 second before making a review to make sure the created_at and updated_at times are different.
         sleep(1);
 
-        // Review for the post.
+        // Review the post.
         $review = [
             'post_id' => $post->id,
             'status' => 'accepted',
@@ -110,6 +110,7 @@ class ReviewsTest extends TestCase
         // Re-grab the updated signup and post from the database.
         $updatedSignup = Signup::where('id', $signup->id)->first();
         $updatedPost = Post::where('id', $post->id)->first();
+        dd($updatedPost);
 
         // Make sure the signup and post's updated_at matches the reaction created_at time.
         $this->assertEquals($post->review->created_at, $updatedSignup->updated_at);

--- a/tests/ReviewsTest.php
+++ b/tests/ReviewsTest.php
@@ -3,6 +3,7 @@
 use Rogue\Models\Event;
 use Rogue\Models\Post;
 use Rogue\Models\User;
+use Rogue\Models\Signup;
 use Faker\Generator;
 
 class ReviewsTest extends TestCase
@@ -75,5 +76,43 @@ class ReviewsTest extends TestCase
 
         $this->json('PUT', $this->reviewsUrl, $review);
         $this->assertResponseStatus(403);
+    }
+
+    /**
+     * Test that a post and signup's updated_at updates when a review is made.
+     *
+     * @return void
+     */
+    public function testUpdatedPostAndSignupWithReview()
+    {
+        $user = factory(User::class)->make([
+            'role' => 'admin',
+        ]);
+
+        $this->be($user);
+
+        // Create a signup and a post, and associate them to each other.
+        $signup = factory(Signup::class)->create();
+        $post = factory(Post::class)->create();
+        $post->signup()->associate($signup);
+
+        // Wait 1 second before making a reaction to make sure the created_at and updated_at times are different.
+        sleep(1);
+
+        // Review for the post.
+        $review = [
+            'post_id' => $post->id,
+            'status' => 'accepted',
+        ];
+
+        $this->json('PUT', $this->reviewsUrl, $review);
+
+        // Re-grab the updated signup and post from the database.
+        $updatedSignup = Signup::where('id', $signup->id)->first();
+        $updatedPost = Post::where('id', $post->id)->first();
+
+        // Make sure the signup and post's updated_at matches the reaction created_at time.
+        $this->assertEquals($post->review->created_at, $updatedSignup->updated_at);
+        $this->assertEquals($post->review->created_at, $updatedPost->updated_at);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds `touches` to Post Model, Reaction Model, and Review Model to update their parents' `updated_at` timestamp when they are updated. 
- Writes tests to make sure everything is working. 
- Updates `Reaction` model factory.

#### How should this be reviewed?
- Make sure all tests pass! 

#### Any background context you want to provide?
When a post is tagged or untagged, the post's nor the signup's `updated_at` will not change. Do we want this to happen? Not sure if this is applicable to Quasar/Looker. Also, we would have to change the model in laravel-tagging to do this as well as the `tagging_tagged` table to include timestamps.
cc @ngjo @sheyd @jamjensen 
#### Relevant tickets
Fixes #271 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.