### PR TITLE
Use only pending posts for the inbox page

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -61,11 +61,13 @@ class CampaignsController extends Controller
     {
         $signups = Signup::campaign([$campaignId])->has('pending')->with('pending')->get();
 
-        // For each post, get and include the user
+        // For each pending post, get and include the user
         // @TODO - we should rethink this logic. Making a request to northstar
         // for each post might be heavy. Ideally we could grab/attach users in bulk when
         // we grab the signup.
         $signups->each(function ($item) {
+            $item->posts = $item->pending;
+
             $item->posts->each(function ($item) {
                 $user = $this->registrar->find($item->northstar_id);
                 $item->user = $user->toArray();


### PR DESCRIPTION
#### What's this PR do?
There was a bug where sometimes on inbox pages, previously reviewed posts would show up. I tracked it down to 
```
$signups = Signup::campaign([$campaignId])->has('pending')->with('pending')->get();
```
in [`showInbox`](https://github.com/DoSomething/rogue/blob/master/app/Http/Controllers/CampaignsController.php#L62-L73) in `CampaignsController` in Rogue. This would get all signups for the given campaign that own pending posts. Off to a great start! However, later on, we never remove the posts that are not pending (we get all signups that have `pending` posts, but those same signups may also have `accepted` or `rejected` posts). My solution was to replace the posts with the pending posts when we are looping over the posts to include the user with the post.

#### How should this be reviewed?
Peruse some campaign inboxes and make sure you only see pending posts in there! Also double check regular reviewing functionality.

#### Relevant tickets
[Trello card
](https://trello.com/c/eS34feYU/494-%F0%9F%90%9B-accepted-posts-are-showing-up-in-the-campaign-inbox-%F0%9F%90%9B)

#### Checklist
- [ ] Tested on staging.