### PR TITLE
Consistent signup_id

### DIFF
--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -45,7 +45,7 @@ Example Response:
         "data": [
           {
             "id": 340,
-            "signup_id": 784,
+            "signup_id": 15,
             "northstar_id": "5571df46a59db12346dsb456d",
             "media": {
               "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
@@ -59,7 +59,7 @@ Example Response:
           },
           {
             "id": 312,
-            "signup_id": 784,
+            "signup_id": 15,
             "northstar_id": "5571df46a59db12346dsb456d",
             "postable_type": "Rogue\\Models\\Photo",
             "media": {


### PR DESCRIPTION
#### What's this PR do?
Updates the `post` part of the response to have the same `signup_id` as the parent signup.

cc: @sheyd 