### PR TITLE
Save a cropped jpeg for all images submitted

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -59,7 +59,6 @@ class PostRepository
             $image = Image::make($data['file'])->orientate();
 
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
-
         } else {
             $fileUrl = 'default';
         }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -60,7 +60,6 @@ class PostRepository
 
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
 
-            $editedImage = $this->crop($data, $signupId);
         } else {
             $fileUrl = 'default';
         }
@@ -88,6 +87,11 @@ class PostRepository
             $post->events->first()->save(['timestamps' => false]);
         } else {
             $post->save();
+        }
+
+        // Edit the image if there is one
+        if (isset($data['file'])) {
+            $editedImage = $this->crop($data, $post->id);
         }
 
         return $post;
@@ -206,14 +210,22 @@ class PostRepository
      * @param  int $signupId
      * @return url|null
      */
-    protected function crop($data, $signupId)
+    protected function crop($data, $postId)
     {
         $cropValues = array_only($data, $this->cropProperties);
 
         if (count($cropValues) > 0) {
             $editedImage = edit_image($data['file'], $cropValues);
 
-            return $this->aws->storeImage($editedImage, 'edited_' . $signupId);
+            return $this->aws->storeImageData($editedImage, 'edited_' . $postId);
+        } else {
+            // Take center crop
+            $editedImage = (string) Image::make($data['file'])
+                        ->orientate()
+                        ->fit(400)
+                        ->encode('jpg', 75);
+
+            return $this->aws->storeImageData($editedImage, 'edited_' . $postId);
         }
 
         return null;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -27,7 +27,7 @@ function edit_image($image, $coords)
         // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
         ->rotate(-$coords['crop_rotate'])
         ->crop($coords['crop_width'], $coords['crop_height'], $coords['crop_x'], $coords['crop_y'])
-        ->encode('data-url');
+        ->encode('jpg', 75);
 
     return $editedImage;
 }


### PR DESCRIPTION
#### What's this PR do?
1. Save the edited image after the post is created so we can use the post id in the url
2. Use `storeImageData` to save images that came with cropping information, and use `->encode('jpg', 75);` on them so we can rebuild the urls reliably later (everything ends in `.jpeg`)
3. Save a center cropped image for images that aren't sent to Rogue with cropping information. We want to have a square crop version of everything.

#### How should this be reviewed?
Will this create a square cropped image for all new images sent to rogue with a filename of `{post_id}.jpeg`?

#### Any background context you want to provide?
We need to make sure that we can find cropped images for all new posts.

#### Relevant tickets
Takes care of this [Trello card](https://trello.com/c/bQcbThcr/510-%F0%9F%90%9B-photos-that-arent-square-are-breaking-the-gallery-when-rogue-is-turned-on-%F0%9F%90%9B) for all future images

#### Checklist
- [ ] Tested on staging.