### PR TITLE
Add competitions

### DIFF
--- a/app/Http/Controllers/Api/SignupsController.php
+++ b/app/Http/Controllers/Api/SignupsController.php
@@ -57,6 +57,8 @@ class SignupsController extends ApiController
 
         if (! $signup) {
             $signup = $this->signups->create($request->all(), $transactionId);
+        } else {
+            $signup = $this->signups->update($signup, $request->all(), $transactionId);
         }
 
         // Transform the data to return it

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -53,6 +53,7 @@ class SignupTransformer extends TransformerAbstract
             'quantity' => $quantity,
             'why_participated' => $signup->why_participated,
             'signup_source' => $signup->source,
+            'competition' => $signup->competition,
             'created_at' => $signup->created_at->toIso8601String(),
             'updated_at' => $signup->updated_at->toIso8601String(),
         ];

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -11,7 +11,7 @@ class Signup extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'event_id', 'northstar_id', 'campaign_id', 'campaign_run_id', 'quantity', 'quantity_pending', 'why_participated', 'source', 'created_at', 'updated_at'];
+    protected $fillable = ['id', 'event_id', 'northstar_id', 'campaign_id', 'campaign_run_id', 'quantity', 'quantity_pending', 'why_participated', 'source', 'competition', 'created_at', 'updated_at'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -43,6 +43,11 @@ class SignupRepository
         return $signup;
     }
 
+    public function update($signup, $data)
+    {
+        dd('update signup');
+    }
+
     /**
      * Get a signup
      *

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -43,9 +43,21 @@ class SignupRepository
         return $signup;
     }
 
+    /**
+     * Update a signup. Quanity and Why participated are the
+     * only fields that can be updated, at the moment.
+     *
+     * @param  Rogue\Models\Signup $signup
+     * @param  array $data
+     * @return \Rogue\Models\Signup|null
+     */
     public function update($signup, $data)
     {
-        dd('update signup');
+        $signup->quantity = isset($data['quantity']) ? $data['quantity'] : $signup->quantity;
+        $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : $signup->why_participated;
+        $signup->save();
+
+        return $signup;
     }
 
     /**

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -24,6 +24,7 @@ class SignupRepository
         $signup->quantity_pending = isset($data['quantity_pending']) ? $data['quantity_pending'] : null;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : null;
+        $signup->competition = isset($data['competition']) ? $data['competition'] : null;
 
         if (isset($data['created_at'])) {
             // Manually set created and updated times for the signup
@@ -55,6 +56,7 @@ class SignupRepository
     {
         $signup->quantity = isset($data['quantity']) ? $data['quantity'] : $signup->quantity;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : $signup->why_participated;
+        $signup->competition = isset($data['competition']) ? $data['competition'] : $signup->competition;
         $signup->save();
 
         return $signup;

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -40,6 +40,26 @@ class SignupService
         return $signup;
     }
 
+    /**
+     * Handles all business logic around updating signups.
+     *
+     * @param \Rogue\Models\Signup $signup
+     * @param array $data
+     * @param string $transactionId
+     *
+     * @return \Illuminate\Database\Eloquent\Model $model
+     */
+    public function update($signup, $data, $transactionId)
+    {
+        $signup = $this->signup->update($signup, $data);
+
+        // Add new transaction id to header.
+        request()->headers->set('X-Request-ID', $transactionId);
+
+        return $signup;
+    }
+
+
     /*
      * Handles all business logic around retrieving a signup.
      *

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -59,7 +59,6 @@ class SignupService
         return $signup;
     }
 
-
     /*
      * Handles all business logic around retrieving a signup.
      *

--- a/database/migrations/2017_06_27_152123_add_competition_column_to_signups.php
+++ b/database/migrations/2017_06_27_152123_add_competition_column_to_signups.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCompetitionColumnToSignups extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->integer('competition')->nullable()->after('source');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropColumn('competition');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

* Adds a `competition` column to the `signups` table that stores if the signup is also opted into a competition
* Updates the `POST /signups` endpoint logic to update the signup if it is found under the given `northstar_id`, `campaign_id`, or `campaign_run_id`. This will only update the `quanity`, `why_participated` and `competition` fields on the signup. I added this so it is more user-friendly to update only these fields without having to hit `/posts`.
* adds logic on signup creation and updates to store the `competition` field.

#### How should this be reviewed?

Make a request that posts to `/signups`. Either create one or update an existing signup. Pass the `competition` parameter to the request. 

#### Any background context you want to provide?

We are adding this to more accurately parallel how this works in phoenix. We are tabling discussions to talk about if we actually want this data in rogue, or if we want looker to pull competition data from gladiator and signup data from rogue and resolve who is signed up for competitions that way.

#### Relevant tickets

This address part 1 of this card: https://trello.com/c/srxkmp3j/480-7-as-rogue-i-want-to-have-competition-information-in-me-so-that-i-can-know-someone-is-in-a-competition-column-actively-being-sav

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.