### PR TITLE
Fix post deletion

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -135,7 +135,7 @@ class CampaignInbox extends React.Component {
           var newState = {...previousState};
 
           // Remove the deleted post from the state
-          newState.posts = reject(newState.posts, ['id', postId]);
+          delete(newState.posts[postId]);
 
           // Return the new state
           return newState;

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -55,18 +55,18 @@ class CampaignInbox extends React.Component {
   updatePost(postId, fields) {
     fields.post_id = postId;
 
-    this.setState((previousState) => {
-      const newState = {...previousState};
-      newState.posts[postId].status = fields.status;
+    let request = this.api.put('reviews', fields);
 
-      let response = this.api.put('reviews', fields);
+    request.then((result) => {
+      this.setState((previousState) => {
+        const newState = {...previousState};
+        console.log(newState.posts.postId);
+        newState.posts[postId].status = fields.status;
 
-      response.then(function(result) {
-        newState.posts[postId].status = result.data.status;
+        return newState;
       });
-
-      return newState;
     });
+
   }
 
   // Tag a post.

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -60,7 +60,6 @@ class CampaignInbox extends React.Component {
     request.then((result) => {
       this.setState((previousState) => {
         const newState = {...previousState};
-        console.log(newState.posts.postId);
         newState.posts[postId].status = fields.status;
 
         return newState;


### PR DESCRIPTION
#### What's this PR do?
1. Refactored how a Post is updated to be consistent with our other calls (only update state if request is successful)
2. Use a different function to remove a Post from the state

![jul-07-2017 11-42-39](https://user-images.githubusercontent.com/4240292/27965490-f38f7b2e-6309-11e7-8f00-b0e552bca26e.gif)


#### How should this be reviewed?
Does reviewing work? Does reviewing work after deleting a post?

#### Any background context you want to provide?
The bug that this aimed to solve was tags not showing up after accepted is clicked after a post has been deleted. The real problem was that you couldn't review ANY posts after a post was deleted. That is, clicking accepted and rejected did nothing (which is why the tags weren't showing up). This is because the format of the Posts in the state changed after a Post was deleted. The change I've made removes the Post from the state and maintains the structure of the state as well.

#### Relevant tickets
[Trello Card](https://trello.com/c/znpEftNs/438-5-%F0%9F%90%9B-tags-dont-show-up-on-accepted-posts-after-you-delete-a-post-%F0%9F%90%9B)

#### Checklist
- [ ] Tested on staging.
