### PR TITLE
Lighten the load on the single view campaign page

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -91,6 +91,7 @@ class CampaignsController extends Controller
      */
     public function showCampaign($id)
     {
+        // @TODO: we should paginate here instead of just showing 100
         $signups = Signup::campaign([$id])->has('posts')->with('posts')->take(100)->get();
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -91,7 +91,7 @@ class CampaignsController extends Controller
      */
     public function showCampaign($id)
     {
-        $signups = Signup::campaign([$id])->has('posts')->with('posts')->get();
+        $signups = Signup::campaign([$id])->has('posts')->with('posts')->take(100)->get();
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
         $signups->each(function ($item) {

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -94,6 +94,15 @@ class CampaignSingle extends React.Component {
 
     return (
       <div className="container">
+        <div className="container__block">
+          <p>
+            Hey there 🐼! Why’s there only ~100 photos on this page you ask? <br/>
+            Good question! We’re only loading ~100 photos to help this page load <em>faster</em> for you! We’re working on showing all the photos while keeping the page load time <em>fast</em>  - this should be done the by 8/1! Stay tuned!<br/>
+            If you  need to see more accepted posts, reach out in #the-bleed in Slack!<br/>
+            Love,<br/>
+            Team Bleed
+          </p>
+        </div>
         <StatusCounter postTotals={this.state.postTotals} campaign={campaign} />
         <PostFilter onChange={this.filterPosts} />
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -22,10 +22,10 @@ export function calculateAge(date) {
 };
 
 export function getImageUrlFromProp(photoProp) {
-  const photo_url = photoProp['url'];
+	const photo_url = photoProp['url'];
 
 	if (photo_url == "default") {
-	  return "https://pics.onsizzle.com/bork-2411135.png";
+	  return "https://www.dosomething.org/sites/default/files/JenBugError.png";
 	}
 	else {
 	  return photo_url;


### PR DESCRIPTION
#### What's this PR do?
1. Only load 100 posts on the single view campaign page
2. Update the default image
3. Add copy on the single view campaign page to warn everyone

new broken image example:
![image](https://user-images.githubusercontent.com/4240292/28432436-deb08d64-6d55-11e7-9997-bafab24975c2.png)


#### How should this be reviewed?
👀 

#### Checklist
- [ ] Tested on staging.