### PR TITLE
Add command to bulk resize images.

### DIFF
--- a/app/Console/Commands/EditImagesCommand.php
+++ b/app/Console/Commands/EditImagesCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Post;
+use Rogue\Services\AWS;
+use Illuminate\Console\Command;
+use Intervention\Image\Facades\Image;
+
+class EditImagesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:images {start=1}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create cropped & resized images for every post.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(AWS $aws)
+    {
+        $start = $this->argument('start');
+
+        Post::where('id', '>', $start)->chunk(100, function ($posts) use ($aws) {
+            foreach ($posts as $post) {
+                $image = $post->url;
+                $editedImage = (string) Image::make($image)
+                    ->orientate()
+                    ->fit(400)
+                    ->encode('jpg', 75);
+
+                $aws->storeImageData($editedImage, 'edited_'.$post->id);
+
+                $this->line('Saved edited image for post '.$post->id);
+            }
+        });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         Commands\ClearDB::class,
+        Commands\EditImagesCommand::class,
     ];
 
     /**

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -39,7 +39,6 @@ class AWS
         // uploads to prevent AWS cache giving the user an old upload.
         $path = '/uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
 
-
         // Push file to S3.
         $success = Storage::put($path, $data);
 
@@ -68,7 +67,7 @@ class AWS
             throw new UnprocessableEntityHttpException('Invalid file type. Upload a JPEG, PNG or GIF.');
         }
 
-        $path = '/uploads/reportback-items/' . $filename . '.' . $extension; ;
+        $path = '/uploads/reportback-items/' . $filename . '.' . $extension;
 
         // Push file to S3.
         $success = Storage::put($path, $data);

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -39,6 +39,37 @@ class AWS
         // uploads to prevent AWS cache giving the user an old upload.
         $path = '/uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
 
+
+        // Push file to S3.
+        $success = Storage::put($path, $data);
+
+        if (! $success) {
+            throw new HttpException(500, 'Unable to save image to S3.');
+        }
+
+        return config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . $path;
+    }
+
+    /**
+     * Store a reportback item (image) in S3.
+     *
+     * @param \Symfony\Component\HttpFoundation\File\UploadedFile|string $file
+     *  File object, or a base-64 encoded data URI
+     * @param string $data - File data
+     *
+     * @return string - URL of stored image
+     */
+    public function storeImageData($data, $filename)
+    {
+        $extension = $this->guessExtension($data);
+
+        // Make sure we're only uploading valid image types
+        if (! in_array($extension, ['jpeg', 'png', 'gif'])) {
+            throw new UnprocessableEntityHttpException('Invalid file type. Upload a JPEG, PNG or GIF.');
+        }
+
+        $path = '/uploads/reportback-items/' . $filename . '.' . $extension; ;
+
         // Push file to S3.
         $success = Storage::put($path, $data);
 


### PR DESCRIPTION
#### What's this PR do?
This adds a `artisan rogue:images` command that we can use to resize a shit ton of images super quickly. This doesn't _do_ anything with these new images, or overwrite any existing data that the app currently relies on.

#### How should this be reviewed?
We added a new `storeImageData` to the AWS client to store the in-memory version of the file and not do all the crazy MD5 timestampy business.

#### Any background context you want to provide?
LET'S DO THIS.™

#### Relevant tickets
Fixes :scream:.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.