### PR TITLE
Test Cleanup, Part III

### DIFF
--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -6,29 +6,21 @@ Retrieve all user activity data.
 GET /api/v2/activity
 ```
 ### Optional Query Parameters
-- **id** _(integer)_
-  - The signup id(s) to filter the response by.
-  - e.g. `/activity?filter[id]=121,122`
+- **filter[column]** _(integer)_
+  - Filter results by the given column: `id`, `campaign_id`, `campaign_run_id`, `northstar_id`
+  - You can filter by more than one column, e.g. `/activity?filter[id]=4&filter[campaign_id]=5`
+  - You can filter by more than one value for a column, e.g. `/activity?filter[id]=121,122`
 - **limit** _(default is 20)_
   - Set the number of records to return in a single response.
   - e.g. `/activity?limit=35`
 - **page** _(integer)_
   - For pagination, specify page of activity to return in the response.
   - e.g. `/activity?page=2`
-- **campaign_id** _(integer)_
-  - The nid(s) to filter the response by.
-  - e.g. `/activity?filter[campaign_id]=47,49`
-- **campaign_run_id** _(integer)_
-  - The campaign run nid(s) to filter the response by.
-  - e.g. `/activity?filter[campaign_run_id]=1771`
-- **user** _(integer)_
-  - Whether or not to include information about the user with the response.
+- **include** _(integer)_
+  - Include additional related records in the response: `user`
   - e.g. `/activity?include=user`
-- **northstar_id** _(integer)_
-  - The northstar id(s) to filter the response by.
-  - e.g. `/activity?filter[northstar_id]=1234`
-- **updated_at** _(timestamp)_
-  - Return records that have been updated at after the updated_at param value. 
+- **filter[updated_at]** _(timestamp)_
+  - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`
 
 

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -6,7 +6,7 @@ use Rogue\Models\Signup;
 class ActivityApiTest extends TestCase
 {
     /**
-     * Test for retrieving a user's activity with limit query param.
+     * Test for retrieving activity.
      *
      * GET /activity?limit=8
      * @return void
@@ -86,10 +86,10 @@ class ActivityApiTest extends TestCase
     /**
      * Test for retrieving a user's activity with campaign_id query param.
      *
-     * GET /activity?filter[campaign_id]=47
+     * GET /activity?filter[]=
      * @return void
      */
-    public function testActivityIndexWithCampaignIdQuery()
+    public function testActivityIndexWithFilter()
     {
         factory(Signup::class, 3)->create(['campaign_id' => 17]);
         factory(Signup::class, 5)->create();
@@ -112,22 +112,23 @@ class ActivityApiTest extends TestCase
     }
 
     /**
-     * Test for retrieving a user's activity with campaign_run_id query param.
+     * Test for retrieving a user's activity with multiple filters.
      *
-     * GET /activity?filter[campaign_run_id]=479
+     * GET /activity?filter[]=&filter[]=
      * @return void
      */
-    public function testActivityIndexWithCampaignRunIdQuery()
+    public function testActivityIndexWithMultipleFilters()
     {
-        factory(Signup::class, 3)->create(['campaign_run_id' => 132]);
+        factory(Signup::class, 3)->create(['campaign_id' => 14, 'campaign_run_id' => 132]);
         factory(Signup::class, 5)->create();
 
-        $this->get('api/v2/activity?filter[campaign_run_id]=132');
+        $this->get('api/v2/activity?filter[campaign_id]=14&filter[campaign_run_id]=132');
 
         $this->assertResponseStatus(200);
         $this->seeJsonSubset([
             'data' => [
                 [
+                    'campaign_id' => 14,
                     'campaign_run_id' => 132,
                     // ...
                 ],
@@ -142,7 +143,7 @@ class ActivityApiTest extends TestCase
      * GET /activity?filter[campaign_run_id]=479,49&filter[campaign_run_id]=z
      * @return void
      */
-    public function testActivityIndexWithMixedQueryReturnsNoResults()
+    public function testActivityIndexWithFilterAndNoResults()
     {
         $signups = factory(Signup::class, 2)->create();
 

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -30,7 +30,7 @@ class ActivityApiTest extends TestCase
                     'signup_source',
                     'created_at',
                     'updated_at',
-                    'posts' => []
+                    'posts' => [],
                 ],
             ],
             'meta' => [
@@ -40,8 +40,8 @@ class ActivityApiTest extends TestCase
                     'per_page',
                     'current_page',
                     'total_pages',
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 
@@ -106,8 +106,8 @@ class ActivityApiTest extends TestCase
             'meta' => [
                 'pagination' => [
                     'count' => 3,
-                ]
-            ]
+                ],
+            ],
         ]);
     }
 

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoSomething\Gateway\Northstar;
-use DoSomething\Gateway\Resources\NorthstarUser;
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
+use DoSomething\Gateway\Northstar;
+use DoSomething\Gateway\Resources\NorthstarUser;
 
 class ActivityApiTest extends TestCase
 {
@@ -183,8 +183,8 @@ class ActivityApiTest extends TestCase
                     'user' => [
                         'data' => [
                             'first_name',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
             ],
         ]);

--- a/tests/Http/Api/ReactionsApiTest.php
+++ b/tests/Http/Api/ReactionsApiTest.php
@@ -116,7 +116,7 @@ class ReactionsApiTest extends TestCase
         // Make sure the signup and post's updated_at matches the reaction created_at time.
         $this->assertEquals($reaction->created_at, $post->fresh()->updated_at);
 
