### PR TITLE
Paginate the single view campaign page

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -115,8 +115,6 @@ class CampaignsController extends Controller
                 ],
                 'next_page' => $signups->nextPageUrl(),
                 'previous_page' => $signups->previousPageUrl(),
-                'next_page_copy' => $signups->nextPageUrl() ? 'next >' : null,
-                'previous_page_copy' => $signups->previousPageUrl() ? '< previous' : null,
             ]);
     }
 }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -91,8 +91,7 @@ class CampaignsController extends Controller
      */
     public function showCampaign($id)
     {
-        // @TODO: we should paginate here instead of just showing 100
-        $signups = Signup::campaign([$id])->has('posts')->with('posts')->paginate(50);
+        $signups = Signup::campaign([$id])->has('posts')->with('posts')->orderBy('created_at', 'desc')->paginate(50);
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
         $signups->each(function ($item) {

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -92,7 +92,7 @@ class CampaignsController extends Controller
     public function showCampaign($id)
     {
         // @TODO: we should paginate here instead of just showing 100
-        $signups = Signup::campaign([$id])->has('posts')->with('posts')->paginate(1);
+        $signups = Signup::campaign([$id])->has('posts')->with('posts')->paginate(50);
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
         $signups->each(function ($item) {
@@ -116,6 +116,8 @@ class CampaignsController extends Controller
                 ],
                 'next_page' => $signups->nextPageUrl(),
                 'previous_page' => $signups->previousPageUrl(),
+                'next_page_copy' => $signups->nextPageUrl() ? 'next >' : null,
+                'previous_page_copy' => $signups->previousPageUrl() ? '< previous' : null,
             ]);
     }
 }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -92,7 +92,7 @@ class CampaignsController extends Controller
     public function showCampaign($id)
     {
         // @TODO: we should paginate here instead of just showing 100
-        $signups = Signup::campaign([$id])->has('posts')->with('posts')->take(100)->get();
+        $signups = Signup::campaign([$id])->has('posts')->with('posts')->paginate(1);
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
         $signups->each(function ($item) {
@@ -107,13 +107,15 @@ class CampaignsController extends Controller
 
         return view('pages.campaign_single')
             ->with('state', [
-                'signups' => $signups,
+                'signups' => $signups->toArray()['data'],
                 'campaign' => $campaign,
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,
                     'pending_count' => $totals->pending_count,
                     'rejected_count' => $totals->rejected_count,
                 ],
+                'next_page' => $signups->nextPageUrl(),
+                'previous_page' => $signups->previousPageUrl(),
             ]);
     }
 }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -106,7 +106,7 @@ class CampaignsController extends Controller
 
         return view('pages.campaign_single')
             ->with('state', [
-                'signups' => $signups->toArray()['data'],
+                'signups' => $signups->items(),
                 'campaign' => $campaign,
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -52,7 +52,3 @@ button.delete {
   font-weight: bold;
   margin-right: 5px;
 }
-
-.next-page {
-  float: right;
-}

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -52,3 +52,12 @@ button.delete {
   font-weight: bold;
   margin-right: 5px;
 }
+
+.paging {
+  .no-show {
+    display: none;
+  }
+  .next-page {
+    float: right;
+  }
+}

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -53,11 +53,6 @@ button.delete {
   margin-right: 5px;
 }
 
-.paging {
-  .no-show {
-    display: none;
-  }
-  .next-page {
-    float: right;
-  }
+.next-page {
+  float: right;
 }

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -99,18 +99,8 @@ class CampaignSingle extends React.Component {
 
     return (
       <div className="container">
-        <div className="container__block">
-          <p>
-            Hey there 🐼! Why’s there only ~100 photos on this page you ask? <br/>
-            Good question! We’re only loading ~100 photos to help this page load <em>faster</em> for you! We’re working on showing all the photos while keeping the page load time <em>fast</em>  - this should be done the by 8/1! Stay tuned!<br/>
-            If you  need to see more accepted posts, reach out in #the-bleed in Slack!<br/>
-            Love,<br/>
-            Team Bleed
-          </p>
-        </div>
         <StatusCounter postTotals={this.state.postTotals} campaign={campaign} />
-        {/* @TODO - add back in when we deal with pagination on the single campaign view*/}
-        {/*<PostFilter onChange={this.filterPosts} />*/}
+        <PostFilter onChange={this.filterPosts} />
 
         { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} /> : null) }
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -24,9 +24,7 @@ class CampaignSingle extends React.Component {
       displayHistoryModal: false,
       historyModalId: null,
       nextPage: props.next_page,
-      nextPageCopy: props.next_page_copy,
       prevPage: props.previous_page,
-      prevPageCopy: props.previous_page_copy,
     };
 
     this.api = new RestApiClient;
@@ -108,7 +106,7 @@ class CampaignSingle extends React.Component {
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
         </ModalContainer>
         
-        <PagingButtons prev={this.state.prevPage} prevCopy={this.state.prevPageCopy} next={this.state.nextPage} nextCopy={this.state.nextPageCopy}></PagingButtons>
+        <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>
       </div>
     )
   }

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -5,6 +5,7 @@ import { extractPostsFromSignups } from '../../helpers';
 import InboxItem from '../InboxItem';
 import ModalContainer from '../ModalContainer';
 import HistoryModal from '../HistoryModal';
+import PagingButtons from '../PagingButtons';
 import PostFilter from '../PostFilter';
 import StatusCounter from '../StatusCounter';
 import { RestApiClient} from '@dosomething/gateway';
@@ -22,6 +23,8 @@ class CampaignSingle extends React.Component {
       postTotals: props.post_totals,
       displayHistoryModal: false,
       historyModalId: null,
+      nextPage: props.next_page,
+      prevPage: props.previous_page,
     };
 
     this.api = new RestApiClient;
@@ -112,6 +115,8 @@ class CampaignSingle extends React.Component {
         <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
         </ModalContainer>
+        
+        <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>
       </div>
     )
   }

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -24,7 +24,9 @@ class CampaignSingle extends React.Component {
       displayHistoryModal: false,
       historyModalId: null,
       nextPage: props.next_page,
+      nextPageCopy: props.next_page_copy,
       prevPage: props.previous_page,
+      prevPageCopy: props.previous_page_copy,
     };
 
     this.api = new RestApiClient;
@@ -116,7 +118,7 @@ class CampaignSingle extends React.Component {
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
         </ModalContainer>
         
-        <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>
+        <PagingButtons prev={this.state.prevPage} prevCopy={this.state.prevPageCopy} next={this.state.nextPage} nextCopy={this.state.nextPageCopy}></PagingButtons>
       </div>
     )
   }

--- a/resources/assets/components/PagingButtons/index.js
+++ b/resources/assets/components/PagingButtons/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import './paging-buttons.scss';
 
 class PagingButtons extends React.Component {
 

--- a/resources/assets/components/PagingButtons/index.js
+++ b/resources/assets/components/PagingButtons/index.js
@@ -6,14 +6,12 @@ class PagingButtons extends React.Component {
   render() {
     const prev = this.props.prev;
     const next = this.props.next;
-    const prevCopy = this.props.prevCopy;
-    const nextCopy = this.props.nextCopy;
 
     return (
         <div className="container__block">
-			<a href={prev}>{prevCopy}</a>
+			<a href={prev} disabled={prev}>{prev ? "< previous" : null}</a>
 			<div className="next-page">
-				<a href={next}>{nextCopy}</a>
+				<a href={next}>{next ? "next >" : null}</a>
 			</div>
         </div>
     )

--- a/resources/assets/components/PagingButtons/index.js
+++ b/resources/assets/components/PagingButtons/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+class PagingButtons extends React.Component {
+
+  render() {
+    const prev = this.props.prev;
+    const next = this.props.next;
+
+    const showPrev = (prev === null) ? "paging -no-show" : "paging";
+    const showNext = (next === null) ? "paging -next-page -noShow" : "paging -next-page";
+
+
+    return (
+        <div className="container__block">
+          <div className={showPrev}>
+            <a href={prev}>&larr; previous</a>
+          </div>
+          <div className={showNext}>
+            <a href={next}>next &rarr;</a>
+          </div>
+        </div>
+    )
+  }
+}
+
+export default PagingButtons;

--- a/resources/assets/components/PagingButtons/index.js
+++ b/resources/assets/components/PagingButtons/index.js
@@ -5,19 +5,15 @@ class PagingButtons extends React.Component {
   render() {
     const prev = this.props.prev;
     const next = this.props.next;
-
-    const showPrev = (prev === null) ? "paging -no-show" : "paging";
-    const showNext = (next === null) ? "paging -next-page -noShow" : "paging -next-page";
-
+    const prevCopy = this.props.prevCopy;
+    const nextCopy = this.props.nextCopy;
 
     return (
         <div className="container__block">
-          <div className={showPrev}>
-            <a href={prev}>&larr; previous</a>
-          </div>
-          <div className={showNext}>
-            <a href={next}>next &rarr;</a>
-          </div>
+			<a href={prev}>{prevCopy}</a>
+			<div className="next-page">
+				<a href={next}>{nextCopy}</a>
+			</div>
         </div>
     )
   }

--- a/resources/assets/components/PagingButtons/paging-buttons.scss
+++ b/resources/assets/components/PagingButtons/paging-buttons.scss
@@ -1,0 +1,3 @@
+.next-page {
+  float: right;
+}

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -33,9 +33,9 @@ export function getImageUrlFromProp(photoProp) {
 };
 
 export function extractPostsFromSignups(signups) {
-    const posts = keyBy(flatMap(signups, signup => {
+    const posts = flatMap(signups, signup => {
       return signup.posts;
-    }), 'id');
+    });
 
     return posts;
 }


### PR DESCRIPTION
#### What's this PR do?
1. Use `->paginate` on the query to get the signups to display on the single view campaign page. I set it at 50, but we can increase or decrease that depending on the performance we see and what works best for people.
2. Remove the 🐼  message because all posts can be accessed now
3. Add back in sorting
4. Add a new component `PagingButtons` to display the links to the adjacent pages (I figured we'll end up having pagination elsewhere too eventually)

Bottom of the page looks like this:
![image](https://user-images.githubusercontent.com/4240292/28532186-15a2e862-7067-11e7-833b-b18f56d5dd42.png)


#### How should this be reviewed?
Caution: I did write some css. See if the way this is organized makes sense. It works, but I don't want to introduce any debt!

#### Any background context you want to provide?
We need to paginate these pages so we aren't trying to load thousands and thousands of posts at once.

#### Relevant tickets
[Pivotal card? did I do this right?](https://www.pivotaltracker.com/story/show/149263495)

#### Checklist
- [ ] Tested on staging.