### PR TITLE
Return compound post_id|northstar_id format for kid.

### DIFF
--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -46,7 +46,7 @@ class ReportbackTransformer extends TransformerAbstract
                         [
                             'current_user' => [
                                 // `$post->reactions` is constrained to only reactions w/ `as_user` Northstar ID.
-                                'kudos_id' => ! empty($post->reactions[0]) ? (string) $post->reactions[0]->id : null,
+                                'kudos_id' => ! empty($post->reactions[0]) ? $post->reactions[0]->post_id . '|' . $post->reactions[0]->northstar_id : null,
                                 'reacted' => ! empty($post->reactions[0]),
                             ],
                             'term' => [


### PR DESCRIPTION
#### What's this PR do?
Since we need `post_id` and `northstar_id` to delete a reaction in Rogue, we need to make these easily available on the front-end. This updates the reportbacks endpoint to return a string formatted as `<post_id>|<northstar_id>` so we can easily grab those two values in Phoenix's "delete kudos" endpoint without having to change any client code.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Here's the corresponding Phoenix PR: DoSomething/phoenix#7471

#### Relevant tickets
Fixes 🐞

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.