### PR TITLE
Return specific errors

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -49,6 +49,9 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $e)
     {
         // Re-cast specific exceptions or uniquely render them:
+        if ($e instanceof AuthorizationException) {
+            return parent::render($request, $e);
+        }
         if ($e instanceof AuthenticationException) {
             return $this->unauthenticated($request, $e);
         } elseif ($e instanceof ValidationException || $e instanceof NorthstarValidationException) {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,8 @@ namespace Rogue\Exceptions;
 use Exception;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Exception\HttpResponseException;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -46,26 +48,68 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
-        if ($e instanceof AuthorizationException) {
-            return parent::render($request, $e);
+        // Re-cast specific exceptions or uniquely render them:
+        if ($e instanceof AuthenticationException) {
+            return $this->unauthenticated($request, $e);
+        } elseif ($e instanceof ValidationException || $e instanceof NorthstarValidationException) {
+            return $this->invalidated($request, $e);
+        } elseif ($e instanceof ModelNotFoundException) {
+            $e = new NotFoundHttpException('That resource could not be found.');
+        }
+        // If request has 'Accepts: application/json' header or we're on a route that
+        // is in the `api` middleware group, render the exception as JSON object.
+        if ($request->ajax() || $request->wantsJson() || has_middleware('api')) {
+            return $this->buildJsonResponse($e);
         }
 
-        if ($e instanceof ModelNotFoundException) {
-            abort(404, $e->getMessage());
-        }
-
-        if ($request->wantsJson()) {
-            $fe = FlattenException::create($e);
-            $json = [
-                'error' => [
-                    'code' => $fe->getStatusCode(),
-                    'message' => $fe->getMessage(),
-                ],
-            ];
-
-            return response()->json($json, $fe->getStatusCode());
-        }
 
         return parent::render($request, $e);
+    }
+
+    /**
+     * Convert an authentication exception into an redirect or JSON response.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Illuminate\Auth\AuthenticationException $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function unauthenticated($request, AuthenticationException $e)
+    {
+        if ($request->ajax() || $request->wantsJson()) {
+            return $this->buildJsonResponse(new HttpException(401, 'Unauthorized.'));
+        }
+        return redirect()->guest('login');
+    }
+
+    /**
+     * Build a JSON error response for API clients.
+     *
+     * @param Exception $e
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function buildJsonResponse(Exception $e)
+    {
+        if ($e instanceof HttpResponseException) {
+
+            return $e->getResponse();
+        }
+
+        $code = $e instanceof HttpException ? $e->getStatusCode() : 500;
+
+        $shouldHideErrorDetails = $code == 500 && ! config('app.debug');
+        $response = [
+            'error' => [
+                'code' => $code,
+                'message' => $shouldHideErrorDetails ? self::PRODUCTION_ERROR_MESSAGE : $e->getMessage(),
+            ],
+        ];
+        // Show more information if we're in debug mode
+        if (config('app.debug')) {
+            $response['debug'] = [
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ];
+        }
+        return response()->json($response, $code);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,11 +3,10 @@
 namespace Rogue\Exceptions;
 
 use Exception;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\Exception\HttpResponseException;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
@@ -65,7 +64,6 @@ class Handler extends ExceptionHandler
             return $this->buildJsonResponse($e);
         }
 
-
         return parent::render($request, $e);
     }
 
@@ -81,6 +79,7 @@ class Handler extends ExceptionHandler
         if ($request->ajax() || $request->wantsJson()) {
             return $this->buildJsonResponse(new HttpException(401, 'Unauthorized.'));
         }
+
         return redirect()->guest('login');
     }
 
@@ -93,7 +92,6 @@ class Handler extends ExceptionHandler
     protected function buildJsonResponse(Exception $e)
     {
         if ($e instanceof HttpResponseException) {
-
             return $e->getResponse();
         }
 
@@ -113,6 +111,7 @@ class Handler extends ExceptionHandler
                 'line' => $e->getLine(),
             ];
         }
+
         return response()->json($response, $code);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -68,5 +68,6 @@ function has_middleware($middleware = null)
     if ($middleware) {
         return in_array($middleware, $currentRoute->middleware());
     }
+
     return $currentRoute->middleware() ? true : false;
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,3 +52,21 @@ function incrementTransactionId($request)
 
     return null;
 }
+
+/**
+ * Check if the current route has any middleware attached.
+ *
+ * @param  null|string  $middleware
+ * @return bool
+ */
+function has_middleware($middleware = null)
+{
+    $currentRoute = app('router')->getCurrentRoute();
+    if (! $currentRoute) {
+        return false;
+    }
+    if ($middleware) {
+        return in_array($middleware, $currentRoute->middleware());
+    }
+    return $currentRoute->middleware() ? true : false;
+}


### PR DESCRIPTION
#### What's this PR do?
Wouldn't it be nice if when you tried to post something to Rogue, but had something wrong in your request, you got a helpful message in response instead of a `500`? Very soon, that will be the reality that we all live in.

This PR steals a bunch of code from Northstar to make that a reality. Taken from Northstar:
[`has_middleware` helper](https://github.com/DoSomething/northstar/blob/4a4b46482652e3e683837867af9ca32a3fcf1759/app/helpers.php#L54-L73) 

[unauthenticated function in `Handler.php`
](https://github.com/DoSomething/northstar/blob/ef9679e89e0aed0af470d9ac93f44e95b4265ca4/app/Exceptions/Handler.php#L115-L129)
[this real nice `buildJsonResponse` function
](https://github.com/DoSomething/northstar/blob/ef9679e89e0aed0af470d9ac93f44e95b4265ca4/app/Exceptions/Handler.php#L131-L157)
[and this chunk of the `render` function of `Handler.php`
](https://github.com/DoSomething/northstar/blob/ef9679e89e0aed0af470d9ac93f44e95b4265ca4/app/Exceptions/Handler.php#L70-L83)
Example response:
```
{
    "campaign_id": [
        "The campaign id must be an integer."
    ],
    "quantity": [
        "The quantity must be an integer."
    ]
}
```

#### How should this be reviewed?
Make sure that you see the correct response for various types of requests and exceptions.

#### Any background context you want to provide?
All tests pass!

#### Relevant tickets
Fixes #276
[Trello card
](https://trello.com/c/XnYvqbRQ/467-5-%F0%9F%90%9B-validation-errors-return-500-instead-of-422-%F0%9F%90%9B)

#### Checklist
- [ ] Tested on staging.
