### PR TITLE
Key by post id in extractPostsFromSignups

### DIFF
--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -33,9 +33,9 @@ export function getImageUrlFromProp(photoProp) {
 };
 
 export function extractPostsFromSignups(signups) {
-    const posts = flatMap(signups, signup => {
+    const posts = keyBy(flatMap(signups, signup => {
       return signup.posts;
-    });
+    }), 'id');
 
     return posts;
 }


### PR DESCRIPTION
#### What's this PR do?
Key by post id in `extractPostsFromSignups`. I took that out while I was working on pagination, I think it had something to do with ordering the posts from most recent to least recent, but it had unintended bad side-effects! Adding it back in here so that reviewing works as expected and tagging shows up. @chloealee wanted to make sure you pull this in to your branch for pagination to make sure ordering from most recent to least recent works with this (since I believe I was having trouble with that).

#### How should this be reviewed?
Check out both types of campaign pages on Rogue (inbox and single view) and make sure that the reviewing works as expected and that everything looks normal.

#### Any background context you want to provide?
I made a 🐛  and this will hopefully crush it.

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.