### PR TITLE
Make campaign_id query unambiguous for #334.

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -59,7 +59,7 @@ class ReportbackController extends ApiController
         if (! empty($filters)) {
             // Only return Posts for the given campaign_id (if there is one)
             if (array_has($filters, 'campaign_id')) {
-                $query = $query->where('campaign_id', '=', $filters['campaign_id']);
+                $query = $query->where('signups.campaign_id', '=', $filters['campaign_id']);
             }
 
             // Only return Posts for the given northstar_id (if there is one)


### PR DESCRIPTION
#### What's this PR do?
This should allow requests to continue running successfully while #334 deploys.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Capistrano runs builds & database migrations while the old codebase is still serving web requests. Unfortunately our migration in #334 made the `campaign_id` in this query ambiguous (since both `posts` and the joined `signups` now have columns with that name).

This change should allow us to continue serving requests while the migration runs on Thor/prod.

#### Relevant tickets
References #334, #325.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.