### PR TITLE
Catch all exceptions in image command

### DIFF
--- a/app/Console/Commands/EditImagesCommand.php
+++ b/app/Console/Commands/EditImagesCommand.php
@@ -56,6 +56,8 @@ class EditImagesCommand extends Command
                     $aws->storeImageData($editedImage, 'edited_'.$post->id);
                 } catch (ImageException $e) {
                     $this->error('Failed to edit image for post '.$post->id.': '.$image);
+                } catch (\Exception $e) {
+                    $this->error('Something failed for post '.$post->id.': '.$image);
                 }
 
                 $this->line('Saved edited image for post '.$post->id);


### PR DESCRIPTION
#### What's this PR do?
Added another `catch` to the image command to catch all `\Exception` and print out an error.

#### How should this be reviewed?
👀 Will this catch 'em all?

#### Any background context you want to provide?
At least one image gave an error that we did not catch.

#### Checklist
- [ ] Tested on staging.
