### PR TITLE
Adds updated_at param to /activity endpoint

### DIFF
--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -33,9 +33,12 @@ trait FiltersRequests
         $filters = array_intersect_key($filters, array_flip($indexes));
 
         // If there is an updated_at param, remove it from $filters and save the value.
-        if (!(array_search('updated_at', $filters))) {
+        if (array_key_exists('updated_at', $filters)) {
             $updatedAtValue = $filters['updated_at'];
             unset($filters['updated_at']);
+        }
+        else {
+            $updatedAtValue = false;
         }
 
         // You can filter by multiple values, e.g. `filter[source]=agg,cgg`

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -36,8 +36,7 @@ trait FiltersRequests
         if (array_key_exists('updated_at', $filters)) {
             $updatedAtValue = $filters['updated_at'];
             unset($filters['updated_at']);
-        }
-        else {
+        } else {
             $updatedAtValue = false;
         }
 

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -29,9 +29,14 @@ trait FiltersRequests
         if (! $filters) {
             return $query;
         }
-
         // Requests may be filtered by indexed fields.
         $filters = array_intersect_key($filters, array_flip($indexes));
+
+        // If there is an updated_at param, remove it from $filters and save the value.
+        if (!(array_search('updated_at', $filters))) {
+            $updatedAtValue = $filters['updated_at'];
+            unset($filters['updated_at']);
+        }
 
         // You can filter by multiple values, e.g. `filter[source]=agg,cgg`
         // to get records that have a source value of either `agg` or `cgg`.
@@ -48,6 +53,10 @@ trait FiltersRequests
             } else {
                 $query->where($filter, $values[0], 'and');
             }
+        }
+
+        if ($updatedAtValue) {
+            $query->where('updated_at', '>', $updatedAtValue);
         }
 
         return $query;

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -22,7 +22,7 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'campaign_run_id',
+        'campaign_id', 'campaign_run_id', 'updated_at',
     ];
 
     /**

--- a/database/migrations/2017_05_30_184559_add_updated_at_index_to_signups_table.php
+++ b/database/migrations/2017_05_30_184559_add_updated_at_index_to_signups_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUpdatedAtIndexToSignupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->index('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropIndex(['updated_at']);
+        });
+    }
+}

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -21,6 +21,9 @@ GET /api/v2/activity
 - **user** _(integer)_
   - Whether or not to include information about the user with the response.
   - e.g. `/activity?include=user`
+- **updated_at** _(timestamp)_
+  - Return records that have been updated at after the updated_at param value. 
+  - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`
 
 
 Example Response:


### PR DESCRIPTION
#### What's this PR do?
- Adds the `updated_at` param to the `/activity` endpoint so you can now filter results to only return signup's whose `updated_at` time is after the value of the `updated_at` param. 
- Updates documentation.
- Adds test. 

#### How should this be reviewed?
- Make sure all tests are passing! 
- You can also manually test this endpoint by itself and with other query params and expected results should be returned. 

#### Relevant tickets
Fixes #274 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.