### PR TITLE
Campaign Inbox Pagination and Confetti Flare 🎉

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dosomething-modal": "^0.3.0",
     "lodash": "^4.17.4",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "react-dom-confetti": "0.0.8"
   },
   "devDependencies": {
     "@dosomething/babel-config": "^1.0.0",

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -16,10 +16,10 @@ class CampaignInbox extends React.Component {
 
     const posts = extractPostsFromSignups(props.signups);
     const allPosts = Object.keys(posts).map(elem => posts[elem]);
-    const initialPost = {};
-    allPosts.slice(0, 5).forEach(postElem => {
-      initialPost[postElem.id] = postElem;
-    });
+    const initialPost = allPosts.slice(0, 5).reduce((posts, postElem) => {
+      posts[postElem.id] = postElem;
+      return posts;
+    }, {});
 
     this.state = {
       allPosts: allPosts,
@@ -45,7 +45,7 @@ class CampaignInbox extends React.Component {
   }
 
   batchIsComplete(posts) {
-    return iscomplete =  Object.keys(posts)
+    return Object.keys(posts)
       .map(postKey => posts[postKey])
       .every(post => post.status !== 'pending');
   }
@@ -54,8 +54,10 @@ class CampaignInbox extends React.Component {
     const from          = this.state.currentBatch * this.state.numberOfPosts;
     const to            = from + this.state.numberOfPosts;
     const nextBatch     = this.state.currentBatch + 1;
-    const nextPostBatch = {};
-    this.state.allPosts.slice(from, to).forEach(postElem => nextPostBatch[postElem.id] = postElem);
+    const nextPostBatch = this.state.allPosts.slice(from, to).reduce((posts, postElem) => {
+      posts[postElem.id] = postElem;
+      return posts;
+    }, {});
 
 
     this.setState({

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -6,11 +6,132 @@ import Tags from '../Tags';
 import InboxTile from './InboxTile';
 import StatusButton from '../StatusButton';
 
+function UserImages(props) {
+  const userImage = getImageUrlFromProp(props.post);
+  return (
+    <div className="container__block -third">
+      <img src={userImage}/>
+      <p>
+        <a href={userImage} target="_blank">Original Photo</a>
+      </p>
+
+      <ul className="gallery -duo">
+        { map(props.getOtherPosts(props.post), (post, key) => <InboxTile key={key} details={post} />) }
+      </ul>
+    </div>
+  );
+}
+
+function UserInfo(props) {
+  return (
+    <div>
+      <h2>{props.post['user']['first_name']} {props.post['user']['last_name']}, {calculateAge(props.post['user']['birthdate'])}</h2>
+      <ul>
+      <li><em>{props.post['user']['email']}</em></li>
+      <li><em>{props.post['user']['mobile']}</em></li>
+      </ul>
+    </div>
+  );
+}
+
+function UserReportBack(props) {
+  return (
+    <div>
+      <article className="figure -left -center">
+        { props.signup.quantity ?
+          <div>
+            <div className="figure__media">
+              <div className="quantity">{props.signup.quantity}</div>
+            </div>
+            <div className="figure__body">
+              {props.campaign['reportback_info']['noun']} {props.campaign['reportback_info']['verb']}
+            </div>
+          </div>
+          : null }
+      </article>
+      <a href="#" onClick={e => props.showHistory(props.post['id'], e)}>Edit | Show History</a>
+      <br/>
+      <br/>
+      {props.post['caption'] ?
+        <div>
+          <h4>Photo Caption</h4>
+          <p>{props.post['caption']}</p>
+        </div>
+        : null}
+      <h4>Why Statement</h4>
+      <p>{props.signup.why_participated}</p>
+    </div>
+  );
+}
+
+function UserInfoReport(props) {
+  return (
+    <div className="container__block -third">
+      <UserInfo post={props.post} />
+      <br/>
+      <UserReportBack
+        showHistory={props.showHistory}
+        post={props.post}
+        campaign={props.campaign}
+        signup={props.signup} />
+    </div>
+  );
+}
+
+function PostMetaData(props){
+  return (
+    <div>
+      <h4>Meta</h4>
+      <p>
+        Post ID: {props.post['id']} <br/>
+        Post Status: {props.post['status']} <br/>
+        Source: {props.post['source']} <br/>
+        Submitted: {props.post['created_at']} <br/>
+      </p>
+    </div>
+  );
+}
+
+function PostReview(props) {
+  return (
+    <div>
+      {props.allowReview ?
+        <div>
+          <ul className="form-actions -inline">
+            <li><StatusButton type="accepted" label="accept" status={props.post.status} setStatus={props.setStatus}/></li>
+            <li><StatusButton type="rejected" label="reject" status={props.post.status} setStatus={props.setStatus}/></li>
+          </ul>
+          <ul className="form-actions -inline">
+            <li><button className="button delete -tertiary" onClick={e => props.deletePost(props.post['id'], e)}>Delete</button></li>
+          </ul>
+          {props.post.status === 'accepted' ? <Tags id={props.post.id} tagged={props.post.tagged} onTag={props.onTag} /> : null}
+        </div>
+        : null }
+    </div>
+  )
+}
+
+function PostReviewAndMetaData(props) {
+  return (
+    <div className="container__block -third">
+      <PostReview
+        post={props.post}
+        setStatus={props.setStatus}
+        allowReview={props.allowReview}
+        deletePost={props.deletePost}
+        onTag={props.onTag} />
+      <PostMetaData
+        post={props.post} />
+    </div>
+  );
+}
+
 class InboxItem extends React.Component {
   constructor () {
     super();
 
     this.setStatus = this.setStatus.bind(this);
+    this.getOtherPosts = this.getOtherPosts.bind(this);
   }
 
   // @todo - define this on the StatusButton component that can set some sort of global state.
@@ -38,72 +159,22 @@ class InboxItem extends React.Component {
     const post = this.props.details.post;
     const campaign = this.props.details.campaign;
     const signup = this.props.details.signup;
-
     return (
       <div className="container__row">
-        <div className="container__block -third">
-          <img src={getImageUrlFromProp(post)}/>
-          <p>
-            <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a>
-          </p>
-
-          <ul className="gallery -duo">
-          { map(this.getOtherPosts(post), (post, key) => <InboxTile key={key} details={post} />) }
-          </ul>
-        </div>
-        <div className="container__block -third">
-          <h2>{post['user']['first_name']} {post['user']['last_name']}, {calculateAge(post['user']['birthdate'])}</h2>
-          <ul>
-            <li><em>{post['user']['email']}</em></li>
-            <li><em>{post['user']['mobile']}</em></li>
-          </ul>
-          <br/>
-          <article className="figure -left -center">
-            { signup.quantity ?
-              <div>
-                <div className="figure__media">
-                  <div className="quantity">{signup.quantity}</div>
-                </div>
-                <div className="figure__body">
-                   {campaign['reportback_info']['noun']} {campaign['reportback_info']['verb']}
-                </div>
-              </div>
-            : null }
-          </article>
-          <a href="#" onClick={e => this.props.showHistory(post['id'], e)}>Edit | Show History</a>
-          <br/>
-          <br/>
-          {post['caption'] ?
-            <div>
-              <h4>Photo Caption</h4>
-              <p>{post['caption']}</p>
-            </div>
-          : null}
-          <h4>Why Statement</h4>
-          <p>{signup.why_participated}</p>
-        </div>
-        <div className="container__block -third">
-          {/* @TODO - make a Review component */}
-          {this.props.allowReview ?
-            <div>
-              <ul className="form-actions -inline">
-                <li><StatusButton type="accepted" label="accept" status={post.status} setStatus={this.setStatus}/></li>
-                <li><StatusButton type="rejected" label="reject" status={post.status} setStatus={this.setStatus}/></li>
-              </ul>
-              <ul className="form-actions -inline">
-                <li><button className="button delete -tertiary" onClick={e => this.props.deletePost(post['id'], e)}>Delete</button></li>
-              </ul>
-              {post.status === 'accepted' ? <Tags id={post.id} tagged={post.tagged} onTag={this.props.onTag} /> : null}
-            </div>
-          : null }
-          <h4>Meta</h4>
-          <p>
-            Post ID: {post['id']} <br/>
-            Post Status: {post['status']} <br/>
-            Source: {post['source']} <br/>
-            Submitted: {post['created_at']} <br/>
-          </p>
-        </div>
+        <UserImages
+          post={post}
+          getOtherPosts={this.getOtherPosts} />
+        <UserInfoReport
+          post={post}
+          campaign={campaign}
+          signup={signup}
+          showHistory={this.props.showHistory}/>
+        <PostReviewAndMetaData
+          post={post}
+          setStatus={this.setStatus}
+          allowReview={this.props.allowReview}
+          deletePost={this.props.deletePost}
+          onTag={this.props.onTag} />
       </div>
     )
   }


### PR DESCRIPTION
#### What's this PR do?
:sparkles: Added pagination to campaign inbox view
:sparkles: Added confetti flare when users retrieve next batch of posts
:sparkles: Restructure InboxItem component to use functional components

#### How should this be reviewed?
* To run locally: [set up] pull down, start up your vm, npm install, build assets
* Navigate to http://rogue.dev/campaigns
* Select any campaign that has pending posts (click on the number of pending reviews)
* Once in campaign inbox 
**Expect**:  total number of posts to be 5
**Expect**:  a 'give me more' button displays (initially disabled)
* Select a review option (accept/reject) 
**Expect**: post status to update from 'pending' to status selected
* Review all items on page, once all the posts are reviewed
Expect: 'give me more' button to be enabled
* Click 'give me more' button to get the next batch of posts (if applicable)
**Expect**: confetti to display once button is clicked
**Expect**: new posts to display
* Once you are at the end of the pending posts 
Expect: button to read 'Done!' - it should still remain disabled until all posts have been reviewed
*Once the last item is reviewed 
**Expect**: the button to show confetti - no click necessary.


#### Any background context you want to provide?
N/A

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.