### PR TITLE
Add post's reaction(s) in Post Transformer 

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -24,6 +24,7 @@ class PostTransformer extends TransformerAbstract
                 'caption' => $post->caption,
             ],
             'tagged' => $post->tagNames(),
+            'reactions' => $post->reactions,
             'status' => $post->status,
             'source' => $post->source,
             'remote_addr' => $post->remote_addr,

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -62,7 +62,7 @@ Example Response:
               {
                   "id": 31,
                   "northstar_id": "1234",
-                  "post_id": 1,
+                  "post_id": 340,
                   "created_at": "2017-05-11 19:52:21",
                   "updated_at": "2017-05-11 20:56:02",
                   "deleted_at": null

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -36,13 +36,10 @@ Example Response:
   "data": [
     {
       "signup_id": 15,
-      "signup_event_id": 121,
-      "submission_type": "user",
       "northstar_id": "1234",
       "campaign_id": 47,
       "campaign_run_id": 1771,
       "quantity": null,
-      "quantity_pending": 3,
       "why_participated": "because i love to help!",
       "signup_source": "phoenix-web",
       "created_at": "2017-01-20T20:26:56+0000",
@@ -57,9 +54,13 @@ Example Response:
               "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
               "caption": "Captioning captions",
             },
+            "tagged": [
+              "Good Photo",
+              "Good Quote"
+            ],
             "status": "pending",
+            "source": "phoenix-web",
             "remote_addr": "207.110.19.130",
-            "post_source": "runscope",
             "created_at": "2017-02-15T18:14:58+0000",
             "updated_at": "2017-02-15T18:14:58+0000"
           },
@@ -67,24 +68,19 @@ Example Response:
             "id": 312,
             "signup_id": 15,
             "northstar_id": "5571df46a59db12346dsb456d",
-            "postable_type": "Rogue\\Models\\Photo",
             "media": {
               "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
               "caption": "Captioning captions",
             },
+            "tagged": [],
             "status": "pending",
+            "source": "phoenix-web",
             "remote_addr": "207.110.19.130",
-            "post_source": "runscope",
             "created_at": "2017-02-11T18:14:58+0000",
             "updated_at": "2017-02-11T18:14:58+0000"
           },
         ]
       },
-      "user": {
-        "data": {
-          "first_name": "Chloe"
-        }
-      }
     }
   ],
   "meta": {

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -49,7 +49,7 @@ Example Response:
           {
             "id": 340,
             "signup_id": 15,
-            "northstar_id": "5571df46a59db12346dsb456d",
+            "northstar_id": "1234",
             "media": {
               "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
               "caption": "Captioning captions",
@@ -57,6 +57,16 @@ Example Response:
             "tagged": [
               "Good Photo",
               "Good Quote"
+            ],
+            "reactions": [
+              {
+                  "id": 31,
+                  "northstar_id": "1234",
+                  "post_id": 1,
+                  "created_at": "2017-05-11 19:52:21",
+                  "updated_at": "2017-05-11 20:56:02",
+                  "deleted_at": null
+              }
             ],
             "status": "pending",
             "source": "phoenix-web",
@@ -67,12 +77,13 @@ Example Response:
           {
             "id": 312,
             "signup_id": 15,
-            "northstar_id": "5571df46a59db12346dsb456d",
+            "northstar_id": "12345",
             "media": {
               "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
               "caption": "Captioning captions",
             },
             "tagged": [],
+            "reactions": [],
             "status": "pending",
             "source": "phoenix-web",
             "remote_addr": "207.110.19.130",


### PR DESCRIPTION
#### What's this PR do?
- Adds a post's reaction(s) in the Post Transformer 
- Updates documentation 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This is needed in order to merge this PR: https://github.com/DoSomething/phoenix/pull/7414

#### Relevant tickets
Helps to fix https://trello.com/c/S7cjnFL1/482-3-when-rogue-is-turned-on-user-cannot-sign-up-via-sms

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.