### PR TITLE
Overview refactor

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -44,7 +44,7 @@ class CampaignsController extends Controller
     {
         $ids = $this->campaignService->getCampaignIdsFromSignups();
         $campaigns = $this->campaignService->findAll($ids);
-        $campaigns = $this->campaignService->appendStatusCountsToCampaigns($campaigns);
+        $campaigns = $this->campaignService->appendPendingCountsToCampaigns($campaigns);
 
         $causes = $campaigns ? $this->campaignService->groupByCause($campaigns) : null;
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -39,7 +39,8 @@ class CampaignService
         if (! $campaign) {
             $campaign = $this->phoenix->getCampaign($id);
 
-            $this->cache->store($campaign['data']['id'], $campaign['data']);
+            // Cache campaign for a day.
+            $this->cache->store($campaign['data']['id'], $campaign['data'], 1440);
 
             $campaign = $campaign['data'];
         }
@@ -64,7 +65,8 @@ class CampaignService
                 if (count($campaigns)) {
                     $group = $campaigns->keyBy('id')->all();
 
-                    $this->cache->storeMany($group);
+                    // Cache campaigns for a day.
+                    $this->cache->storeMany($group, 1440);
                 }
             } else {
                 $campaigns = $this->resolveMissingCampaigns($campaigns);
@@ -303,9 +305,9 @@ class CampaignService
                     $statusCounts = $campaignsWithCounts->get($campaign['id']);
 
                     if ($statusCounts) {
-                        $campaign['accepted_count'] = 0; // (int) $statusCounts->accepted_count;
+                        $campaign['accepted_count'] = (int) $statusCounts->accepted_count;
                         $campaign['pending_count'] = (int) $statusCounts->pending_count;
-                        $campaign['rejected_count'] = 0; //(int) $statusCounts->rejected_count;
+                        $campaign['rejected_count'] = (int) $statusCounts->rejected_count;
                     }
                 }
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -182,53 +182,12 @@ class CampaignService
     }
 
     /**
-     * Get Post totals for a collection of campaigns or a single campaign.
-     *
-     * @return Illuminate\Support\Collection| object $campaigns
-     */
-    public function getPostTotals($campaigns)
-    {
-        if ($campaigns instanceof \Illuminate\Support\Collection) {
-            return $this->getCollectionOfCampaignsPostTotals($campaigns);
-        }
-
-        if (is_array($campaigns)) {
-            return $this->getSingleCampaignPostTotals($campaigns);
-        }
-
-        return null;
-    }
-
-    /**
-     * Gets the count of pending, accepted, and rejected stautses on each post for a collection of campaigns.
-     *
-     * @param  Illuminate\Support\Collection $campaigns
-     * @return Illuminate\Support\Collection $campaigns
-     */
-    public function getCollectionOfCampaignsPostTotals($campaigns)
-    {
-        $ids = $campaigns->pluck('id')->filter()->toArray();
-
-        $totals = DB::table('signups')
-                ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
-                ->select('signups.campaign_id',
-                    DB::raw('SUM(case when posts.status = "accepted" then 1 else 0 end) as accepted_count'),
-                    DB::raw('SUM(case when posts.status = "pending" then 1 else 0 end) as pending_count'),
-                    DB::raw('SUM(case when posts.status = "rejected" then 1 else 0 end) as rejected_count'))
-                ->wherein('campaign_id', $ids)
-                ->groupBy('signups.campaign_id')
-                ->get();
-
-        return $totals ? collect($totals)->keyBy('campaign_id') : collect();
-    }
-
-    /**
      * Gets the count of pending, accepted, and rejected stautses on each post for a single campaign.
      *
      * @param  array $campaign
      * @return array $toals | null
      */
