### PR TITLE
Web signup api route

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -4,14 +4,15 @@ namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
-use Illuminate\Http\Request;
 use Rogue\Services\PostService;
-use Rogue\Http\Requests\PostRequest;
 use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
+use Rogue\Http\Controllers\Traits\PostRequests;
 
 class PostsController extends ApiController
 {
+    use PostRequests;
+
     /**
      * The post service instance.
      *
@@ -43,44 +44,5 @@ class PostsController extends ApiController
         $this->signups = $signups;
 
         $this->transformer = new PostTransformer;
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    // @TODO - Validate post request.
-    public function store(PostRequest $request)
-    {
-        $transactionId = incrementTransactionId($request);
-
-        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
-
-        $updating = ! is_null($signup);
-
-        // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
-        if (! $updating) {
-            $signup = $this->signups->create($request->all());
-
-            // Send the data to the PostService class which will handle determining
-            // which type of post we are dealing with and which repostitory to use to actually create the post.
-            $post = $this->posts->create($request->all(), $signup->id, $transactionId);
-
-            $code = 200;
-
-            return $this->item($post);
-        } else {
-            $post = $this->posts->update($signup, $request->all(), $transactionId);
-
-            $code = 201;
-
-            if (isset($request['file'])) {
-                return $this->item($post);
-            } else {
-                return $signup;
-            }
-        }
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,7 +2,11 @@
 
 namespace Rogue\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Rogue\Services\PostService;
+use Rogue\Http\Requests\PostRequest;
+use Rogue\Repositories\SignupRepository;
+use Rogue\Http\Transformers\PostTransformer;
 
 class PostController extends Controller
 {
@@ -14,17 +18,71 @@ class PostController extends Controller
     protected $posts;
 
     /**
+     * The signup repository instance.
+     *
+     * @var Rogue\Repositories\SignupRepository
+     */
+    protected $signups;
+
+    /**
+     * @var \League\Fractal\TransformerAbstract;
+     */
+    protected $transformer;
+
+    /**
      * Create a controller instance.
      *
      * @param  PostContract  $posts
      * @return void
      */
-    public function __construct(PostService $posts)
+    public function __construct(PostService $posts, SignupRepository $signups)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
 
         $this->posts = $posts;
+        $this->signups = $signups;
+
+        $this->transformer = new PostTransformer;
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    // @TODO - Move to shared Post Trait so that
+    public function store(PostRequest $request)
+    {
+        $transactionId = incrementTransactionId($request);
+
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+
+        $updating = ! is_null($signup);
+
+        // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
+        if (! $updating) {
+            $signup = $this->signups->create($request->all());
+
+            // Send the data to the PostService class which will handle determining
+            // which type of post we are dealing with and which repostitory to use to actually create the post.
+            $post = $this->posts->create($request->all(), $signup->id, $transactionId);
+
+            $code = 200;
+
+            return $this->item($post);
+        } else {
+            $post = $this->posts->update($signup, $request->all(), $transactionId);
+
+            $code = 201;
+
+            if (isset($request['file'])) {
+                return $this->item($post);
+            } else {
+                return $signup;
+            }
+        }
     }
 
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,14 +2,15 @@
 
 namespace Rogue\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Rogue\Services\PostService;
-use Rogue\Http\Requests\PostRequest;
 use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
+use Rogue\Http\Controllers\Traits\PostRequests;
 
 class PostController extends Controller
 {
+    use PostRequests;
+
     /**
      * The post service instance.
      *
@@ -44,45 +45,6 @@ class PostController extends Controller
         $this->signups = $signups;
 
         $this->transformer = new PostTransformer;
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    // @TODO - Move to shared Post Trait so that
-    public function store(PostRequest $request)
-    {
-        $transactionId = incrementTransactionId($request);
-
-        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
-
-        $updating = ! is_null($signup);
-
-        // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
-        if (! $updating) {
-            $signup = $this->signups->create($request->all());
-
-            // Send the data to the PostService class which will handle determining
-            // which type of post we are dealing with and which repostitory to use to actually create the post.
-            $post = $this->posts->create($request->all(), $signup->id, $transactionId);
-
-            $code = 200;
-
-            return $this->item($post);
-        } else {
-            $post = $this->posts->update($signup, $request->all(), $transactionId);
-
-            $code = 201;
-
-            if (isset($request['file'])) {
-                return $this->item($post);
-            } else {
-                return $signup;
-            }
-        }
     }
 
     /**

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rogue\Http\Controllers\Traits;
+
+use Rogue\Http\Requests\PostRequest;
+
+trait PostRequests
+{
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(PostRequest $request)
+    {
+        $transactionId = incrementTransactionId($request);
+
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+
+        $updating = ! is_null($signup);
+
+        // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
+        if (! $updating) {
+            $signup = $this->signups->create($request->all());
+
+            // Send the data to the PostService class which will handle determining
+            // which type of post we are dealing with and which repostitory to use to actually create the post.
+            $post = $this->posts->create($request->all(), $signup->id, $transactionId);
+
+            $code = 200;
+
+            return $this->item($post);
+        } else {
+            $post = $this->posts->update($signup, $request->all(), $transactionId);
+
+            $code = 201;
+
+            if (isset($request['file'])) {
+                return $this->item($post);
+            } else {
+                return $signup;
+            }
+        }
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -28,7 +28,7 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('users', 'UsersController@index');
 
     // posts
-    Route::post('posts', 'PostsController@store');
+    Route::post('posts', 'PostController@store');
     Route::delete('posts/{id}', 'PostController@destroy');
 
     // reviews

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -28,6 +28,7 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('users', 'UsersController@index');
 
     // posts
+    Route::post('posts', 'PostsController@store');
     Route::delete('posts/{id}', 'PostController@destroy');
 
     // reviews

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -107,7 +107,7 @@ class CampaignInbox extends React.Component {
     };
 
     // Make API request to Rogue to update the quantity on the backend
-    let response = this.api.post('api/v2/posts', fields);
+    let response = this.api.post('posts', fields);
 
     response.then((result) => {
       // Update the state

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -119,7 +119,7 @@ class CampiagnsTest extends TestCase
 
 
         $campaignService = $this->app->make(CampaignService::class);
-        $campaignCounts = $campaignService->getCampaignPostStatusCounts($testCampaigns);
+        $campaignCounts = $campaignService->getPostTotals($testCampaigns);
 
         $this->assertEquals($campaignCounts->get($testCampaigns[0]['id'])->accepted_count, 30);
         $this->assertEquals($campaignCounts->get($testCampaigns[0]['id'])->pending_count, 30);


### PR DESCRIPTION
#### What's this PR do?

Creates a new endpoint at `POST /posts` that lives under the web middleware so we can make requests that get authenticated based on the logged in user from the frontend, instead of the API headers. 

Also - sidebar - fixes a failing CampaignService test. 

#### Any background context you want to provide?

When updating quantity from the history modal in Rogue, I was getting authentication errors because we were not using the API headers. We don't want to use the API routes for requests from the frontend, we want to use web routes that authenticate based on the logged in user. 

