### PR TITLE
State refactor

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { flatMap, keyBy, map, sample, forEach, reject } from 'lodash';
-import { RestApiClient} from '@dosomething/gateway';
+import { map, sample, forEach, reject } from 'lodash';
+import { RestApiClient } from '@dosomething/gateway';
 
+import { extractPostsFromSignups } from '../../helpers';
 import InboxItem from '../InboxItem';
 import ModalContainer from '../ModalContainer';
 import HistoryModal from '../HistoryModal';
@@ -10,14 +11,10 @@ class CampaignInbox extends React.Component {
   constructor(props) {
     super(props);
 
-    const posts = keyBy(flatMap(props.signups, signup => {
-      return signup.posts.map(post => {
-        post.signup = signup;
-        return post;
-      });
-    }), 'id');
+    const posts = extractPostsFromSignups(props.signups)
 
     this.state = {
+      signups: props.signups,
       posts: posts,
       displayHistoryModal: false,
       historyModalId: null,

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { map, sample, forEach, reject } from 'lodash';
+import { keyBy, map, sample, forEach, reject } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
 
 import { extractPostsFromSignups } from '../../helpers';
@@ -11,10 +11,10 @@ class CampaignInbox extends React.Component {
   constructor(props) {
     super(props);
 
-    const posts = extractPostsFromSignups(props.signups)
+    const posts = extractPostsFromSignups(props.signups);
 
     this.state = {
-      signups: props.signups,
+      signups: keyBy(props.signups, 'id'),
       posts: posts,
       displayHistoryModal: false,
       historyModalId: null,
@@ -168,7 +168,7 @@ class CampaignInbox extends React.Component {
       return (
         <div className="container">
 
-          { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign}} />) }
+          { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} />) }
 
           <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign}}/> : null}

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -171,7 +171,7 @@ class CampaignInbox extends React.Component {
           { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} />) }
 
           <ModalContainer>
