### PR TITLE
Make sure to resize all cropped images to 400x400

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -16,24 +16,6 @@ function scriptify($json = [], $store = 'STATE')
 }
 
 /**
- * Crop and rotate an image based on given parameters.
- *
- * @param  mixed  $image
- * @return string $image base-64 encoded data URI
- */
-function edit_image($image, $coords)
-{
-    $editedImage = (string) Image::make($image)
-        // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
-        ->rotate(-$coords['crop_rotate'])
-        ->crop($coords['crop_width'], $coords['crop_height'], $coords['crop_x'], $coords['crop_y'])
-        ->fit(400)
-        ->encode('jpg', 75);
-
-    return $editedImage;
-}
-
-/**
  * Helper function to increment transaction id.
  *
  * @param \Illuminate\Http\Request $request

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\HtmlString;
-use Intervention\Image\Facades\Image;
 
 /**
  * Create a script tag to set a global variable.

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -27,6 +27,7 @@ function edit_image($image, $coords)
         // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
         ->rotate(-$coords['crop_rotate'])
         ->crop($coords['crop_width'], $coords['crop_height'], $coords['crop_x'], $coords['crop_y'])
+        ->fit(400)
         ->encode('jpg', 75);
 
     return $editedImage;


### PR DESCRIPTION
#### What's this PR do?
All images, will be made into 400x400 squares, whether we have the cropping information or not. The `edit_image` helper has also been removed because everything has been moved into `crop` in `PostRepository.php`. 

#### How should this be reviewed?
Do all the things to upload images to Rogue!
1. Step 4 Prove It
    - everything should work as normal and your images should end up in Rogue
2. Hit the Rogue `POST /posts`
    - everything should work as normal and your images should end up in Rogue

Make sure the edited images for the ones you uploaded are 400x400. They live at `{bucket_for_environment_you're_using}/edited_{post_it}.jpeg`.

#### Any background context you want to provide?
We always cropped, but we didn't always resize so we ended up with some pretty big squares.

#### Checklist
- [ ] Tested on staging.
