### PR TITLE
Add POST /tags endpoint

### DIFF
--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -2,12 +2,14 @@
 
 namespace Rogue\Http\Controllers\Api;
 
+use Rogue\Http\Controllers\Traits\TagsRequests;
 use Rogue\Http\Requests\TagsRequest;
 use Rogue\Repositories\PostRepository;
 use Rogue\Http\Transformers\PostTransformer;
 
 class TagsController extends ApiController
 {
+    use TagsRequests;
     /**
      * The post service instance.
      *
@@ -30,14 +32,5 @@ class TagsController extends ApiController
     {
         $this->post = $post;
         $this->transformer = new PostTransformer;
-    }
-
-    public function store(TagsRequest $request)
-    {
-        $post = $this->post->find($request->post_id);
-
-        $taggedPost = $this->post->tag($post, $request->tag_name);
-
-        return $this->item($taggedPost);
     }
 }

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -2,21 +2,42 @@
 
 namespace Rogue\Http\Controllers\Api;
 
+use Rogue\Http\Requests\TagsRequest;
+use Rogue\Http\Transformers\PostTransformer;
+use Rogue\Repositories\PostRepository;
+
 class TagsController extends ApiController
 {
+    /**
+     * The post service instance.
+     *
+     * @var Rogue\Repositories\PostRepository
+     */
+    protected $post;
+
+    /**
+     * @var \League\Fractal\TransformerAbstract;
+     */
+    protected $transformer;
+
     /**
      * Create a controller instance.
      *
      * @param  PostContract $posts
      * @return void
      */
-    public function __construct()
+    public function __construct(PostRepository $post)
     {
-        $this->middleware('api');
+        $this->post = $post;
+        $this->transformer = new PostTransformer;
     }
 
-    public function store(TagRequest $request)
+    public function store(TagsRequest $request)
     {
-        dd('Here is what we got:', $request);
+        $post = $this->post->find($request->post_id);
+
+        $taggedPost = $this->post->tag($post, $request->tag_name);
+
+        return $this->item($taggedPost);
     }
 }

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -3,8 +3,8 @@
 namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Http\Requests\TagsRequest;
-use Rogue\Http\Transformers\PostTransformer;
 use Rogue\Repositories\PostRepository;
+use Rogue\Http\Transformers\PostTransformer;
 
 class TagsController extends ApiController
 {

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -2,10 +2,9 @@
 
 namespace Rogue\Http\Controllers\Api;
 
-use Rogue\Http\Controllers\Traits\TagsRequests;
-use Rogue\Http\Requests\TagsRequest;
 use Rogue\Repositories\PostRepository;
 use Rogue\Http\Transformers\PostTransformer;
+use Rogue\Http\Controllers\Traits\TagsRequests;
 
 class TagsController extends ApiController
 {

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rogue\Http\Controllers\Api;
+
+class TagsController extends ApiController
+{
+    /**
+     * Create a controller instance.
+     *
+     * @param  PostContract $posts
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('api');
+    }
+
+    public function store(TagRequest $request)
+    {
+        dd('Here is what we got:', $request);
+    }
+}

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -2,12 +2,14 @@
 
 namespace Rogue\Http\Controllers;
 
+use Rogue\Http\Controllers\Traits\TagsRequests;
 use Rogue\Http\Requests\TagsRequest;
 use Rogue\Repositories\PostRepository;
 use Rogue\Http\Transformers\PostTransformer;
 
 class TagsController extends Controller
 {
+    use TagsRequests;
     /**
      * The post service instance.
      *
@@ -33,24 +35,5 @@ class TagsController extends Controller
 
         $this->post = $post;
         $this->transformer = new PostTransformer;
-    }
-
-    /**
-     * Add or soft delete a tag to a post when reviewed.
-     *
-     * @param Rogue\Http\Requests\TagsRequest $request
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function store(TagsRequest $request)
-    {
-        $post = $this->post->find($request->input('post_id'));
-        $taggedPost = $this->post->tag($post, $request->input('tag_name'));
-
-        // @TODO: $post isn't showing the updated tags right now.
-
-        // @TODO: We should use a transformer anywhere we send data to client.
-
-        return response()->json($taggedPost);
     }
 }

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -2,10 +2,9 @@
 
 namespace Rogue\Http\Controllers;
 
-use Rogue\Http\Controllers\Traits\TagsRequests;
-use Rogue\Http\Requests\TagsRequest;
 use Rogue\Repositories\PostRepository;
 use Rogue\Http\Transformers\PostTransformer;
+use Rogue\Http\Controllers\Traits\TagsRequests;
 
 class TagsController extends Controller
 {

--- a/app/Http/Controllers/Traits/TagsRequests.php
+++ b/app/Http/Controllers/Traits/TagsRequests.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rogue\Http\Controllers\Traits;
+
+use Rogue\Http\Requests\TagsRequest;
+
+trait TagsRequests
+{
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(TagsRequest $request)
+    {
+        $post = $this->post->find($request->post_id);
+
+        $taggedPost = $this->post->tag($post, $request->tag_name);
+
+        return $this->item($taggedPost);
+    }
+}

--- a/app/Http/Controllers/Traits/TagsRequests.php
+++ b/app/Http/Controllers/Traits/TagsRequests.php
@@ -14,6 +14,7 @@ trait TagsRequests
      */
     public function store(TagsRequest $request)
     {
+        // Depends on the $post of whatever is using this trait
         $post = $this->post->find($request->post_id);
 
         $taggedPost = $this->post->tag($post, $request->tag_name);

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -25,7 +25,7 @@ class PostTransformer extends TransformerAbstract
                 'url' => $url,
                 'caption' => $post->caption,
             ],
-            'tagged' => $post->tagNames(),
+            'tagged' => $post->tagSlugs(),
             'reactions' => $post->reactions,
             'status' => $post->status,
             'source' => $post->source,

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -71,4 +71,7 @@ Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api', 'log.received.r
 
     // signups
     Route::post('signups', 'Api\SignupsController@store');
+
+    // tags
+    Route::post('tags', 'Api\TagsController@store');
 });

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -54,7 +54,7 @@ class ModelServiceProvider extends ServiceProvider
                 'eventable_type' => 'Rogue\Models\Post',
                 'content' => $post->toJson(),
                 // Only authenticated admins can tag, so grab the authenticated user.
-                'user' => auth()->user()->northstar_id,
+                'user' => (auth()->user()) ? auth()->user()->northstar_id : null,
             ]);
         });
     }

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -58,8 +58,8 @@ Example Response:
               "caption": "Captioning captions",
             },
             "tagged": [
-              "Good Photo",
-              "Good Quote"
+              "good-photo",
+              "good-quote"
             ],
             "reactions": [
               {

--- a/documentation/endpoints/tags.md
+++ b/documentation/endpoints/tags.md
@@ -24,7 +24,7 @@ Example Response:
             "caption": "This one's for you, Bill!"
         },
         "tagged": [
-            "Good Photo"
+            "good-photo"
         ],
         "reactions": [],
         "status": "pending",
@@ -34,36 +34,4 @@ Example Response:
         "updated_at": "2017-03-15T03:21:42+00:00"
     }
 }
