### PR TITLE
Show a link to the edited photo on the inbox item

### DIFF
--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { calculateAge, getImageUrlFromProp } from '../../helpers';
+import { calculateAge, getImageUrlFromProp, getEditedImageUrl } from '../../helpers';
 import { remove, map, clone } from 'lodash';
 
 import Tags from '../Tags';
@@ -44,7 +44,7 @@ class InboxItem extends React.Component {
         <div className="container__block -third">
           <img src={getImageUrlFromProp(post)}/>
           <p>
-            <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a>
+            <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a> | <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
           </p>
 
           <ul className="gallery -duo">

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -39,3 +39,13 @@ export function extractPostsFromSignups(signups) {
 
     return posts;
 }
+
+export function getEditedImageUrl(photoProp) {
+  const edited_file_name = `edited_${photoProp.id}.jpeg`;
+  const url_parts = photoProp['url'].split("/");
+
+  url_parts.pop();
+  url_parts.push(edited_file_name);
+
+  return url_parts.join('/');
+};


### PR DESCRIPTION
#### What's this PR do?

Adds an "edited photo" link next to the "original photo" link on inbox items. 

![image](https://user-images.githubusercontent.com/1700409/28476189-ea030896-6e03-11e7-9240-c7ea0c38c948.png)

#### How should this be reviewed?

👀 . Verify my string logic makes sense. 

#### Any background context you want to provide?

Admins might need to smaller edited version of an image. 

