### PR TITLE
Always return edited images

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -20,7 +20,7 @@ class PostTransformer extends TransformerAbstract
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
             'media' => [
-                'url' => $post->url,
+                'url' => config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . '/uploads/reportback-items/edited_' . $post->id . '.jpeg',
                 'caption' => $post->caption,
             ],
             'tagged' => $post->tagNames(),

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -24,7 +24,7 @@ class ReportbackTransformer extends TransformerAbstract
             // Add link to review reportback item in Rogue here once that page exists
             // 'uri' => 'link_goes_here'
             'media' => [
-                'uri' => $post->url,
+                'uri' => config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . '/uploads/reportback-items/edited_' . $post->id . '.jpeg',
                 'type' => 'image',
             ],
             'tagged' => $post->tagNames(),


### PR DESCRIPTION
#### What's this PR do?
In `PostTransformer` (used by activity and other endpoints) and `ReportbackTransformer` (used by Phoenix gallery), we return the edited image instead of the original. The edited one is a square center crop. 

The urls will look something like this:
`https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_1.jpeg`

My local data is kind of wonky so I will want to test this on Thor to make sure it's working.

#### How should this be reviewed?
Is there anywhere else that we return urls that needs to be updated?

#### Any background context you want to provide?
This was way easier than doing it on the Phoenix side!!!

#### Relevant tickets
[Trello card](https://trello.com/c/bo4mBuN5/516-gallery-frontend-work-to-make-things-look-like-squares)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.