### PR TITLE
Handle exceptions when cropping images.

### DIFF
--- a/app/Console/Commands/EditImagesCommand.php
+++ b/app/Console/Commands/EditImagesCommand.php
@@ -55,7 +55,7 @@ class EditImagesCommand extends Command
 
                     $aws->storeImageData($editedImage, 'edited_'.$post->id);
                 } catch (ImageException $e) {
-                    $this->error('Failed to edit image for post '.$post->id);
+                    $this->error('Failed to edit image for post '.$post->id.': '.$image);
                 }
 
                 $this->line('Saved edited image for post '.$post->id);

--- a/app/Console/Commands/EditImagesCommand.php
+++ b/app/Console/Commands/EditImagesCommand.php
@@ -5,6 +5,7 @@ namespace Rogue\Console\Commands;
 use Rogue\Models\Post;
 use Rogue\Services\AWS;
 use Illuminate\Console\Command;
+use Intervention\Image\Exception\ImageException;
 use Intervention\Image\Facades\Image;
 
 class EditImagesCommand extends Command
@@ -45,12 +46,17 @@ class EditImagesCommand extends Command
         Post::where('id', '>', $start)->chunk(100, function ($posts) use ($aws) {
             foreach ($posts as $post) {
                 $image = $post->url;
-                $editedImage = (string) Image::make($image)
-                    ->orientate()
-                    ->fit(400)
-                    ->encode('jpg', 75);
 
-                $aws->storeImageData($editedImage, 'edited_'.$post->id);
+                try {
+                    $editedImage = (string) Image::make($image)
+                        ->orientate()
+                        ->fit(400)
+                        ->encode('jpg', 75);
+
+                    $aws->storeImageData($editedImage, 'edited_'.$post->id);
+                } catch (ImageException $e) {
+                    $this->error('Failed to edit image for post '.$post->id);
+                }
 
                 $this->line('Saved edited image for post '.$post->id);
             }

--- a/app/Console/Commands/EditImagesCommand.php
+++ b/app/Console/Commands/EditImagesCommand.php
@@ -5,8 +5,8 @@ namespace Rogue\Console\Commands;
 use Rogue\Models\Post;
 use Rogue\Services\AWS;
 use Illuminate\Console\Command;
-use Intervention\Image\Exception\ImageException;
 use Intervention\Image\Facades\Image;
+use Intervention\Image\Exception\ImageException;
 
 class EditImagesCommand extends Command
 {


### PR DESCRIPTION
#### What's this PR do?
This pull request adds some simple error handling so we don't stop the whole dang process if a single image can't be processed. We can then look over the log from running the command for specific errors afterwards.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This error occurred on Thor when it hit a post with `default` as the URL:

```
Saved edited image for post 1175
Saved edited image for post 1176
Saved edited image for post 1177
Saved edited image for post 1178
Saved edited image for post 1179
Saved edited image for post 1180

                                                       
  [Intervention\Image\Exception\NotReadableException]  
  Image source not readable          
```

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.