### PR TITLE
Adds northstar_id filter to /activity endpoint

### DIFF
--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -22,7 +22,7 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'campaign_run_id', 'updated_at',
+        'campaign_id', 'campaign_run_id', 'updated_at', 'northstar_id',
     ];
 
     /**

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -21,6 +21,9 @@ GET /api/v2/activity
 - **user** _(integer)_
   - Whether or not to include information about the user with the response.
   - e.g. `/activity?include=user`
+- **northstar_id** _(integer)_
+  - The northstar id(s) to filter the response by.
+  - e.g. `/activity?filter[northstar_id]=1234`
 - **updated_at** _(timestamp)_
   - Return records that have been updated at after the updated_at param value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`


### PR DESCRIPTION
#### What's this PR do?
Adds the ability to filter `/activity` response by `northstar_id`. 

#### How should this be reviewed?
👀  and test endpoint with `northstar_id` filter (and a combination or those with other filters). 

#### Any background context you want to provide?
This is needed to fix [the bug](https://trello.com/c/wshiB68W/470-6-as-a-developer-figuring-out-how-we-want-to-know-if-someone-is-signed-up-for-a-campaign-already-and-then-doing-it) to not show pitch page when a user signsup in Phoenix when Rogue is on. Right now, the pitch page is shown if a signup doesn't exist. 

#### Relevant tickets
@DFurnes @sbsmith86 will this suffice to fix [this issue](https://trello.com/c/wshiB68W/470-6-as-a-developer-figuring-out-how-we-want-to-know-if-someone-is-signed-up-for-a-campaign-already-and-then-doing-it)? 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.