### PR TITLE
Tracking the user that did a thing

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
      *
      * @var array
      */
-    protected $fillable = ['eventable_id', 'eventable_type', 'content'];
+    protected $fillable = ['eventable_id', 'eventable_type', 'content', 'user'];
 
     public function eventable()
     {

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -14,13 +14,6 @@ class Review extends Model
     protected $fillable = ['signup_id', 'northstar_id', 'admin_northstar_id', 'status', 'old_status', 'comment', 'post_id'];
 
     /**
-     * All of the relationships to be touched.
-     *
-     * @var array
-     */
-    protected $touches = ['post'];
-
-    /**
      * Each review has events.
      */
     public function events()

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -21,8 +21,9 @@ class ModelServiceProvider extends ServiceProvider
         // When Signups are saved create an event for them.
         Signup::saved(function ($signup) {
             $signup->events()->create([
-                // @TODO - Should this just be the attributes that have changed? Or the whole thing?
                 'content' => $signup->toJson(),
+                // Use the authenticated user if coming from the web,
+                // otherwise use the id of the user in the request.
                 'user' => auth()->user() ? auth()->user()->northstar_id : $signup->northstar_id,
             ]);
         });
@@ -31,6 +32,8 @@ class ModelServiceProvider extends ServiceProvider
         Post::saved(function ($post) {
             $post->events()->create([
                 'content' => $post->toJson(),
+                // Use the authenticated user if coming from the web,
+                // otherwise use the id of the user in the request.
                 'user' => auth()->user() ? auth()->user()->northstar_id : $post->northstar_id,
             ]);
         });
@@ -50,6 +53,7 @@ class ModelServiceProvider extends ServiceProvider
                 'eventable_id' => $post->id,
                 'eventable_type' => 'Rogue\Models\Post',
                 'content' => $post->toJson(),
+                // Only authenticated admins can tag, so grab the authenticated user.
                 'user' => auth()->user()->northstar_id,
             ]);
         });

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -23,6 +23,7 @@ class ModelServiceProvider extends ServiceProvider
             $signup->events()->create([
                 // @TODO - Should this just be the attributes that have changed? Or the whole thing?
                 'content' => $signup->toJson(),
+                'user' => auth()->user() ? auth()->user()->northstar_id : $signup->northstar_id,
             ]);
         });
 
@@ -30,6 +31,7 @@ class ModelServiceProvider extends ServiceProvider
         Post::saved(function ($post) {
             $post->events()->create([
                 'content' => $post->toJson(),
+                'user' => auth()->user() ? auth()->user()->northstar_id : $post->northstar_id,
             ]);
         });
 
@@ -37,22 +39,18 @@ class ModelServiceProvider extends ServiceProvider
         Review::saved(function ($review) {
             $review->events()->create([
                 'content' => $review->toJson(),
+                'user' => $review->admin_northstar_id,
             ]);
         });
 
         Tagged::saved(function ($tagged) {
             $post = Post::find($tagged->taggable_id);
-            $adminId = auth()->user()->northstar_id;
-
-            $post->action = [
-                'type' => 'tagged',
-                'admin' => $adminId,
-            ];
 
             Event::create([
                 'eventable_id' => $post->id,
                 'eventable_type' => 'Rogue\Models\Post',
                 'content' => $post->toJson(),
+                'user' => auth()->user()->northstar_id,
             ]);
         });
     }

--- a/database/migrations/2017_06_29_194312_add_user_column_to_events_table.php
+++ b/database/migrations/2017_06_29_194312_add_user_column_to_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUserColumnToEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('user')->after('content')->nullable()->index()->comment('Northstar ID of the user who did the action');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('northstar_id');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

*Adds a `user` column to the `events` table that will hold the `northstar_id` of the user that did the event.
* Stores the authenticated user if coming from the web API (admins), stores the user passed in the request if coming from the API (i.e if posting a signup from Phoenix, we store the user that was sent in that signup request as the user responsible for the event).
* Removes the touch property on the `Review` model that would cause two Post events to be created when something got reviewed. When something gets reviewed, we create a new review record but we also update the post with the new status and that update the `updated_at` timestamp for the post and will also will touch the parent Signup to update the `updated_at` timestamp.


#### How should this be reviewed?

Post to `/signups` or `/posts`, or review something in Rogue. Look up the event, and if you kicked off the event as an admin you should see your NS ID in the `user` column. 

#### Relevant tickets
https://trello.com/c/abaBqGPF/411-5-as-a-developer-i-want-to-track-moving-forward-if-its-an-admin-or-member-who-has-updated-quantity-or-anything-about-the-post

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.