### PR TITLE
Disable save button when no quantity is entered

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.27.3",
+            "version": "3.28.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "5530121afccd4c7842de11d0e5c1d1ac2526f26d"
+                "reference": "942d5c026b537fe76571b24aa02bc8abb9f24bb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5530121afccd4c7842de11d0e5c1d1ac2526f26d",
-                "reference": "5530121afccd4c7842de11d0e5c1d1ac2526f26d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/942d5c026b537fe76571b24aa02bc8abb9f24bb1",
+                "reference": "942d5c026b537fe76571b24aa02bc8abb9f24bb1",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-05-15T21:42:26+00:00"
+            "time": "2017-06-01T20:01:52+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -144,20 +144,20 @@
         },
         {
             "name": "barryvdh/laravel-debugbar",
-            "version": "v2.3.2",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/laravel-debugbar.git",
-                "reference": "24e4f0261e352d3fd86d0447791b56ae49398674"
+                "reference": "de15d00a74696db62e1b4782474c27ed0c4fc763"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/24e4f0261e352d3fd86d0447791b56ae49398674",
-                "reference": "24e4f0261e352d3fd86d0447791b56ae49398674",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/de15d00a74696db62e1b4782474c27ed0c4fc763",
+                "reference": "de15d00a74696db62e1b4782474c27ed0c4fc763",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*",
+                "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
                 "maximebf/debugbar": "~1.13.0",
                 "php": ">=5.5.9",
                 "symfony/finder": "~2.7|~3.0"
@@ -165,7 +165,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facade"
+                    }
                 }
             },
             "autoload": {
@@ -194,7 +202,7 @@
                 "profiler",
                 "webprofiler"
             ],
-            "time": "2017-01-19T08:19:49+00:00"
+            "time": "2017-06-01T17:46:08+00:00"
         },
         {
             "name": "classpreloader/classpreloader",
@@ -2787,25 +2795,28 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.2.8",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b8a401f733b43251e1d088c589368b2a94155e40"
+                "reference": "a9f8b02b0ef07302eca92cd4bba73200b7980e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b8a401f733b43251e1d088c589368b2a94155e40",
-                "reference": "b8a401f733b43251e1d088c589368b2a94155e40",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a9f8b02b0ef07302eca92cd4bba73200b7980e9c",
+                "reference": "a9f8b02b0ef07302eca92cd4bba73200b7980e9c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~2.8|~3.0",
-                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
                 "symfony/expression-language": "~2.8|~3.0",
                 "symfony/stopwatch": "~2.8|~3.0"
             },
@@ -2816,7 +2827,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -2843,7 +2854,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01T14:58:48+00:00"
+            "time": "2017-05-04T12:23:07+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4474,23 +4485,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -4522,7 +4533,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4891,16 +4902,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.8",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "acec26fcf7f3031e094e910b94b002fa53d4e4d6"
+                "reference": "885db865f6b2b918404a1fae28f9ac640f71f994"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/acec26fcf7f3031e094e910b94b002fa53d4e4d6",
-                "reference": "acec26fcf7f3031e094e910b94b002fa53d4e4d6",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/885db865f6b2b918404a1fae28f9ac640f71f994",
+                "reference": "885db865f6b2b918404a1fae28f9ac640f71f994",
                 "shasum": ""
             },
             "require": {
@@ -4915,7 +4926,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -4942,7 +4953,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01T14:55:58+00:00"
+            "time": "2017-05-28T10:56:20+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -16,9 +16,9 @@ class HistoryModal extends React.Component {
 	}
 
 	render() {
-    const post = this.props.details['post'];
-    const signup = this.props.details['post']['signup'];
-    const campaign = this.props.details['campaign'];
+    	const post = this.props.details['post'];
+    	const signup = this.props.details['post']['signup'];
+    	const campaign = this.props.details['campaign'];
 
 		return (
 			<div className="modal">

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -1,6 +1,20 @@
 import React from 'react';
 
 class HistoryModal extends React.Component {
+	constructor() {
+		super();
+
+		this.state = {
+			quantity: null
+		};
+
+		this.onUpdate = this.onUpdate.bind(this);
+	}
+
+	onUpdate(event) {
+		this.setState({ quantity: event.target.value });
+	}
+
 	render() {
     const post = this.props.details['post'];
     const signup = this.props.details['post']['signup'];
@@ -18,14 +32,14 @@ class HistoryModal extends React.Component {
 					<div className="container__block -half">
 						<h4>New Quantity</h4>
 						<div className="form-item">
-							<input ref={(input) => this.newQuantity = input} type="text" className="text-field" placeholder="Enter # here"/>
+							<input type="text" onChange={this.onUpdate} className="text-field" placeholder="Enter # here"/>
 						</div>
 					</div>
 
 					<h3>Reportback History</h3>
 					<p>table of all the history goes here 📖</p>
 				</div>
-				<a className="button -history" onClick={() => this.props.onUpdate(post, this.newQuantity.value)}>Save</a>
+				<button className="button -history" disabled={!this.state.quantity} onClick={() => this.props.onUpdate(post, this.state.quantity)}>Save</button>
 			</div>
 		);
 	}

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -8,7 +8,7 @@
 
         <title>Rogue</title>
 
-        <link rel="icon" type="image/ico" href="http://twooter.biz/Gifs/tonguecat.png">
+        <link rel="icon" type="image/png" href="http://twooter.biz/Gifs/tonguecat.png">
         <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}">
     </head>
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -8,7 +8,7 @@
 
         <title>Rogue</title>
 
-        <link rel="icon" type="image/ico" href="/favicon.ico?v1">
+        <link rel="icon" type="image/ico" href="http://twooter.biz/Gifs/tonguecat.png">
         <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}">
     </head>
 


### PR DESCRIPTION
#### What's this PR do?
Added `quantity` to the state of `HistoryModal` to keep an eye on if the admin has input anything in the form. Once there is something in the form, the button becomes active. If everything is removed from the form, the button becomes inactive again.

![quantity](https://cloud.githubusercontent.com/assets/4240292/26733252/37265148-4788-11e7-8a15-371e392a1940.gif)


#### How should this be reviewed?
1. Go to any reportback inbox that is not at inbox zero
2. Click "Edit | See History." The "Save" button should be gray.
3. Click "Save." Nothing should happen!
4. Enter something into the quantity box. As soon as you enter it, the "Save" button should turn blue.
5. Remove what you entered from the box. The "Save" button should go back to gray.
6. Enter something into the box again and this time hit "Save". The modal should disappear.

#### Any background context you want to provide?
Please note that the bug spotted by @chloealee in which the quantity does not actually update when you hit save is still at large!

#### Relevant tickets
[Trello card](https://trello.com/c/UMYf4MtA/427-(5)-rb-review-edit%2Fhistory%3A-as-a-developer%2C-i-want-to-disable-the-save-button-if-something-hasn%27t-been-entered-so-nulls-don%27t-ge)

#### Checklist
- [ ] Tested on staging.