### PR TITLE
Move `campaign_id` into posts table & re-apply #329.

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -54,6 +54,8 @@ class ReportbackController extends ApiController
             ->where('status', 'accepted')
             // ...and haven't been hidden from the gallery.
             ->withoutTags(['Hide In Gallery']);
+
+        // @TODO: Use `FiltersRequests` trait here!
         $filters = $request->query('filter');
         if (! empty($filters)) {
             // Only return Posts for the given campaign_id (if there is one)

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -63,7 +63,7 @@ class ReportbackController extends ApiController
 
             // Only return Posts for the given northstar_id (if there is one)
             if (array_has($filters, 'northstar_id')) {
-                $query = $query->where('signups.northstar_id', '=', $filters['northstar_id']);
+                $query = $query->where('northstar_id', '=', $filters['northstar_id']);
             }
 
             // Only return Posts for the given status (if there is one)

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -45,17 +45,16 @@ class ReportbackController extends ApiController
     public function index(Request $request)
     {
         // Create an empty Post query, which we can filter and paginate
-        // Only return Posts that do not have 'Hide In Gallery' tag
-        $query = $this->newQuery(Post::class)->withoutTags(['Hide In Gallery']);
-
-        // 1. Join with signups so we can access the signup data and filter by campaign
-        // 2. Only return approved Posts
-        // 3. Select all the fields that we will be using
-        $query = $query->join('signups', 'signups.id', '=', 'posts.signup_id')
-            ->select('posts.id as id', 'signups.campaign_id as campaign_id', 'posts.status as status', 'posts.caption as caption', 'posts.url as url', 'posts.created_at as created_at', 'posts.signup_id as signup_id');
-
+        $query = $this->newQuery(Post::class)
+            // Eagerly load the `signup` relationship.
+            ->with('signup')
+            // And eagerly load the count of reactions per post.
+            ->withCount('reactions')
+            // Only return posts that have been approved by a campaign lead...
+            ->where('status', 'accepted')
+            // ...and haven't been hidden from the gallery.
+            ->withoutTags(['Hide In Gallery']);
         $filters = $request->query('filter');
-
         if (! empty($filters)) {
             // Only return Posts for the given campaign_id (if there is one)
             if (array_has($filters, 'campaign_id')) {
@@ -74,12 +73,9 @@ class ReportbackController extends ApiController
 
             // Exclude Posts if exclude param is present
             if (array_has($filters, 'exclude')) {
-                $query = $query->whereNotIn('posts.id', explode(',', $filters['exclude']));
+                $query = $query->whereNotIn('id', explode(',', $filters['exclude']));
             }
         }
-
-        // Eagerly load the count of all reactions on a post.
-        $query = $query->withCount('reactions');
 
         // If user param is passed, return whether or not the user has liked the particular post.
         if ($request->query('as_user')) {

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -58,7 +58,9 @@ class ReportbackController extends ApiController
         if (! empty($filters)) {
             // Only return Posts for the given campaign_id (if there is one)
             if (array_has($filters, 'campaign_id')) {
-                $query = $query->where('campaign_id', '=', $filters['campaign_id']);
+                $query = $query
+                    ->leftJoin('signups', 'signups.id', '=', 'posts.signup_id')
+                    ->where('signups.campaign_id', '=', $filters['campaign_id']);
             }
 
             // Only return Posts for the given northstar_id (if there is one)

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -58,9 +58,9 @@ class ReportbackController extends ApiController
         if (! empty($filters)) {
             // Only return Posts for the given campaign_id (if there is one)
             if (array_has($filters, 'campaign_id')) {
-                $query = $query
-                    ->leftJoin('signups', 'signups.id', '=', 'posts.signup_id')
-                    ->where('signups.campaign_id', '=', $filters['campaign_id']);
+                $query = $query->whereHas('signup', function($query) use ($filters) {
+                    $query->where('campaign_id', $filters['campaign_id']);
+                });
             }
 
             // Only return Posts for the given northstar_id (if there is one)

--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -58,9 +58,7 @@ class ReportbackController extends ApiController
         if (! empty($filters)) {
             // Only return Posts for the given campaign_id (if there is one)
             if (array_has($filters, 'campaign_id')) {
-                $query = $query->whereHas('signup', function($query) use ($filters) {
-                    $query->where('campaign_id', $filters['campaign_id']);
-                });
+                $query = $query->where('campaign_id', '=', $filters['campaign_id']);
             }
 
             // Only return Posts for the given northstar_id (if there is one)

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -29,7 +29,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
 
     /**
      * Each post has events.

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -4,6 +4,7 @@ namespace Rogue\Repositories;
 
 use Rogue\Models\Post;
 use Rogue\Models\Event;
+use Rogue\Models\Signup;
 use Rogue\Services\AWS;
 use Rogue\Models\Review;
 use Rogue\Services\Registrar;
@@ -63,10 +64,13 @@ class PostRepository
             $fileUrl = 'default';
         }
 
+        $signup = Signup::find($signupId);
+
         // Create a post.
         $post = new Post([
-            'signup_id' => $signupId,
+            'signup_id' => $signup->id,
             'northstar_id' => $data['northstar_id'],
+            'campaign_id' => $signup->campaign_id,
             'url' => $fileUrl,
             'caption' => $data['caption'],
             'status' => isset($data['status']) ? $data['status'] : 'pending',

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -3,10 +3,9 @@
 namespace Rogue\Repositories;
 
 use Rogue\Models\Post;
-use Rogue\Models\Event;
-use Rogue\Models\Signup;
 use Rogue\Services\AWS;
 use Rogue\Models\Review;
+use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Intervention\Image\Facades\Image;
 

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -71,7 +71,7 @@ return [
      | Extension, without the server-side code. It uses Debugbar collectors instead.
      |
      */
-    'clockwork' => false,
+    'clockwork' => true,
 
     /*
      |--------------------------------------------------------------------------

--- a/database/migrations/2017_07_31_153255_add_campaign_id_to_posts.php
+++ b/database/migrations/2017_07_31_153255_add_campaign_id_to_posts.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+use Rogue\Models\Post;
+
+class AddCampaignIdToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->integer('campaign_id')->after('signup_id')->index()
+                ->comment('The campaign node ID for this post.');
+        });
+
+        // Copy `campaign_id` from the signups table so we can make more
+        // efficient queries against the posts table (without expensive join).
+        foreach (Post::with('signup')->cursor() as $post) {
+            $campaign_id = $post->signup->campaign_id;
+            $post->update(['campaign_id' => $campaign_id]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('campaign_id');
+        });
+    }
+}

--- a/database/migrations/2017_07_31_153255_add_campaign_id_to_posts.php
+++ b/database/migrations/2017_07_31_153255_add_campaign_id_to_posts.php
@@ -1,9 +1,9 @@
 <?php
 
+use Rogue\Models\Post;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\Schema;
-use Rogue\Models\Post;
 
 class AddCampaignIdToPosts extends Migration
 {

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -119,7 +119,7 @@ class CampiagnsTest extends TestCase
 
 
         $campaignService = $this->app->make(CampaignService::class);
-        $campaignCounts = $campaignService->getPostTotals($testCampaigns);
+        $campaignCounts = $campaignService->getPostTotals($testCampaigns[0]);
 
         $this->assertEquals($campaignCounts->get($testCampaigns[0]['id'])->accepted_count, 30);
         $this->assertEquals($campaignCounts->get($testCampaigns[0]['id'])->pending_count, 30);

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -50,7 +50,9 @@ class PostApiTest extends TestCase
         $response = $this->decodeResponseJson();
 
         // Make sure the file_url is saved to the database.
-        $this->seeInDatabase('posts', ['url' => $response['data']['media']['url']]);
+        $this->seeInDatabase('posts', [
+            'id' => $response['data']['id'],
+        ]);
 
         $this->seeInDatabase('signups', [
             'id' => $response['data']['signup_id'],

--- a/tests/PostApiTest.php
+++ b/tests/PostApiTest.php
@@ -43,7 +43,7 @@ class PostApiTest extends TestCase
         // Mock sending image to AWS.
         Storage::shouldReceive('put')->andReturn(true);
 
-        $response = $this->authed()->json('POST', $this->postsApiUrl, $post);
+        $this->authed()->json('POST', $this->postsApiUrl, $post);
 
         $this->assertResponseStatus(200);
 
@@ -52,10 +52,13 @@ class PostApiTest extends TestCase
         // Make sure the file_url is saved to the database.
         $this->seeInDatabase('posts', [
             'id' => $response['data']['id'],
+            'signup_id' => $response['data']['signup_id'],
+            'campaign_id' => $post['campaign_id'],
         ]);
 
         $this->seeInDatabase('signups', [
             'id' => $response['data']['signup_id'],
+            'campaign_id' => $post['campaign_id'],
             'quantity' => $post['quantity'],
         ]);
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request hopefully wraps up the performance work on the reportbacks endpoint for now:

🤔 I tried a couple approaches to avoid having to duplicate the `campaign_id` column but neither seemed to work all that well. From what I can tell, joins on big tables are just inherently not good. (2bd00f8, 4ca02f4)

🆔 The best solution, at least for now, seems to be copying the `campaign_id` into the posts table so that we can just query against the indexed column directly. This runs in ~130ms rather than the 12 or 15 seconds I was seeing with joins and subqueries. (d281c7a)

🚥 I made some updates to the `PostApiTest` since it hadn't been updated with the "edited URL" change we made pre-launch (2a06a64), and updated `PostRepository` to set `campaign_id` on new posts (1058eee). More tests are still failing, but I'll revisit in another PR.

🕰 I enabled [Clockwork](https://chrome.google.com/webstore/detail/clockwork/dmggabnehkmmfmdffgajcflpdjlnoemp?hl=en) support since that made it easier to dive into query performance on API requests, instead of die-dumping the query events like I was earlier. (b0e7903)

#### How should this be reviewed?
Let's test this thoroughly on Thor since the test suite is still pretty light! Am I missing any code paths that create posts in other ways (or any other gotchas)?

#### Any background context you want to provide?
🥞 🤷‍♂️

#### Relevant tickets
Fixes #325.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.