### PR TITLE
Adds check to see if signup exists before creating a new one

### DIFF
--- a/app/Http/Controllers/Api/SignupsController.php
+++ b/app/Http/Controllers/Api/SignupsController.php
@@ -50,7 +50,12 @@ class SignupsController extends ApiController
     {
         $transactionId = incrementTransactionId($request);
 
-        $signup = $this->signups->create($request->all(), $transactionId);
+        // Check to see if the signup exists before creating one.
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+
+        if (! $signup) {
+            $signup = $this->signups->create($request->all(), $transactionId);
+        }
 
         if ($signup) {
             $code = 201;

--- a/app/Http/Controllers/Api/SignupsController.php
+++ b/app/Http/Controllers/Api/SignupsController.php
@@ -53,12 +53,10 @@ class SignupsController extends ApiController
         // Check to see if the signup exists before creating one.
         $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
 
+        $code = $signup ? 200 : 201;
+
         if (! $signup) {
             $signup = $this->signups->create($request->all(), $transactionId);
-        }
-
-        if ($signup) {
-            $code = 201;
         }
 
         // Transform the data to return it

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -27,7 +27,6 @@ class SignupService
      * Handles all business logic around creating signups.
      *
      * @param array $data
-     * @param int $signupId
      * @param string $transactionId
      * @return Illuminate\Database\Eloquent\Model $model
      */
@@ -37,6 +36,21 @@ class SignupService
 
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
+
+        return $signup;
+    }
+
+    /*
+     * Handles all business logic around retrieving a signup.
+     *
+     * @param  string $northstarId
+     * @param  int $campaignId
+     * @param  int $campaignRunId
+     * @return \Rogue\Models\Signup|null
+     */
+    public function get($northstarId, $campaignId, $campaignRunId)
+    {
+        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
 
         return $signup;
     }


### PR DESCRIPTION
#### What's this PR do?
Adds check to see if signup exists before creating a new one. 

#### How should this be reviewed?
- Hit the `/signups` endpoint.
- Hit it again with the exact same information. 
- Check the `signups` table and make sure that there is not a duplicate signup. 

#### Any background context you want to provide?
In order to keep our pattern consistent, I added a small function to the Signup Service to then forward on to the Signup Repository to check if there is an existing signup (since repository is supposed to deal with database and service is supposed to deal with business logic). I wanted to keep it consistent but if it isn't needed, LMK!). 

#### Relevant tickets
Fixes https://trello.com/c/YRabtbG4/495-2-%F0%9F%90%9B-when-rogue-is-on-and-if-you-create-a-signup-it-doesnt-check-to-see-if-it-exists-already-it-just-creates-one-every-time-so-we

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.