-```
-
-Add or delete a post's tags.
-
-```
-POST /tags
-```
-
-  - **post_id**: (string) required.
-    The id of the post that has been reviewed.
-  - **tag_name**: (string) required.
-    The tag that is being added or deleted from a post.
-
-Example Response:
-
-```
-Object {id: 1, signup_id: 1, northstar_id: "1234", url: "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg", caption: "post 1"…}
-caption: "post 1"
-created_at: "2017-04-28 20:14:49"
-deleted_at: null
-id: 1
-northstar_id: "1234"
-remote_addr: "10.0.2.2"
-signup: Object
-signup_id: 1
-source: "phoenix-web"
-status: "accepted"
-tagged: Array(2)
-updated_at: "2017-05-16 17:39:29"
-url: "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg"
-user: Object
-__proto__: Object
 ```

--- a/documentation/endpoints/tags.md
+++ b/documentation/endpoints/tags.md
@@ -1,6 +1,42 @@
 ## Tags
 
-Add or delete a post's tags. 
+Add or delete a post's tags.
+
+```
+POST api/v2/tags
+```
+
+  - **post_id**: (string) required.
+    The id of the post being tagged or untagged.
+  - **tag_name**: (string) required.
+    The tag that is being added or deleted from a post. Note that this is the tag name and not the tag slug.
+
+Example Response:
+
+```
+{
+    "data": {
+        "id": 2959,
+        "signup_id": 4636,
+        "northstar_id": "58c844ec7f43c24e4f621702",
+        "media": {
+            "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_2959.jpeg",
+            "caption": "This one's for you, Bill!"
+        },
+        "tagged": [
+            "Good Photo"
+        ],
+        "reactions": [],
+        "status": "pending",
+        "source": null,
+        "remote_addr": "74.65.196.233, 74.65.196.233",
+        "created_at": "2017-03-15T03:21:42+00:00",
+        "updated_at": "2017-03-15T03:21:42+00:00"
+    }
+}
+```
+
+Add or delete a post's tags.
 
 ```
 POST /tags

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -85,7 +85,7 @@ class CampaignInbox extends React.Component {
         const newState = {...previousState};
         const user = newState.posts[postId].user;
 
-        newState.posts[postId] = data;
+        newState.posts[postId] = data['data'];
 
         // Keep the user from the initial page load.
         newState.posts[postId].user = user;

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -77,12 +77,12 @@ class CampaignInbox extends React.Component {
     };
 
     let response = this.api.post('tags', fields);
-    response.then((data) => {
+    response.then((result) => {
       this.setState((previousState) => {
         const newState = {...previousState};
         const user = newState.posts[postId].user;
 
-        newState.posts[postId] = data['data'];
+        newState.posts[postId] = result['data'];
 
         // Keep the user from the initial page load.
         newState.posts[postId].user = user;

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -53,13 +53,17 @@ class CampaignInbox extends React.Component {
 
   // Updates a post status.
   updatePost(postId, fields) {
+    console.log(postId);
+    console.log(fields);
     fields.post_id = postId;
 
     let request = this.api.put('reviews', fields);
 
     request.then((result) => {
+      console.log(result);
       this.setState((previousState) => {
         const newState = {...previousState};
+        console.log(newState.posts);
         newState.posts[postId].status = fields.status;
 
         return newState;

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -53,17 +53,14 @@ class CampaignInbox extends React.Component {
 
   // Updates a post status.
   updatePost(postId, fields) {
-    console.log(postId);
-    console.log(fields);
     fields.post_id = postId;
 
     let request = this.api.put('reviews', fields);
 
     request.then((result) => {
-      console.log(result);
       this.setState((previousState) => {
         const newState = {...previousState};
-        console.log(newState.posts);
+
         newState.posts[postId].status = fields.status;
 
         return newState;

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -15,7 +15,6 @@ class InboxItem extends React.Component {
 
   // @todo - define this on the StatusButton component that can set some sort of global state.
   setStatus(status) {
-    console.log(status);
     this.props.onUpdate(this.props.details.post.id, { status: status })
   }
 

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -15,6 +15,7 @@ class InboxItem extends React.Component {
 
   // @todo - define this on the StatusButton component that can set some sort of global state.
   setStatus(status) {
+    console.log(status);
     this.props.onUpdate(this.props.details.post.id, { status: status })
   }
 

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { map, findKey } from 'lodash';
+import { map } from 'lodash';
 import classnames from 'classnames';
 
 class Tags extends React.Component {
@@ -33,7 +33,7 @@ class Tags extends React.Component {
         <ul className="aligned-actions">
           {map(tags, (label, key) => (
             <li key={key}>
-              <button className={classnames('tag', {'is-active': findKey(this.props.tagged, {'tag_slug': key})})}
+              <button className={classnames('tag', {'is-active': this.props.tagged.includes(key)})}
                       onClick={() => this.handleClick(label)}>{label}</button>
             </li>
           ))}

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -24,6 +24,8 @@ export function calculateAge(date) {
 export function getImageUrlFromProp(photoProp) {
 	var photo_url;
 
+  // Sometimes we get the url right on the post and sometimes it is nested under
+  // media (in cases where it goes through the PostTransformer), so handle both cases
   if ('url' in photoProp) {
     photo_url = photoProp['url'];
   }
@@ -51,6 +53,9 @@ export function extractPostsFromSignups(signups) {
 export function getEditedImageUrl(photoProp) {
   const edited_file_name = `edited_${photoProp.id}.jpeg`;
   var url_parts;
+
+  // Sometimes we get the url right on the post and sometimes it is nested under
+  // media (in cases where it goes through the PostTransformer), so handle both cases
   if ('url' in photoProp) {
     url_parts = photoProp['url'].split("/");
   }

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -26,6 +26,7 @@ export function getImageUrlFromProp(photoProp) {
 
   // Sometimes we get the url right on the post and sometimes it is nested under
   // media (in cases where it goes through the PostTransformer), so handle both cases
+  // @TODO: make sure everything goes through a transformer so we don't need this
   if ('url' in photoProp) {
     photo_url = photoProp['url'];
   }

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -22,11 +22,19 @@ export function calculateAge(date) {
 };
 
 export function getImageUrlFromProp(photoProp) {
-	const photo_url = photoProp['url'];
+	var photo_url;
 
-	if (photo_url == "default") {
-	  return "https://www.dosomething.org/sites/default/files/JenBugError.png";
-	}
+  if ('url' in photoProp) {
+    photo_url = photoProp['url'];
+  }
+  else if ('media' in photoProp) {
+    photo_url = photoProp['media']['url'];
+  }
+
+
+  if (photo_url == "default") {
+    return "https://www.dosomething.org/sites/default/files/JenBugError.png";
+  }
 	else {
 	  return photo_url;
 	}
@@ -42,7 +50,16 @@ export function extractPostsFromSignups(signups) {
 
 export function getEditedImageUrl(photoProp) {
   const edited_file_name = `edited_${photoProp.id}.jpeg`;
-  const url_parts = photoProp['url'].split("/");
+  var url_parts;
+  if ('url' in photoProp) {
+    url_parts = photoProp['url'].split("/");
+  }
+  else if ('media' in photoProp) {
+    return photoProp['media']['url'];
+  }
+  else {
+    return null;
+  }
 
   url_parts.pop();
   url_parts.push(edited_file_name);


### PR DESCRIPTION
#### What's this PR do?
- Added `Api/TagsController.php` to handle posts getting tagged (or untagged) via the api
- Added a new route: `POST api/v2/tags`
- For tag or untag events via the API (or anytime there is no `auth()->user()`), store `null` for the user column on the event
- Updated documentation

#### How should this be reviewed?
👀 Hit the endpoint and make sure you get a response like one provided in the documentation. Send the same request again and the tag you just added should disappear 🎱 

#### Any background context you want to provide?
We need this endpoint to migrate over the tags that live in Phoenix (excluded = Hide in Gallery, promoted = Good Photo).

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/149658211)

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.