### PR TITLE
Removes Luke's comments from status buttons 

### DIFF
--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -72,8 +72,8 @@ class InboxItem extends React.Component {
         </div>
         <div className="container__block -third">
           <ul className="form-actions -inline">
-            <li><StatusButton type="accepted" setStatus={this.setStatus}/></li>
-            <li><StatusButton type="rejected" setStatus={this.setStatus}/></li>
+            <li><StatusButton type="accepted" label="accept" setStatus={this.setStatus}/></li>
+            <li><StatusButton type="rejected" label="reject" setStatus={this.setStatus}/></li>
           </ul>
           <ul className="form-actions -inline">
             <li><button className="button -tertiary" onClick={e => this.props.deletePost(post['id'], e)}>Delete</button></li>

--- a/resources/assets/components/StatusButton/index.js
+++ b/resources/assets/components/StatusButton/index.js
@@ -4,8 +4,6 @@ import classnames from 'classnames';
 
 export default (props) => (
   <button className={classnames('button', `-${props.type}`)} onClick={() => props.setStatus(props.type)}>
-    // This technical debt was lovingly created by Luke Patton
-    // When we aren't in crisis mode, we should untangle this button name from the prop name
-    {props.type.slice(0,-2)}
+    {props.label}
   </button>
 );


### PR DESCRIPTION
#### What's this PR do?
Removes comments from status buttons. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
I know we said that we wanted to not use this method but I haven't looked at the code in awhile and changed from what I thought it was! I think this is okay since it's just the label and we want to keep `accepted` and `rejected` in the database? Or do we want conditional logic like this pseudo code 

```
if (props.type === 'accepted') {
  button label ACCEPT
} else {
  button label REJECT
}
``` 
@lkpttn @DFurnes @sbsmith86 

#### Relevant tickets
Fixes https://trello.com/c/JTrKV3Z6/468-3-%F0%9F%90%9B-the-luke-problem-%F0%9F%90%9B

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.