### PR TITLE
adds signup id filter to /activity endpoint

### DIFF
--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -22,7 +22,7 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'campaign_run_id', 'updated_at', 'northstar_id',
+        'campaign_id', 'campaign_run_id', 'updated_at', 'northstar_id', 'id',
     ];
 
     /**

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -6,6 +6,9 @@ Retrieve all user activity data.
 GET /api/v2/activity
 ```
 ### Optional Query Parameters
+- **id** _(integer)_
+  - The signup id(s) to filter the response by.
+  - e.g. `/activity?filter[id]=121,122`
 - **limit** _(default is 20)_
   - Set the number of records to return in a single response.
   - e.g. `/activity?limit=35`


### PR DESCRIPTION
#### What's this PR do?
- Adds an `id` filter to the `GET /activity` endpoint to allow to filter by signup id(s)

#### How should this be reviewed?
Hit `/api/v2/activity?filter[id]=121,122` (or any combination of signup ids and only those should be returned. 

#### Any background context you want to provide?
We need this in order to create a proxy for Pheonix Ashes' `GET /signup/:sid` 

#### Relevant tickets
Needed in order to fix [this ticket](https://trello.com/c/QYdM5vVN/485-as-a-developer-i-want-to-make-sure-phoenixs-signups-sid-endpoint-has-a-rogue-proxy-for-gladiator-to-still-work-when-rogue-is-tur) and for https://github.com/DoSomething/phoenix/pull/7441 to work

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.