### PR TITLE
Fix another ambiguous query with joined tables.

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -214,7 +214,7 @@ class CampaignService
                 ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
                 ->selectRaw('signups.campaign_id, count(posts.id) as pending_count')
                 ->where('status', '=', 'pending')
-                ->wherein('campaign_id', $ids)
+                ->wherein('signups.campaign_id', $ids)
                 ->groupBy('signups.campaign_id')
                 ->get();
 


### PR DESCRIPTION
#### What's this PR do?
One more query that got confused!

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Rogue campaign index is still showing this bad boy:

```
Illuminate\Database\QueryException: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'campaign_id' in where clause is ambiguous (SQL: select signups.campaign_id, count(posts.id) as pending_count from `signups` left join `posts` on `signups`.`id` = `posts`.`signup_id` where `status` = pending and `campaign_id` in (4, 6, 7, 8, 9, 10, 13, 14, 15, 17, 18, 19, 21, 22, 24, 28, 31, 32, 33, 34, 35, 36, 37, 38, 40, 41, 42, 43, 44, 45, 46, 47, 48, 50, 52, 53, 54, 55, 56, 57, 58, 61, 62, 63, 66, 69, 73, 74, 75, 76, 84, 345, 362, 689, 819, 822, 830, 832, 836, 839, 842, 843, 850, 854, 876, 886, 946, 955, 958, 1144, 1357, 1476, 1508, 1516, 1524, 1526, 1536, 1538, 1662, 1819, 1820, 1822, 1826, 2003, 2005, 2012, 2015, 2016, 2041, 2043, 2046, 2059, 2063, 2070, 2072, 2075, 2078, 2084, 2086, 2089, 2091, 2092, 2093, 2104, 2115, 2144, 2149, 2169, 2175, 2178, 2186, 2227, 2238, 2240, 2259, 2272, 2273, 2277, 2279, 2283, 2286, 2290, 2299, 2307, 2324, 2327, 2334, 2349, 2366, 2401, 2410, 2427, 2440, 2461, 2465, 2476, 2487, 2532, 2535, 2542, 2544, 2559, 2624, 2691, 2693, 2710, 2737, 2757, 2775, 2805, 2808, 2810, 2900, 2906, 2915, 2929, 2930, 2931, 2932, 2933, 2938, 2978, 3108, 3271, 3276, 3280, 3302, 3316, 3331, 3345, 3346, 3394, 3396, 3397, 3413, 3427, 3435, 3441, 3446, 3455, 3466, 3478, 3496, 3501, 3504, 3509, 3513, 3534, 3539, 3543, 3559, 3567, 3573, 3576, 3585, 3590, 3616, 3618, 3624, 3625, 3690, 3691, 3717, 3723, 3726, 3731, 3743, 3755, 3773, 3801, 3812, 3827, 3909, 3966, 4001, 4044, 4115, 4118, 4121, 4139, 4140, 4142, 4148, 4173, 4264, 4532, 4551, 4793, 4941, 4944, 4946, 4974, 4987, 5051, 5052, 5069, 5114, 5140, 5213, 5215, 5234, 5236, 5245, 5275, 5356, 5359, 5394, 5411, 5438, 5455, 5459, 5475, 5483, 5498, 5519, 5543, 5564, 5565, 5566, 5573, 5615, 5625, 5636, 5639, 5646, 5651, 5676, 5685, 5686, 5711, 5740, 5769, 5775, 5776, 5777, 5778, 5779, 5783, 5840, 6045, 6054, 6056, 6078, 6091, 6163, 6620, 6621, 6661, 6690, 6691, 6692, 6798, 6829, 6832, 6922, 6964, 7043, 7059, 7077, 7128, 7135, 7149, 7177, 7183, 7189, 7192, 7231, 7241, 7277, 7314, 7333, 7334, 7389, 7395, 7402, 7421, 7423, 7433, 7436, 7472, 7483, 7497, 7505, 7508, 7512, 7515, 7518, 7523, 7526, 7529, 7536, 7554, 7589, 7596, 7623, 7624, 7629, 7641, 7645, 7650, 7656, 7661, 7662, 7675, 7682, 7684, 7691, 7693, 7703, 7713, 7771, 7802, 7822, 7831) group by `signups`.`campaign_id`) in /var/www/rogue/releases/20170802171141/vendor/laravel/framework/src/Illuminate/Database/Connection.php:729
```

#### Relevant tickets
Fixes 🐛

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.