### PR TITLE
GET /posts endpoint

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -10,6 +10,7 @@ use Rogue\Http\Controllers\Traits\PostRequests;
 class PostController extends Controller
 {
     use PostRequests;
+    use FiltersRequests;
 
     /**
      * The post service instance.

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -10,7 +10,6 @@ use Rogue\Http\Controllers\Traits\PostRequests;
 class PostController extends Controller
 {
     use PostRequests;
-    use FiltersRequests;
 
     /**
      * The post service instance.

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -38,9 +38,6 @@ trait FiltersRequests
             $excludedValues = false;
         }
 
-        // Requests may be filtered by indexed fields.
-        $filters = array_intersect_key($filters, array_flip($indexes));
-
         // If there is an updated_at param, remove it from $filters and save the value.
         if (array_key_exists('updated_at', $filters)) {
             $updatedAtValue = $filters['updated_at'];
@@ -48,6 +45,9 @@ trait FiltersRequests
         } else {
             $updatedAtValue = false;
         }
+
+        // Requests may be filtered by indexed fields.
+        $filters = array_intersect_key($filters, array_flip($indexes));
 
         // You can filter by multiple values, e.g. `filter[source]=agg,cgg`
         // to get records that have a source value of either `agg` or `cgg`.
@@ -71,7 +71,7 @@ trait FiltersRequests
         }
 
         if ($excludedValues) {
-            // @TODO - Only excludes `id` fields, we coul update this to be more flexible.
+            // @TODO - Only excludes `id` fields, we could update this to be more flexible.
             $query->whereNotIn('id', explode(',', $excludedValues));
         }
 

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -30,6 +30,14 @@ trait FiltersRequests
             return $query;
         }
 
+        // If there is an exclude filter, remove it from $filters and save the value.
+        if (array_key_exists('exclude', $filters)) {
+            $excludedValues = $filters['exclude'];
+            unset($filters['exclude']);
+        } else {
+            $excludedValues = false;
+        }
+
         // Requests may be filtered by indexed fields.
         $filters = array_intersect_key($filters, array_flip($indexes));
 
@@ -60,6 +68,10 @@ trait FiltersRequests
 
         if ($updatedAtValue) {
             $query->where('updated_at', '>', $updatedAtValue);
+        }
+
+        if ($excludedValues) {
+            $query->whereNotIn('id', explode(',', $excludedValues));
         }
 
         return $query;

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -71,6 +71,7 @@ trait FiltersRequests
         }
 
         if ($excludedValues) {
+            // @TODO - Only excludes `id` fields, we coul update this to be more flexible.
             $query->whereNotIn('id', explode(',', $excludedValues));
         }
 

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -29,6 +29,7 @@ trait FiltersRequests
         if (! $filters) {
             return $query;
         }
+
         // Requests may be filtered by indexed fields.
         $filters = array_intersect_key($filters, array_flip($indexes));
 

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -43,4 +43,9 @@ trait PostRequests
             }
         }
     }
+
+    public function index()
+    {
+        return "get posts";
+    }
 }

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -5,7 +5,6 @@ namespace Rogue\Http\Controllers\Traits;
 use Rogue\Models\Post;
 use Illuminate\Http\Request;
 use Rogue\Http\Requests\PostRequest;
-use Rogue\Http\Controllers\Traits\FiltersRequests;
 
 trait PostRequests
 {

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -58,7 +58,7 @@ trait PostRequests
      */
     public function index(Request $request)
     {
-        $query = $this->newQuery(Post::class)->with('signup');
+        $query = $this->newQuery(Post::class)->with('signup')->withCount('reactions');
 
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Post::$indexes);

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -63,6 +63,14 @@ trait PostRequests
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Post::$indexes);
 
+        // If user param is passed, return whether or not the user has liked the particular post.
+        if ($request->query('as_user')) {
+            $userId = $request->query('as_user');
+            $query = $query->with(['reactions' => function ($query) use ($userId) {
+                $query->where('northstar_id', '=', $userId);
+            }]);
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 }

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -49,6 +49,13 @@ trait PostRequests
         }
     }
 
