### PR TITLE
Add validation to /signups

### DIFF
--- a/app/Http/Controllers/Api/SignupsController.php
+++ b/app/Http/Controllers/Api/SignupsController.php
@@ -2,9 +2,9 @@
 
 namespace Rogue\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
 use Rogue\Services\PostService;
 use Rogue\Services\SignupService;
+use Rogue\Http\Requests\SignupRequest;
 use Rogue\Http\Transformers\SignupTransformer;
 
 class SignupsController extends ApiController
@@ -46,7 +46,7 @@ class SignupsController extends ApiController
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(SignupRequest $request)
     {
         $transactionId = incrementTransactionId($request);
 

--- a/app/Http/Requests/SignupRequest.php
+++ b/app/Http/Requests/SignupRequest.php
@@ -28,7 +28,6 @@ class SignupRequest extends Request
             'quantity' => 'int',
             'why_participated' => 'string',
             'source' => 'string',
-            'remote_addr' => 'string',
         ];
     }
 }

--- a/app/Http/Requests/SignupRequest.php
+++ b/app/Http/Requests/SignupRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rogue\Http\Requests;
+
+class SignupRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'northstar_id' => 'required|string',
+            'campaign_id' => 'required|int',
+            'campaign_run_id' => 'required|int',
+            'quantity' => 'int',
+            'why_participated' => 'string',
+            'source' => 'string',
+            'remote_addr' => 'string',
+        ];
+    }
+}

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -20,8 +20,6 @@ POST /api/v2/signups
     The reason why the user participated.
   - **source**: (string) optional (for migration purposes, there are signups on prod with no source).
     The source of the signup.
-  - **remote_addr**: (string).
-    IP address of where the reportback is submitted from.
   - **created_at**: (string) optional.
     `Y-m-d H:i:s` format. When the signup was created.
   - **updated_at**: (string) optional.


### PR DESCRIPTION
#### What's this PR do?
Adds some validation to `/signups`! Makes the required fields enforced, and enforces the correct type on all fields.

Also, it seems that generally in Rogue when we throw a validation error it returns a `500` instead of a `422` (here included). I've done some digging on this and found that it does hit the code in Laravel to return a validation error, but somehow doesn't end up returning that (at least that is not what I am seeing in Postman). Here is the issue: https://github.com/DoSomething/rogue/issues/276

#### How should this be reviewed?
Will this let you create a signup without any of the required fields or with the wrong type for any field?

#### Any background context you want to provide?
Trust no one.

#### Relevant tickets
Fixes #178

#### Checklist
- [ ] Tested on staging.