-        // @TODO: Signup timestamp isn't being touched.
+        // @TODO: Laravel doesn't touch timestamps recursively - only direct relationships.
         // $this->assertEquals($reaction->created_at, $signup->fresh()->updated_at);
         $this->markTestIncomplete();
     }

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -2,7 +2,6 @@
 
 use Rogue\Models\Post;
 use Rogue\Models\User;
-use Rogue\Models\Signup;
 
 class PostTest extends TestCase
 {
@@ -34,32 +33,5 @@ class PostTest extends TestCase
         $this->actingAs($user)->delete('posts/' . $post->id);
 
         $this->assertResponseStatus(403);
-    }
-
-    /**
-     * Test that a signup's updated_at updates when a post is updated.
-     *
-     * @return void
-     */
-    public function testUpdatingSignupTimestampWhenPostIsUpdated()
-    {
-        // Freeze time since we're making assertions on timestamps.
-        $this->mockTime('8/3/2017 14:00:00');
-
-        // Create a signup and a post, and associate them to each other.
-        $signup = factory(Signup::class)->create();
-        $post = factory(Post::class)->create();
-        $post->signup()->associate($signup);
-
-        // And then later on, we'll update the post...
-        $this->mockTime('8/3/2017 16:52:00');
-        $post->update(['caption' => 'new caption']);
-
-        // Make sure the signup and post's updated_at are both updated.
-        $this->assertEquals((string) $post->updated_at, '2017-08-03 16:52:00');
-
-        // @TODO: Signup timestamp isn't being touched.
-        // $this->assertEquals((string) $signup->updated_at, '2017-08-03 16:52:00');
-        $this->markTestIncomplete();
     }
 }

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -83,7 +83,7 @@ class ReviewsTest extends TestCase
         // Make sure the signup and post's updated_at are both updated.
         $this->assertEquals('2017-08-03 16:55:00', (string) $post->fresh()->updated_at);
 
-        // @TODO: Signup timestamp isn't being touched.
+        // @TODO: Laravel doesn't touch timestamps recursively - only direct relationships.
         // $this->assertEquals('2017-08-03 16:55:00', (string) $signup->fresh()->updated_at);
         $this->markTestIncomplete();
     }

--- a/tests/Models/PostModelTest.php
+++ b/tests/Models/PostModelTest.php
@@ -25,10 +25,7 @@ class PostModelTest extends TestCase
         $post->update(['caption' => 'new caption']);
 
         // Make sure the signup and post's updated_at are both updated.
-        $this->assertEquals((string)$post->updated_at, '2017-08-03 16:52:00');
-
-        // @TODO: Signup timestamp isn't being touched.
-        // $this->assertEquals((string) $signup->updated_at, '2017-08-03 16:52:00');
-        $this->markTestIncomplete();
+        $this->assertEquals('2017-08-03 16:52:00', (string) $post->fresh()->updated_at);
+        $this->assertEquals('2017-08-03 16:52:00', (string) $signup->fresh()->updated_at);
     }
 }

--- a/tests/Models/PostModelTest.php
+++ b/tests/Models/PostModelTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+
+class PostModelTest extends TestCase
+{
+    /**
+     * Test that a signup's updated_at updates when a post is updated.
+     *
+     * @return void
+     */
+    public function testUpdatingSignupTimestampWhenPostIsUpdated()
+    {
+        // Freeze time since we're making assertions on timestamps.
+        $this->mockTime('8/3/2017 14:00:00');
+
+        // Create a signup and a post, and associate them to each other.
+        $signup = factory(Signup::class)->create();
+        $post = factory(Post::class)->create();
+        $post->signup()->associate($signup);
+
+        // And then later on, we'll update the post...
+        $this->mockTime('8/3/2017 16:52:00');
+        $post->update(['caption' => 'new caption']);
+
+        // Make sure the signup and post's updated_at are both updated.
+        $this->assertEquals((string)$post->updated_at, '2017-08-03 16:52:00');
+
+        // @TODO: Signup timestamp isn't being touched.
+        // $this->assertEquals((string) $signup->updated_at, '2017-08-03 16:52:00');
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/Services/CampaignServiceTest.php
+++ b/tests/Services/CampaignServiceTest.php
@@ -7,7 +7,7 @@ use Rogue\Services\CampaignService;
 use Illuminate\Support\Facades\Cache;
 use Rogue\Repositories\CacheRepository;
 
-class CampaignTest extends TestCase
+class CampaignServiceTest extends TestCase
 {
     /**
      * A test finding a single campaign.


### PR DESCRIPTION
#### What's this PR do?
Last general purpose cleanup pull request!

🗃 Moves non-HTTP tests (models and services) to their own directories. f8a7933, 26e4046

🐎 Adds some more tests to the activity endpoint, since before we were mostly just testing the built-in paginator (rather than actual JSON results). 555188c

🆕 Makes sure to re-fetch from database before making assertions, and swaps order of arguments so PHPUnit outputs the correct things in the "expected" and "actual" columns. 813e40c

👉 Updates `TODO`s for broken "touching". It turns out that Laravel only touches immediate parents for the `$touches` property, so a reaction would update post timestamp but _not_ the signup timestamp. We should prioritize this and fix in a future sprint. aca684d

#### How should this be reviewed?
🚥 👀 

#### Any background context you want to provide?
☔️

#### Relevant tickets
[#149662237](https://www.pivotaltracker.com/story/show/149662237)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.