### PR TITLE
Save indicators

### DIFF
--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -6,14 +6,23 @@ $forge-path: "~@dosomething/forge/assets/";
 .tag {
   list-style-type: none;
   clear: both;
-  background: $light-gray;
-  color: $med-gray;
+  background: $white;
+  color: $light-gray;
   font-size: $font-regular;
   font-weight: $weight-normal;
   font-family: $font-proxima-nova;
   text-align: center;
   border: 0;
+  border-color: $light-gray;
+  border-width: 1px;
+  border-style: solid;
   margin: 10px 10px 0 0;
+  border-radius: 5px;
+
+  &:hover {
+    background: $blue;
+    color: $white;
+  }
 
   &:active, &.is-active {
     background: $blue;

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -12,7 +12,6 @@ $forge-path: "~@dosomething/forge/assets/";
   font-weight: $weight-normal;
   font-family: $font-proxima-nova;
   text-align: center;
-  border: 0;
   border-color: $light-gray;
   border-width: 1px;
   border-style: solid;

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -72,10 +72,6 @@ class CampaignInbox extends React.Component {
   }
 
   updateTag(postId, tag) {
-    if (tag === 'Hide In Gallery 👻') {
-      tag = 'Hide In Gallery';
-    }
-
     const fields = {
       post_id: postId,
       tag_name: tag,

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -72,6 +72,10 @@ class CampaignInbox extends React.Component {
   }
 
   updateTag(postId, tag) {
+    if (tag === 'Hide In Gallery 👻') {
+      tag = 'Hide In Gallery';
+    }
+
     const fields = {
       post_id: postId,
       tag_name: tag,

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -72,8 +72,8 @@ class InboxItem extends React.Component {
         </div>
         <div className="container__block -third">
           <ul className="form-actions -inline">
-            <li><StatusButton type="accepted" label="accept" setStatus={this.setStatus}/></li>
-            <li><StatusButton type="rejected" label="reject" setStatus={this.setStatus}/></li>
+            <li><StatusButton type="accepted" label="accept" status={post.status} setStatus={this.setStatus}/></li>
+            <li><StatusButton type="rejected" label="reject" status={post.status} setStatus={this.setStatus}/></li>
           </ul>
           <ul className="form-actions -inline">
             <li><button className="button -tertiary" onClick={e => this.props.deletePost(post['id'], e)}>Delete</button></li>

--- a/resources/assets/components/StatusButton/index.js
+++ b/resources/assets/components/StatusButton/index.js
@@ -3,7 +3,7 @@ import './status-button.scss';
 import classnames from 'classnames';
 
 export default (props) => (
-  <button className={classnames('button', `-${props.type}`)} onClick={() => props.setStatus(props.type)}>
+  <button className={classnames('button', `-${props.type}`, {'accepted' : props.status == 'accepted'}, {'rejected' : props.status == 'rejected'})} onClick={() => props.setStatus(props.type)}>
     {props.label}
   </button>
 );

--- a/resources/assets/components/StatusButton/status-button.scss
+++ b/resources/assets/components/StatusButton/status-button.scss
@@ -12,13 +12,18 @@ $accepted-green: #80E85D;
     border-color: $light-gray;
     border-width: 3px;
     border-style: solid;
+    text-transform: capitalize;
 
     &:hover {
       background: lighten($accepted-green, $color-tint);
+      color: $white;
+      border: none;
     }
 
     &:active, &:focus, &.accepted{
       background: darken($accepted-green, $color-tint);
+      color: $white;
+      border: none;
     }
   }
 
@@ -28,13 +33,18 @@ $accepted-green: #80E85D;
     border-color: $light-gray;
     border-width: 3px;
     border-style: solid;
+    text-transform: capitalize;
 
     &:hover {
       background: lighten($error-color, $color-tint);
+      color: $white;
+      border: none;
     }
 
     &:active, &:focus, &.rejected {
       background: darken($error-color, $color-tint);
+      color: $white;
+      border: none;
     }
   }
 }

--- a/resources/assets/components/StatusButton/status-button.scss
+++ b/resources/assets/components/StatusButton/status-button.scss
@@ -13,7 +13,7 @@ $accepted-green: #80E85D;
       background: lighten($accepted-green, $color-tint);
     }
 
-    &:active, &:focus, &.is-active{
+    &:active, &:focus, &.accepted{
       background: darken($accepted-green, $color-tint);
     }
   }
@@ -25,7 +25,7 @@ $accepted-green: #80E85D;
       background: lighten($error-color, $color-tint);
     }
 
-    &:active, &:focus, &.is-active {
+    &:active, &:focus, &.rejected {
       background: darken($error-color, $color-tint);
     }
   }

--- a/resources/assets/components/StatusButton/status-button.scss
+++ b/resources/assets/components/StatusButton/status-button.scss
@@ -7,25 +7,25 @@ $accepted-green: #80E85D;
 
 .button {
   &.-accepted {
-    background: $accepted-green;
+    background: $light-gray;
 
     &:hover {
       background: lighten($accepted-green, $color-tint);
     }
 
-    &:active, &:focus {
+    &:active, &:focus, &.is-active{
       background: darken($accepted-green, $color-tint);
     }
   }
 
   &.-rejected {
-    background: $error-color;
+    background: $light-gray;
 
     &:hover {
       background: lighten($error-color, $color-tint);
     }
 
-    &:active, &:focus {
+    &:active, &:focus, &.is-active {
       background: darken($error-color, $color-tint);
     }
   }

--- a/resources/assets/components/StatusButton/status-button.scss
+++ b/resources/assets/components/StatusButton/status-button.scss
@@ -7,7 +7,11 @@ $accepted-green: #80E85D;
 
 .button {
   &.-accepted {
-    background: $light-gray;
+    background: $white;
+    color: $light-gray;
+    border-color: $light-gray;
+    border-width: 3px;
+    border-style: solid;
 
     &:hover {
       background: lighten($accepted-green, $color-tint);
@@ -19,7 +23,11 @@ $accepted-green: #80E85D;
   }
 
   &.-rejected {
-    background: $light-gray;
+    background: $white;
+    color: $light-gray;
+    border-color: $light-gray;
+    border-width: 3px;
+    border-style: solid;
 
     &:hover {
       background: lighten($error-color, $color-tint);

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -11,6 +11,10 @@ class Tags extends React.Component {
 
   handleClick(label) {
     // Ask the CampaignInbox to update the post's tags.
+    if (label === 'Hide In Gallery 👻') {
+      label = 'Hide In Gallery';
+    }
+
     this.props.onTag(this.props.id, label);
   }
 

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -18,7 +18,7 @@ class Tags extends React.Component {
     const tags = {
       'good-photo': 'Good Photo',
       'good-quote': 'Good Quote',
-      'hide-in-gallery': 'Hide In Gallery',
+      'hide-in-gallery': 'Hide In Gallery 👻',
       'good-for-sponsor': 'Good For Sponsor',
       'good-for-storytelling': 'Good For Storytelling',
     };


### PR DESCRIPTION
#### What's this PR do?
Provides visual indicators that the status and tags applied to a post have been saved. 
1) When you first come to the inbox, status are greyed out
2) When you click Accept, it becomes Green
3) When you click Reject, it becomes Red
4) When you click Accept, the tags show up grey (this is how it works already)
5) When you click a tag, it turns blue (this is how it works already)

#### How should this be reviewed?
Test out all of the above! 

#### Relevant tickets
Fixes https://trello.com/c/xf0O6xRA/479-5-as-a-campaign-lead-i-want-a-visual-indicator-that-the-status-and-tags-applied-to-a-post-have-been-saved

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.