### PR TITLE
Make sure we only set kudos_id if there's a reaction.

### DIFF
--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -44,7 +44,7 @@ class ReportbackTransformer extends TransformerAbstract
                         [
                             'current_user' => [
                                 // `$post->reactions` is constrained to only reactions w/ `as_user` Northstar ID.
-                                'kudos_id' => ! empty($post->reactions[0]) ? $post->reactions[0]->id ? : null,
+                                'kudos_id' => ! empty($post->reactions[0]) ? $post->reactions[0]->id : null,
                                 'reacted' => ! empty($post->reactions[0]),
                             ],
                             'term' => [

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -43,9 +43,9 @@ class ReportbackTransformer extends TransformerAbstract
                     'data' => [
                         [
                             'current_user' => [
-                                'kudos_id' => 1,
                                 // `$post->reactions` is constrained to only reactions w/ `as_user` Northstar ID.
-                                'reacted' => $post->reactions->count() >= 1,
+                                'kudos_id' => ! empty($post->reactions[0]) ? $post->reactions[0]->id ? : null,
+                                'reacted' => ! empty($post->reactions[0]),
                             ],
                             'term' => [
                                 'id' => 641,


### PR DESCRIPTION
#### What's this PR do?
Phoenix Ashes relies on `kudos_id` to determine whether to fill in the ❤️ in the interface, so we can't just hardcode that to a `1` or else they all show as filled. (I think we did it this way to work around a Phoenix Ashes bug with the `reacted` property? I'm not sure...)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🤷‍♂️

#### Relevant tickets
Fixes 💔

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.