### PR TITLE
adds northstar_id as param for reportbacks endpoint

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -63,6 +63,11 @@ class ReportbackController extends ApiController
                 $query = $query->where('campaign_id', '=', $filters['campaign_id']);
             }
 
+            // Only return Posts for the given northstar_id (if there is one)
+            if (array_has($filters, 'northstar_id')) {
+                $query = $query->where('signups.northstar_id', '=', $filters['northstar_id']);
+            }
+
             // Exclude Posts if exclude param is present
             if (array_has($filters, 'exclude')) {
                 $query = $query->whereNotIn('posts.id', explode(',', $filters['exclude']));

--- a/documentation/endpoints/reportbacks.md
+++ b/documentation/endpoints/reportbacks.md
@@ -16,6 +16,9 @@ GET /api/v1/reportbacks
 - **campaign_id** _(integer)_
   - The nid to filter the response by.
   - e.g. `/reportbacks?filter[campaign_id]=47`
+- **northstar_id** _(integer)_
+  - The northstar_id to filter the response by.
+  - e.g. `/reportbacks?filter[northstar_id]=47asdf23abc`
 - **exclude** _(integer)_
   - The post id(s) to exclude in response. 
   - e.g. `/reportbacks?filter[exclude]=2,3,4`


### PR DESCRIPTION
#### What's this PR do?
Adds `northstar_id` query param for `/reportbacks` endpoint for user profile work. 

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.