-    public function getSingleCampaignPostTotals($campaign)
+    public function getPostTotals($campaign)
     {
         return DB::table('signups')
                 ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
@@ -247,7 +206,7 @@ class CampaignService
      * @param  Illuminate\Support\Collection $campaigns
      * @return Illuminate\Support\Collection $totals
      */
-    public function getPendingTotals($campaigns)
+    public function getPendingPostTotals($campaigns)
     {
         $ids = $campaigns->pluck('id')->filter()->toArray();
 
@@ -270,7 +229,7 @@ class CampaignService
      */
     public function appendPendingCountsToCampaigns($campaigns)
     {
-        $campaignsWithCounts = $this->getPostTotals($campaigns);
+        $campaignsWithCounts = $this->getPendingPostTotals($campaigns);
 
         if ($campaignsWithCounts) {
             $campaigns = $campaigns->map(function ($campaign, $key) use ($campaignsWithCounts) {

--- a/resources/assets/components/CampaignTable/index.js
+++ b/resources/assets/components/CampaignTable/index.js
@@ -10,7 +10,7 @@ class CampaignTable extends React.Component {
     return (
       <div className="table-responsive container__block">
         <h2>{cause}</h2>
-        <Table key={cause} className="table" headings={['Campaign Name', 'Pending', 'Approved', 'Rejected']} data={this.props.campaigns} />
+        <Table key={cause} className="table" headings={['Campaign Name', 'Pending']} data={this.props.campaigns} />
       </div>
     )
   }

--- a/resources/assets/components/CampaignTable/index.js
+++ b/resources/assets/components/CampaignTable/index.js
@@ -10,7 +10,7 @@ class CampaignTable extends React.Component {
     return (
       <div className="table-responsive container__block">
         <h2>{cause}</h2>
-        <Table key={cause} className="table" headings={['Campaign Name', 'Pending']} data={this.props.campaigns} />
+        <Table key={cause} className="table" headings={['Campaign Name', 'Pending', 'Inbox']} data={this.props.campaigns} />
       </div>
     )
   }

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -9,7 +9,8 @@ class Row extends React.Component {
     return (
       <tr className="table__row">
         <td className="table__cell"><a href={campaignUrl}>{campaign ? campaign.title : 'Campaign Not Found'}</a></td>
-        <td className="table__cell"><a href={inboxUrl}>{this.props.pending}</a></td>
+        <td className="table__cell">{this.props.pending}</td>
+        <td className="table__cell"><a href={inboxUrl}>review</a></td>
       </tr>
     )
   }

--- a/resources/assets/components/Table/Row.js
+++ b/resources/assets/components/Table/Row.js
@@ -10,8 +10,6 @@ class Row extends React.Component {
       <tr className="table__row">
         <td className="table__cell"><a href={campaignUrl}>{campaign ? campaign.title : 'Campaign Not Found'}</a></td>
         <td className="table__cell"><a href={inboxUrl}>{this.props.pending}</a></td>
-        <td className="table__cell">{this.props.approved}</td>
-        <td className="table__cell">{this.props.rejected}</td>
       </tr>
     )
   }

--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -11,7 +11,7 @@ class Table extends React.Component {
     });
 
     const rows = this.props.data.map((content, index) => {
-      return <Row key={index} campaign={content} campaign_id={content ? content.id : ''} approved={content ? content.accepted_count : 0} pending={content ? content.pending_count : 0} rejected={content ? content.rejected_count : 0} />;
+      return <Row key={index} campaign={content} campaign_id={content ? content.id : ''} pending={content ? content.pending_count : 0} />;
     });
 
     return (


### PR DESCRIPTION
#### What's this PR do?

Tries to tackle the slow performance we are seeing on `/campaigns` trying to tally up the counts for each status is a heavy operation because we don't store campaigns in the DB so we have to iterate over signups and posts to get counts.

In order to lighten the load a little bit, I am only pulling pending post totals for each campaign. This is a quick win to run a simpler query and cuts the load time for the page to around 2.5 seconds instead of the 11secs we were seeing. 

I also am caching campaign objects for longer, upping the time we store it in cache to 1 day instead of 15 mins. 

I also made a bit of a change to the frontend, where instead of linking the pending count number, we have a separate link to the inbox next to it. I did this because I heard some feedback that it was confusing to know what to click. 

Screenshot of the load times I am seeing on my local. 
![image](https://user-images.githubusercontent.com/1700409/28684291-db1c30dc-72d1-11e7-9b64-a96097471d6b.png)

#### How should this be reviewed?
Commit by commit should be safe. 

#### Any background context you want to provide?

I think there is a case to be made to store these totals in a separate table in the DB and then we could just have an event that fires when something gets reviewed to tick the count up or down. But this was the easiest win in the meantime. 

#### Relevant tickets
Addresses: https://www.pivotaltracker.com/story/show/149263517

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.