### PR TITLE
Change Reportback gallery thumbnail items to 2/row

### DIFF
--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -44,7 +44,7 @@ class InboxItem extends React.Component {
             <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a>
           </p>
 
-          <ul className="gallery -quartet">
+          <ul className="gallery -duo">
           { map(this.getOtherPosts(post), (post, key) => <InboxTile key={key} details={post} />) }
           </ul>
         </div>


### PR DESCRIPTION
#### What's this PR do?
This just involves a simple css class change to display thumbnails of additional reportbacks to display as 2 thumbnails per row (previously 4 thumbnails per row)

#### How should this be reviewed?
Checkout the branch, build assets (`npm run build`) and go to /campaigns/1631/inbox, to the pikachu reportbacks. You should see that the gallery of thumbnails displays in rows of two (rather than four).

<img width="1060" alt="double-thumbnail-row-rogue" src="https://user-images.githubusercontent.com/896728/26943054-4711e2ba-4c52-11e7-9f03-0027a35c1d6b.png">


#### Any background context you want to provide?

- I'm not sure if I should add any tests or anything like that. 
- Also is this all that was needed? I wonder if I'm missing something.

#### Relevant tickets
Fixes [As a campaign lead, I want the thumbnails to be bigger so that I can see what's in them](https://trello.com/c/1qAoKkRb/451-3-as-a-campaign-lead-i-want-the-thumbnails-to-be-bigger-so-that-i-can-see-whats-in-them)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.