### PR TITLE
Add tags to reportbacks endpoint and only return posts that don't have "Hide In Gallery" tag

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -44,11 +44,11 @@ class ReportbackController extends ApiController
         // 3. Only return Posts that do not have 'Hide In Gallery' tag
         // 4. Select all the fields that we will be using
         $query = $query->join('signups', 'signups.id', '=', 'posts.signup_id')
+            ->join('tagging_tagged', 'tagging_tagged.taggable_id', '=', 'posts.id')
             ->where('posts.status', '=', 'accepted')
-            // ->join('tagging_tagged', 'tagging_tagged.taggable_id', '=', 'posts.id')
-            // ->groupBy('tagging_tagged.taggable_id')
-            // ->where('tagging_tagged.tag_name', '<>', 'Hide In Gallery')
-            ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id');
+            ->groupBy('tagging_tagged.taggable_id')
+            ->having('tagging_tagged.tag_name', '!=', 'Hide In Gallery')
+            ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id', 'tagging_tagged.tag_name as tag_name');
 
         $filters = $request->query('filter');
 

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -41,9 +41,13 @@ class ReportbackController extends ApiController
 
         // 1. Join with signups so we can access the signup data and filter by campaign
         // 2. Only return approved Posts
-        // 3. Select all the fields that we will be using
+        // 3. Only return Posts that do not have 'Hide In Gallery' tag
+        // 4. Select all the fields that we will be using
         $query = $query->join('signups', 'signups.id', '=', 'posts.signup_id')
-            ->where('status', '=', 'accepted')
+            ->where('posts.status', '=', 'accepted')
+            // ->join('tagging_tagged', 'tagging_tagged.taggable_id', '=', 'posts.id')
+            // ->groupBy('tagging_tagged.taggable_id')
+            // ->where('tagging_tagged.tag_name', '<>', 'Hide In Gallery')
             ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id');
 
         $filters = $request->query('filter');

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -37,18 +37,15 @@ class ReportbackController extends ApiController
     public function index(Request $request)
     {
         // Create an empty Post query, which we can filter and paginate
-        $query = $this->newQuery(Post::class);
+        // Only return Posts that do not have 'Hide In Gallery' tag
+        $query = $this->newQuery(Post::class)->withoutTags(['Hide In Gallery']);
 
         // 1. Join with signups so we can access the signup data and filter by campaign
         // 2. Only return approved Posts
-        // 3. Only return Posts that do not have 'Hide In Gallery' tag
-        // 4. Select all the fields that we will be using
+        // 3. Select all the fields that we will be using
         $query = $query->join('signups', 'signups.id', '=', 'posts.signup_id')
-            ->join('tagging_tagged', 'tagging_tagged.taggable_id', '=', 'posts.id')
-            ->where('posts.status', '=', 'accepted')
-            ->groupBy('tagging_tagged.taggable_id')
-            ->having('tagging_tagged.tag_name', '!=', 'Hide In Gallery')
-            ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id', 'tagging_tagged.tag_name as tag_name');
+            ->where('status', '=', 'accepted')
+            ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id');
 
         $filters = $request->query('filter');
 

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -111,7 +111,12 @@ trait TransformsRequests
         $paginator->appends($queryParams);
 
         $resource = new Collection($paginator->getCollection(), $transformer);
-
+        // Check to see if this is a collection of posts.
+        // If so, map over the collection and remove all posts that have Hide In Gallery tag.
+        // Is this too specific to Rogue to add here?
+        $resource->map(function ($item, $key) {
+            if ($item)
+        });
         $resource->setMeta($meta);
 
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -111,12 +111,7 @@ trait TransformsRequests
         $paginator->appends($queryParams);
 
         $resource = new Collection($paginator->getCollection(), $transformer);
-        // Check to see if this is a collection of posts.
-        // If so, map over the collection and remove all posts that have Hide In Gallery tag.
-        // Is this too specific to Rogue to add here?
-        $resource->map(function ($item, $key) {
-            if ($item)
-        });
+
         $resource->setMeta($meta);
 
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -17,9 +17,9 @@ class ReportbackTransformer extends TransformerAbstract
     {
         $signup = $post->signup;
 
-        if (in_array('Hide In Gallery', $post->tagNames())) {
-            return;
-        }
+        // if (in_array('Hide In Gallery', $post->tagNames())) {
+        //     return;
+        // }
 
         $result = [
             'id' => $post->id,

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -17,10 +17,6 @@ class ReportbackTransformer extends TransformerAbstract
     {
         $signup = $post->signup;
 
-        // if (in_array('Hide In Gallery', $post->tagNames())) {
-        //     return;
-        // }
-
         $result = [
             'id' => $post->id,
             'status' => $post->status,

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -16,7 +16,11 @@ class ReportbackTransformer extends TransformerAbstract
     public function transform(Post $post)
     {
         $signup = $post->signup;
-        dd($post);
+
+        if (in_array('Hide In Gallery', $post->tagNames())) {
+            return;
+        }
+
         $result = [
             'id' => $post->id,
             'status' => $post->status,
@@ -27,6 +31,7 @@ class ReportbackTransformer extends TransformerAbstract
                 'uri' => $post->url,
                 'type' => 'image',
             ],
+            'tagged' => $post->tagNames(),
             'created_at' => $post->created_at->toIso8601String(),
             'reportback' => [
                 'id' => $signup->id,

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -16,7 +16,7 @@ class ReportbackTransformer extends TransformerAbstract
     public function transform(Post $post)
     {
         $signup = $post->signup;
-
+        dd($post);
         $result = [
             'id' => $post->id,
             'status' => $post->status,


### PR DESCRIPTION
#### What's this PR do?
- Add tags to reportbacks endpoint 
- Only return Posts that don't have "Hide In Gallery" tag so these don't show up in the Phoenix Ashes gallery

#### How should this be reviewed?
- Hit `/api/v1/reportbacks` endpoint 
- You should now be able to see the Post's tags
- There shouldn't be any posts with the "Hide In Gallery" tag
- In Phoenix Ashes gallery, posts that are tagged "Hide In Gallery" should not be in gallery

#### Relevant tickets
Fixes #249 
Fixes https://trello.com/c/ZunwuNfb/496-might-not-be-needed-as-a-campaign-lead-and-phoenix-i-dont-want-posts-w-the-tag-hide-in-gallery-to-show-up-in-the-gallery-and-the
Fixes https://trello.com/c/59LxTGPN/416-3-as-a-developer-i-want-to-update-the-reportbacks-endpoints-to-include-post-tags-so-that-the-gallery-can-get-this-tag-informatio

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.