### PR TITLE
gets rid of ambiguous query in getPostTotals function

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -195,7 +195,7 @@ class CampaignService
                     DB::raw('SUM(case when posts.status = "accepted" then 1 else 0 end) as accepted_count'),
                     DB::raw('SUM(case when posts.status = "pending" then 1 else 0 end) as pending_count'),
                     DB::raw('SUM(case when posts.status = "rejected" then 1 else 0 end) as rejected_count'))
-                ->where('campaign_id', '=', $campaign['id'])
+                ->where('signups.campaign_id', '=', $campaign['id'])
                 ->groupBy('signups.campaign_id')
                 ->first();
     }


### PR DESCRIPTION
#### What's this PR do?
Adds `signups.campaign_id` in `getPostTotals` function to get rid of ambiguous query error. 

#### How should this be reviewed?
Hit `/campaigns/:id` page and all should work as expected.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.