+    /**
+     * Returns Posts, filtered by params, if provided.
+     * GET /posts
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)->with('signup');

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -2,6 +2,8 @@
 
 namespace Rogue\Http\Controllers\Traits;
 
+use Rogue\Models\Post;
+use Illuminate\Http\Request;
 use Rogue\Http\Requests\PostRequest;
 
 trait PostRequests
@@ -44,8 +46,55 @@ trait PostRequests
         }
     }
 
-    public function index()
+    public function index(Request $request)
     {
-        return "get posts";
+        // Create an empty Post query, which we can filter and paginate
+        $query = $this->newQuery(Post::class)
+            // Eagerly load the count of reactions per post.
+            ->withCount('reactions')
+            // Only return posts that have been approved by a campaign lead...
+            ->where('status', 'accepted')
+            // ...and haven't been hidden from the gallery.
+            ->withoutTags(['Hide In Gallery']);
+
+        $filters = $request->query('filter');
+
+        if (! empty($filters)) {
+            // Only return Posts for the given campaign_id (if there is one)
+            if (array_has($filters, 'campaign_id')) {
+                // $query = $query->where('campaign_id', '=', $filters['campaign_id']);
+                $query = $query->whereHas('signup', function ($query) {
+                    $query->where('campaign_id', '=', 1631);
+                });
+            }
+
+            // Only return Posts for the given northstar_id (if there is one)
+            if (array_has($filters, 'northstar_id')) {
+                $query = $query->where('signups.northstar_id', '=', $filters['northstar_id']);
+            }
+
+            // Only return Posts for the given status (if there is one)
+            if (array_has($filters, 'status')) {
+                $query = $query->where('status', '=', $filters['status']);
+            }
+
+            // Exclude Posts if exclude param is present
+            if (array_has($filters, 'exclude')) {
+                $query = $query->whereNotIn('posts.id', explode(',', $filters['exclude']));
+            }
+        }
+
+        // If user param is passed, return whether or not the user has liked the particular post.
+        if ($request->query('as_user')) {
+            $userId = $request->query('as_user');
+            $query = $query->with(['reactions' => function ($query) use ($userId) {
+                $query->where('northstar_id', '=', $userId);
+            }]);
+        }
+
+        // Eager load signups.
+        $query->with('signup');
+
+        return $this->paginatedCollection($query, $request);
     }
 }

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -5,9 +5,12 @@ namespace Rogue\Http\Controllers\Traits;
 use Rogue\Models\Post;
 use Illuminate\Http\Request;
 use Rogue\Http\Requests\PostRequest;
+use Rogue\Http\Controllers\Traits\FiltersRequests;
 
 trait PostRequests
 {
+    use FiltersRequests;
+
     /**
      * Store a newly created resource in storage.
      *
@@ -48,52 +51,10 @@ trait PostRequests
 
     public function index(Request $request)
     {
-        // Create an empty Post query, which we can filter and paginate
-        $query = $this->newQuery(Post::class)
-            // Eagerly load the count of reactions per post.
-            ->withCount('reactions')
-            // Only return posts that have been approved by a campaign lead...
-            ->where('status', 'accepted')
-            // ...and haven't been hidden from the gallery.
-            ->withoutTags(['Hide In Gallery']);
+        $query = $this->newQuery(Post::class)->with('signup');
 
         $filters = $request->query('filter');
-
-        if (! empty($filters)) {
-            // Only return Posts for the given campaign_id (if there is one)
-            if (array_has($filters, 'campaign_id')) {
-                // $query = $query->where('campaign_id', '=', $filters['campaign_id']);
-                $query = $query->whereHas('signup', function ($query) {
-                    $query->where('campaign_id', '=', 1631);
-                });
-            }
-
-            // Only return Posts for the given northstar_id (if there is one)
-            if (array_has($filters, 'northstar_id')) {
-                $query = $query->where('signups.northstar_id', '=', $filters['northstar_id']);
-            }
-
-            // Only return Posts for the given status (if there is one)
-            if (array_has($filters, 'status')) {
-                $query = $query->where('status', '=', $filters['status']);
-            }
-
-            // Exclude Posts if exclude param is present
-            if (array_has($filters, 'exclude')) {
-                $query = $query->whereNotIn('posts.id', explode(',', $filters['exclude']));
-            }
-        }
-
-        // If user param is passed, return whether or not the user has liked the particular post.
-        if ($request->query('as_user')) {
-            $userId = $request->query('as_user');
-            $query = $query->with(['reactions' => function ($query) use ($userId) {
-                $query->where('northstar_id', '=', $userId);
-            }]);
-        }
-
-        // Eager load signups.
-        $query->with('signup');
+        $query = $this->filter($query, $filters, Post::$indexes);
 
         return $this->paginatedCollection($query, $request);
     }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -29,6 +29,7 @@ Route::group(['middleware' => 'web'], function () {
 
     // posts
     Route::post('posts', 'PostController@store');
+    Route::get('posts', 'PostController@index');
     Route::delete('posts/{id}', 'PostController@destroy');
 
     // reviews

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -60,6 +60,7 @@ Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api', 'log.received.r
 
     // posts
     Route::post('posts', 'Api\PostsController@store');
+    Route::get('posts', 'Api\PostsController@index');
 
     // reactions
     Route::post('reactions', 'Api\ReactionController@store');

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -32,6 +32,16 @@ class Post extends Model
     protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
 
     /**
+     * Attributes that can be queried when filtering.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $indexes = [ 'id', 'signup_id', 'campaign_id', 'northstar_id', 'status'];
+
+    /**
      * Each post has events.
      */
     public function events()

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -39,7 +39,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = [ 'id', 'signup_id', 'campaign_id', 'northstar_id', 'status'];
+    public static $indexes = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'status'];
 
     /**
      * Each post has events.

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -70,3 +70,85 @@ Example Response:
   "message": "Post deleted."
 }
 ```
+
+Retrieve all Posts.
+
+```
+GET /api/v2/posts
+```
+
+### Optional Query Parameters
+- **limit**
+  - Set the number of records to return in a single response.
+  - e.g. `/posts?limit=35`
+- **page** _(integer)_
+  - For pagination, specify page of activity to return in the response.
+  - e.g. `/posts?page=2`
+- **campaign_id** _(integer)_
+  - The nid to filter the response by.
+  - e.g. `/posts?filter[campaign_id]=47`
+- **northstar_id** _(integer)_
+  - The northstar_id to filter the response by.
+  - e.g. `/posts?filter[northstar_id]=47asdf23abc`
+- **status** _(string)_
+  - The string to filter the response by.
+  - e.g. `/posts?filter[status]=accepted`
+- **exclude** _(integer)_
+  - The post id(s) to exclude in response.
+  - e.g. `/posts?filter[exclude]=2,3,4`
+- **as_user** _(string)_
+  - The logged in user to display if they have reacted to the post or not.
+  - e.g. `/posts?as_user=1234`
+
+Example Response:
+
+```
+{
+    "data": [
+        {
+            "id": 2984,
+            "signup_id": 4673,
+            "northstar_id": "5594429fa59dbfc9578b48f4",
+            "media": {
+                "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_2984.jpeg",
+                "caption": null
+            },
+            "tagged": [],
+            "reactions": [],
+            "status": "accepted",
+            "source": null,
+            "remote_addr": "52.3.68.224, 52.3.68.224",
+            "created_at": "2016-11-30T21:21:24+00:00",
+            "updated_at": "2017-08-02T14:11:26+00:00"
+        },
+        {
+            "id": 3655,
+            "signup_id": 5787,
+            "northstar_id": "5575e568a59dbf3b7a8b4572",
+            "media": {
+                "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_3655.jpeg",
+                "caption": "Perhaps you CAN be of some assistance, Bill"
+            },
+            "tagged": [],
+            "reactions": [],
+            "status": "accepted",
+            "source": null,
+            "remote_addr": "207.110.19.130, 207.110.19.130",
+            "created_at": "2016-02-10T16:19:25+00:00",
+            "updated_at": "2017-08-02T14:11:35+00:00"
+        }
+    ],
+    "meta": {
+        "pagination": {
+            "total": 53,
+            "count": 2,
+            "per_page": 2,
+            "current_page": 1,
+            "total_pages": 27,
+            "links": {
+                "next": "http://rogue.app/api/v2/posts?filter%5Bcampaign_id%5D=1631%2C12&filter%5Bstatus%5D=accepted&filter%5Bexclude%5D=2962%2C3654&limit=2&as_user=559442cca59dbfc&page=2"
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
#### What's this PR do?

Creates `GET /api/v2/posts` (API requests) and `GET /posts` (app requests) endpoint that returns a set of posts given the query params it is passed. 

This works exactly like the `GET /reportbacks` endpoint but returns response formatted for the new rogue data schema. 

Also should note that I update the logic for the filtering to use the `FiltersRequest` trait instead of doing it separately as we are doing in the `ReportbackController`. Now that we have made some updates to the `posts` table, I think this is a little easier to use. 

#### How should this be reviewed?

👀 , commit-by-commit, Make sure the updates to `FiltersRequests` seem ok. 

#### Any background context you want to provide?

Will help the app do some of the filtering, pagination and sorting it needs to do by making an api request for posts directly. 

Also make things more RESTful :) 

#### Relevant tickets
https://www.pivotaltracker.com/story/show/149811449

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.