### PR TITLE
Don't return edited images for broken images

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -15,12 +15,14 @@ class PostTransformer extends TransformerAbstract
      */
     public function transform(Post $post)
     {
+        $url = ($post->url === 'default') ? 'default' : config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . '/uploads/reportback-items/edited_' . $post->id . '.jpeg';
+
         return [
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
             'media' => [
-                'url' => config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . '/uploads/reportback-items/edited_' . $post->id . '.jpeg',
+                'url' => $url,
                 'caption' => $post->caption,
             ],
             'tagged' => $post->tagNames(),

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -17,13 +17,15 @@ class ReportbackTransformer extends TransformerAbstract
     {
         $signup = $post->signup;
 
+        $uri = ($post->url === 'default') ? 'default' : config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . '/uploads/reportback-items/edited_' . $post->id . '.jpeg';
+
         $result = [
             'id' => (string) $post->id,
             'status' => $post->status,
             'caption' => $post->caption,
             'uri' => url(config('services.phoenix.uri') . '/api/v1/reportback-items/'.$post->id, ['absolute' => true]),
             'media' => [
-                'uri' => config('filesystems.disks.s3.public_url') . '/' . config('filesystems.disks.s3.bucket') . '/uploads/reportback-items/edited_' . $post->id . '.jpeg',
+                'uri' => $uri,
                 'type' => 'image',
             ],
             'tagged' => $post->tagNames(),


### PR DESCRIPTION
#### What's this PR do?
Previously we were returning the edited image url even for images whose original url was `default`. This stops that! We still return `default` if the original url is `default`.

#### How should this be reviewed?
👀  Make sure I didn't make a dumb typo!

#### Any background context you want to provide?
This should fix the broken image in the Phoenix gallery.

#### Checklist
- [ ] Tested on staging.
