### PR TITLE
Turn filtering off and only show accepted posts

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -91,8 +91,7 @@ class CampaignsController extends Controller
      */
     public function showCampaign($id)
     {
-        // @TODO: currently we do not allow filtering so we only show accepted posts, so
-        // remove the contraint on status once filtering is rockin' 'n' rollin' again
+        // Always load the page with just accepted posts
         $signups = Signup::campaign([$id])->has('posts')->with(['posts' => function ($query) {
             $query->where('status', '=', 'accepted');
         }])->orderBy('created_at', 'desc')->paginate(50);

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -93,7 +93,7 @@ class CampaignsController extends Controller
     {
         // @TODO: currently we do not allow filtering so we only show accepted posts, so
         // remove the contraint on status once filtering is rockin' 'n' rollin' again
-        $signups = Signup::campaign([$id])->has('posts')->with(['posts' => function ($query){
+        $signups = Signup::campaign([$id])->has('posts')->with(['posts' => function ($query) {
             $query->where('status', '=', 'accepted');
         }])->orderBy('created_at', 'desc')->paginate(50);
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -91,7 +91,11 @@ class CampaignsController extends Controller
      */
     public function showCampaign($id)
     {
-        $signups = Signup::campaign([$id])->has('posts')->with('posts')->orderBy('created_at', 'desc')->paginate(50);
+        // @TODO: currently we do not allow filtering so we only show accepted posts, so
+        // remove the contraint on status once filtering is rockin' 'n' rollin' again
+        $signups = Signup::campaign([$id])->has('posts')->with(['posts' => function ($query){
+            $query->where('status', '=', 'accepted');
+        }])->orderBy('created_at', 'desc')->paginate(50);
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
         $signups->each(function ($item) {

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -98,7 +98,8 @@ class CampaignSingle extends React.Component {
     return (
       <div className="container">
         <StatusCounter postTotals={this.state.postTotals} campaign={campaign} />
-        <PostFilter onChange={this.filterPosts} />
+        { /* @TODO: we will want this back oncefiltering is back */ }
+        { /* <PostFilter onChange={this.filterPosts} /> */}
 
         { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} /> : null) }
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -101,6 +101,11 @@ class CampaignSingle extends React.Component {
         { /* @TODO: we will want this back oncefiltering is back */ }
         { /* <PostFilter onChange={this.filterPosts} /> */}
 
+      { /* @TODO: remove this heading once filtering is back */}
+        <div className="heading -gamma">
+          Accepted Posts
+        </div>
+
         { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} /> : null) }
 
         <ModalContainer>


### PR DESCRIPTION
#### What's this PR do?
This will I think let us push campaign single view pagination live. The page will only include accepted posts and does not allow filtering. I also added copy to let admins know that this page only shows accepted posts.

![image](https://user-images.githubusercontent.com/4240292/28794773-79262bda-7605-11e7-8983-dd227f212a16.png)

#### How should this be reviewed?
Is this the interim state that we want for this? 👀 

#### Any background context you want to provide?
Currently, we can't have pagination and filtering because the pagination happens before the filtering, so if there are no `accepted` posts on the first page and the filter is set to `accepted` it will be a blank page with a `next >` button which is not what we want.

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.