### PR TITLE
Remove filtering on single campaign view

### DIFF
--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -104,7 +104,8 @@ class CampaignSingle extends React.Component {
           </p>
         </div>
         <StatusCounter postTotals={this.state.postTotals} campaign={campaign} />
-        <PostFilter onChange={this.filterPosts} />
+        {/* @TODO - add back in when we deal with pagination on the single campaign view*/}
+        {/*<PostFilter onChange={this.filterPosts} />*/}
 
         { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} /> : null) }
 

--- a/resources/assets/components/StatusCounter/index.js
+++ b/resources/assets/components/StatusCounter/index.js
@@ -9,6 +9,7 @@ export default (props) => (
               <span className="status">Pending</span>
               <a className="button -secondary" href={`/campaigns/${props.campaign.id}/inbox`}>Review</a>
           </li>
+          {/* @TODO - add back in when we deal with pagination on the single campaign view
           <li>
               <span className="status">Accepted</span>
               <span className="count">{props.postTotals.accepted_count}</span>
@@ -16,7 +17,7 @@ export default (props) => (
           <li>
               <span className="status">Rejected</span>
               <span className="count">{props.postTotals.rejected_count}</span>
-          </li>
+          </li>*/}
       </ul>
   </div>
 );


### PR DESCRIPTION
#### What's this PR do?
Removes the filtering on the single campaign view page.

Looks like this now: 

![image](https://user-images.githubusercontent.com/1700409/28433786-fe82e38a-6d5a-11e7-9a6e-dfea2bb2aaf0.png)


#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Removing this because we are only pulling 100 signups with posts to show on this page and we don't know how many of these are pending, reject, approved. 

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.