-            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign}}/> : null}
+            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups }}/> : null}
           </ModalContainer>
         </div>
       )

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -94,7 +94,6 @@ class CampaignInbox extends React.Component {
 
   // Update a signups quanity.
   updateQuantity(signup, newQuantity) {
-    console.log(signup);
     // Fields to send to /posts
     const fields = {
       northstar_id: signup.northstar_id,
@@ -108,24 +107,11 @@ class CampaignInbox extends React.Component {
 
     request.then((result) => {
       // Update the state
-      console.log('result');
-      console.log(result);
       this.setState((previousState) => {
         const newState = {...previousState};
-        // const updatedSignup = newState.signups[signup.id];
-        // console.log(updatedSignup.quantity);
-        console.log(newState.signups[signup.id].quantity);
+
         newState.signups[signup.id].quantity = result.quantity;
-        // const signupChanged = signup.id;
 
-        // // Update the quantity for each post under this signup
-        // forEach (newState.posts, (value) => {
-        //   if (value.signup_id == signupChanged) {
-        //     value.signup.quantity = result.quantity;
-        //   }
-        // });
-
-        // Return the new state
         return newState;
       });
     });

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -78,7 +78,6 @@ class CampaignInbox extends React.Component {
 
     let response = this.api.post('tags', fields);
     response.then((data) => {
-      console.log(data);
       this.setState((previousState) => {
         const newState = {...previousState};
         const user = newState.posts[postId].user;
@@ -94,30 +93,37 @@ class CampaignInbox extends React.Component {
   }
 
   // Update a signups quanity.
-  updateQuantity(post, newQuantity) {
+  updateQuantity(signup, newQuantity) {
+    console.log(signup);
     // Fields to send to /posts
     const fields = {
-      northstar_id: post.user.id,
-      campaign_id: post.signup.campaign_id,
-      campaign_run_id: post.signup.campaign_run_id,
+      northstar_id: signup.northstar_id,
+      campaign_id: signup.campaign_id,
+      campaign_run_id: signup.campaign_run_id,
       quantity: newQuantity,
     };
 
     // Make API request to Rogue to update the quantity on the backend
-    let response = this.api.post('posts', fields);
+    let request = this.api.post('posts', fields);
 
-    response.then((result) => {
+    request.then((result) => {
       // Update the state
+      console.log('result');
+      console.log(result);
       this.setState((previousState) => {
         const newState = {...previousState};
-        const signupChanged = post.signup_id;
+        // const updatedSignup = newState.signups[signup.id];
+        // console.log(updatedSignup.quantity);
+        console.log(newState.signups[signup.id].quantity);
+        newState.signups[signup.id].quantity = result.quantity;
+        // const signupChanged = signup.id;
 
-        // Update the quantity for each post under this signup
-        forEach (newState.posts, (value) => {
-          if (value.signup_id == signupChanged) {
-            value.signup.quantity = result.quantity;
-          }
-        });
+        // // Update the quantity for each post under this signup
+        // forEach (newState.posts, (value) => {
+        //   if (value.signup_id == signupChanged) {
+        //     value.signup.quantity = result.quantity;
+        //   }
+        // });
 
         // Return the new state
         return newState;

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -16,9 +16,9 @@ class HistoryModal extends React.Component {
 	}
 
 	render() {
-    	const post = this.props.details['post'];
-    	const signup = this.props.details['post']['signup'];
-    	const campaign = this.props.details['campaign'];
+  	const post = this.props.details['post'];
+  	const signup = this.props.details.signups[post.signup_id];
+  	const campaign = this.props.details['campaign'];
 
 		return (
 			<div className="modal">

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -39,7 +39,7 @@ class HistoryModal extends React.Component {
 					<h3>Reportback History</h3>
 					<p>table of all the history goes here 📖</p>
 				</div>
-				<button className="button -history" disabled={!this.state.quantity} onClick={() => this.props.onUpdate(post, this.state.quantity)}>Save</button>
+				<button className="button -history" disabled={!this.state.quantity} onClick={() => this.props.onUpdate(signup, this.state.quantity)}>Save</button>
 			</div>
 		);
 	}

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -20,8 +20,10 @@ class InboxItem extends React.Component {
 
   getOtherPosts(post) {
     const post_id = post['id'];
+    const signup = this.props.details.signup;
+
     // get array of posts
-    const other_posts = clone(post['signup']['posts']);
+    const other_posts = clone(signup.posts);
 
     // find index that has that post_id and remove
     const big_post = remove(other_posts, function(current_post) {
@@ -33,8 +35,9 @@ class InboxItem extends React.Component {
   }
 
   render() {
-    const post = this.props.details['post'];
-    const campaign = this.props.details['campaign'];
+    const post = this.props.details.post;
+    const campaign = this.props.details.campaign;
+    const signup = this.props.details.signup;
 
     return (
       <div className="container__row">
@@ -56,10 +59,10 @@ class InboxItem extends React.Component {
           </ul>
           <br/>
           <article className="figure -left -center">
-            { post['signup']['quantity'] ?
+            { signup.quantity ?
               <div>
                 <div className="figure__media">
-                  <div className="quantity">{post['signup']['quantity']}</div>
+                  <div className="quantity">{signup.quantity}</div>
                 </div>
                 <div className="figure__body">
                    {campaign['reportback_info']['noun']} {campaign['reportback_info']['verb']}
@@ -77,7 +80,7 @@ class InboxItem extends React.Component {
             </div>
           : null}
           <h4>Why Statement</h4>
-          <p>{post['signup']['why_participated']}</p>
+          <p>{signup.why_participated}</p>
         </div>
         <div className="container__block -third">
           {/* @TODO - make a Review component */}

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -3,6 +3,8 @@
  *
  * @param {Function} fn
  */
+import { flatMap, keyBy } from 'lodash';
+
 export function ready(fn) {
   if (document.readyState !== 'loading'){
     fn();
@@ -29,3 +31,11 @@ export function getImageUrlFromProp(photoProp) {
 	  return photo_url;
 	}
 };
+
+export function extractPostsFromSignups(signups) {
+    const posts = keyBy(flatMap(signups, signup => {
+      return signup.posts;
+    }), 'id');
+
+    return posts;
+}


### PR DESCRIPTION
#### What's this PR do?

This updates how we are handling state on the `CampaignInbox` and `CampaignSingle` components. Before, we were extracting all of the posts from the signups passed via the `window.state` object and then looping over all of them to re-embed the signup object inside of the post so we could do things like show signup fields on a post or update the quantity.

This PR updates how we handle the signup data by adding the signups to the component's state so that when we need to do anything, like update quantity, or display `why_participated` we use the `signup_id` on the post to look up the individual signup in the `signups` object and update that. What that means is all posts related to that sign up will immediately get the update. 

This should make thing easier to work with on the frontend. 

#### How should this be reviewed?

I think you should be good to go commit-by-commit. 

There are no real changes to the experience, so pull down the branch and everything should work they way it was working. 

#### Relevant tickets
Fixes #259
https://trello.com/c/3ST2uIDd/431-10-as-a-developer-i-want-to-have-signup-data-living-in-the-state-and-post-use-the-signup-id-associate-w-it-to-update-quantity

