### PR TITLE
Filters posts powered by the API

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -31,7 +31,7 @@ class ActivityController extends ApiController
 
         $filters = $request->query('filter');
 
-        if (array_key_exists('status', $filters)) {
+        if (array_has($filters, 'status')) {
             // Constrain Eager Load, only returning posts with status query.
             $query = $query->with(['posts' => function ($query) use ($filters) {
                 $query->where('status', $filters['status']);

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -27,22 +27,9 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
-        $query = $this->newQuery(Signup::class);
+        $query = $this->newQuery(Signup::class)->with('posts');
 
         $filters = $request->query('filter');
-
-        if (array_has($filters, 'status')) {
-            // Constrain Eager Load, only returning posts with status query.
-            $query = $query->with(['posts' => function ($query) use ($filters) {
-                $query->where('status', $filters['status']);
-            }]);
-
-            // Remove status from $filters to query Signups.
-            unset($filters['status']);
-        } else {
-            $query = $query->with('posts');
-        }
-
         $query = $this->filter($query, $filters, Signup::$indexes);
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -27,9 +27,22 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
-        $query = $this->newQuery(Signup::class)->with('posts');
+        $query = $this->newQuery(Signup::class);
 
         $filters = $request->query('filter');
+
+        if (array_key_exists('status', $filters)) {
+            // Constrain Eager Load, only returning posts with status query.
+            $query = $query->with(['posts' => function ($query) use ($filters) {
+                $query->where('status', $filters['status']);
+            }]);
+
+            // Remove status from $filters to query Signups.
+            unset($filters['status']);
+        } else {
+            $query->with('posts');
+        }
+
         $query = $this->filter($query, $filters, Signup::$indexes);
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -40,7 +40,7 @@ class ActivityController extends ApiController
             // Remove status from $filters to query Signups.
             unset($filters['status']);
         } else {
-            $query->with('posts');
+            $query = $query->with('posts');
         }
 
         $query = $this->filter($query, $filters, Signup::$indexes);

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -95,9 +95,9 @@ class CampaignsController extends Controller
     public function showCampaign($id)
     {
         // Always load the page with just accepted posts
-        // @TODO: update this query - the below only loads the posts on a signup if they are accepted.
-        // We want to only load signups that have accepted posts with the accepted posts.
-        $signups = Signup::campaign([$id])->has('posts')->with(['posts' => function ($query) {
+        $signups = Signup::campaign([$id])->whereHas('posts', function ($query) {
+            $query->where('status', '=', 'accepted');
+        })->with(['posts' => function ($query) {
             $query->where('status', '=', 'accepted');
         }])->orderBy('created_at', 'desc')->paginate(50);
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -95,6 +95,8 @@ class CampaignsController extends Controller
     public function showCampaign($id)
     {
         // Always load the page with just accepted posts
+        // @TODO: update this query - the below only loads the posts on a signup if they are accepted.
+        // We want to only load signups that have accepted posts with the accepted posts.
         $signups = Signup::campaign([$id])->has('posts')->with(['posts' => function ($query) {
             $query->where('status', '=', 'accepted');
         }])->orderBy('created_at', 'desc')->paginate(50);

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -94,32 +94,17 @@ class CampaignsController extends Controller
      */
     public function showCampaign($id)
     {
-        // Always load the page with just accepted posts
-        // $signups = Signup::campaign([$id])->whereHas('posts', function ($query) {
-        //     $query->where('status', '=', 'accepted');
-        // })->with(['posts' => function ($query) {
-        //     $query->where('status', '=', 'accepted');
-        // }])->orderBy('created_at', 'desc')->paginate(50);
-
-        // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
-        // $signups->each(function ($item) {
-        //     $item->posts->each(function ($item) {
-        //         $user = $this->registrar->find($item->northstar_id);
-
         $campaign = $this->campaignService->find($id);
         $totals = $this->campaignService->getPostTotals($campaign);
 
         return view('pages.campaign_single')
             ->with('state', [
-                // 'signups' => $signups->items(),
                 'campaign' => $campaign,
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,
                     'pending_count' => $totals->pending_count,
                     'rejected_count' => $totals->rejected_count,
                 ],
-                // 'next_page' => $signups->nextPageUrl(),
-                // 'previous_page' => $signups->previousPageUrl(),
             ]);
     }
 }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -95,36 +95,31 @@ class CampaignsController extends Controller
     public function showCampaign($id)
     {
         // Always load the page with just accepted posts
-        $signups = Signup::campaign([$id])->whereHas('posts', function ($query) {
-            $query->where('status', '=', 'accepted');
-        })->with(['posts' => function ($query) {
-            $query->where('status', '=', 'accepted');
-        }])->orderBy('created_at', 'desc')->paginate(50);
+        // $signups = Signup::campaign([$id])->whereHas('posts', function ($query) {
+        //     $query->where('status', '=', 'accepted');
+        // })->with(['posts' => function ($query) {
+        //     $query->where('status', '=', 'accepted');
+        // }])->orderBy('created_at', 'desc')->paginate(50);
 
         // @TODO EXTRACT AND FIGURE OUT HOW NOT TO HAVE TO DO THIS.
-        $signups->each(function ($item) {
-            $item->posts->each(function ($item) {
-                $user = $this->registrar->find($item->northstar_id);
-
-                // @TODO: Can we handle failure better?
-                $item->user = $user->toArray() ?: ['first_name' => 'A Doer'];
-            });
-        });
+        // $signups->each(function ($item) {
+        //     $item->posts->each(function ($item) {
+        //         $user = $this->registrar->find($item->northstar_id);
 
         $campaign = $this->campaignService->find($id);
         $totals = $this->campaignService->getPostTotals($campaign);
 
         return view('pages.campaign_single')
             ->with('state', [
-                'signups' => $signups->items(),
+                // 'signups' => $signups->items(),
                 'campaign' => $campaign,
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,
                     'pending_count' => $totals->pending_count,
                     'rejected_count' => $totals->rejected_count,
                 ],
-                'next_page' => $signups->nextPageUrl(),
-                'previous_page' => $signups->previousPageUrl(),
+                // 'next_page' => $signups->nextPageUrl(),
+                // 'previous_page' => $signups->previousPageUrl(),
             ]);
     }
 }

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -116,8 +116,11 @@ trait TransformsRequests
 
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
-        $include = isset($request->include) ? $request->include : null;
+        $includes = null;
+        if ($request->query('include')) {
+            $includes = explode(',', $request->query('include'));
+        }
 
-        return $this->transform($resource, $code, [], $include);
+        return $this->transform($resource, $code, [], $includes);
     }
 }

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -8,6 +8,16 @@ use League\Fractal\TransformerAbstract;
 class PostTransformer extends TransformerAbstract
 {
     /**
+     * List of resources possible to include
+     *
+     * @var array
+     */
+    protected $availableIncludes = [
+        'signup',
+        'siblings',
+    ];
+
+    /**
      * Transform resource data.
      *
      * @param \Rogue\Models\Post $post
@@ -26,12 +36,35 @@ class PostTransformer extends TransformerAbstract
                 'caption' => $post->caption,
             ],
             'tagged' => $post->tagSlugs(),
-            'reactions' => $post->reactions,
             'status' => $post->status,
             'source' => $post->source,
             'remote_addr' => $post->remote_addr,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];
+    }
+
+    /**
+     * Include the signup.
+     *
+     * @param \Rogue\Models\Post $post
+     * @return \League\Fractal\Resource\Collection
+     */
+    public function includeSignup(Post $post)
+    {
+        $transformer = (new SignupTransformer)->setDefaultIncludes([]);
+
+        return $this->item($post->signup, $transformer);
+    }
+
+    /**
+     * Include the siblings.
+     *
+     * @param \Rogue\Models\Post $post
+     * @return \League\Fractal\Resource\Collection
+     */
+    public function includeSiblings(Post $post)
+    {
+        return $this->collection($post->siblings, new self);
     }
 }

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -20,7 +20,9 @@ class PostTransformer extends TransformerAbstract
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
             'media' => [
+
                 'url' => $post->getMediaUrl(),
+                'original_image_url' => $post->url,
                 'caption' => $post->caption,
             ],
             'tagged' => $post->tagSlugs(),

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -52,7 +52,8 @@ class PostTransformer extends TransformerAbstract
      */
     public function includeSignup(Post $post)
     {
-        $transformer = (new SignupTransformer)->setDefaultIncludes([]);
+        // Don't include posts but include the user.
+        $transformer = (new SignupTransformer)->setDefaultIncludes(['user']);
 
         return $this->item($post->signup, $transformer);
     }

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -16,6 +16,10 @@ class UserTransformer extends TransformerAbstract
     {
         return [
             'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'birthdate' => $user->birthdate,
+            'email' => $user->email,
+            'mobile' => $user->mobile,
         ];
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -95,6 +95,6 @@ class Post extends Model
      */
     public function siblings()
     {
-        return $this->hasMany(Post::class, 'signup_id', 'signup_id');
+        return $this->hasMany(self::class, 'signup_id', 'signup_id');
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -89,4 +89,12 @@ class Post extends Model
 
         return url($path);
     }
+
+    /**
+     * Get the reactions associated with this post.
+     */
+    public function siblings()
+    {
+        return $this->hasMany(Post::class, 'signup_id', 'signup_id');
+    }
 }

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -34,7 +34,11 @@ Endpoint                                       | Functionality
 #### Posts
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
-`POST /api/v2/posts`                           | [Create a post](endpoints/posts.md#posts)
+`POST /api/v2/posts`                           | [Create a post](endpoints/posts.md#create-a-post-and/or-create/Update-a-signup)
+---------------------------------------------- | --------------------------------------------------------
+`GET /api/v2/posts`                            | [Get posts](endpoints/posts.md#retrieve-all-posts)
+---------------------------------------------- | --------------------------------------------------------
+`DELETE /api/v2/posts`                         | [Delete a post](endpoints/posts.md#delete-a-post)
 
 #### Reactions
 Endpoint                                       | Functionality                                           

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -22,8 +22,8 @@ GET /api/v2/activity
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`
-- **status** _(string)_
-  - Only return posts with this status. 
+- **filter[status]** _(string)_
+  - Only return the signup's posts with the given status. 
   - e.g. `/activity?filter[status]=pending`
 
 

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -49,7 +49,8 @@ Example Response:
             "signup_id": 15,
             "northstar_id": "1234",
             "media": {
-              "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
+              "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_214.jpeg",
+              "original_image_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/128-482cab927f6529c7f5e5c4bfd2594186-1501090354.jpeg",
               "caption": "Captioning captions",
             },
             "tagged": [

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -22,6 +22,9 @@ GET /api/v2/activity
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`
+- **status** _(string)_
+  - Only return posts with this status. 
+  - e.g. `/activity?filter[status]=pending`
 
 
 Example Response:

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -22,10 +22,6 @@ GET /api/v2/activity
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`
-- **filter[status]** _(string)_
-  - Only return the signup's posts with the given status. 
-  - e.g. `/activity?filter[status]=pending`
-
 
 Example Response:
 

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -102,6 +102,9 @@ GET /api/v2/posts
 - **as_user** _(string)_
   - The logged in user to display if they have reacted to the post or not.
   - e.g. `/posts?as_user=1234`
+- **include** _(string)_
+  - Include additional related records in the response: `signup`, `siblings`
+  - e.g. `/activity?include=signup,siblings`
 
 Example Response:
 
@@ -133,7 +136,6 @@ Example Response:
                 "caption": "Perhaps you CAN be of some assistance, Bill"
             },
             "tagged": [],
-            "reactions": [],
             "status": "accepted",
             "source": null,
             "remote_addr": "207.110.19.130, 207.110.19.130",

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -44,7 +44,8 @@ Example Response:
     "signup_id": 784,
     "northstar_id": "5571df46a59db12346dsb456d",
     "media": {
-      "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/18-1487182498.jpeg",
+      "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_214.jpeg",
+      "original_image_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/128-482cab927f6529c7f5e5c4bfd2594186-1501090354.jpeg",
       "caption": "Captioning captions",
     },
     "status": "pending",

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -1,6 +1,6 @@
 ## Posts
 
-Create a Post and/or Create/Update a Signup
+## Create a Post and/or Create/Update a Signup
 
 ```
 POST /api/v2/posts
@@ -56,6 +56,8 @@ Example Response:
 }
 ```
 
+## Delete a post 
+
 Allows admins to delete a post. Posts get soft deleted from the database.
 
 ```
@@ -71,7 +73,7 @@ Example Response:
 }
 ```
 
-Retrieve all Posts.
+## Retrieve all Posts
 
 ```
 GET /api/v2/posts

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@dosomething/forge": "^6.7.4",
-    "@dosomething/gateway": "^1.1.1",
+    "@dosomething/gateway": "^1.1.2",
     "classnames": "^2.2.5",
     "dosomething-modal": "^0.3.0",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@dosomething/forge": "^6.7.4",
-    "@dosomething/gateway": "^1.1.0",
+    "@dosomething/gateway": "^1.1.1",
     "classnames": "^2.2.5",
     "dosomething-modal": "^0.3.0",
     "lodash": "^4.17.4",

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -160,7 +160,7 @@ class CampaignInbox extends React.Component {
       return (
         <div className="container">
 
-          { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} />) }
+          { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} post={post} campaign={campaign} signup={this.state.signups[post.signup_id]} />) }
 
           <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups }}/> : null}

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -48,7 +48,8 @@ class CampaignSingle extends React.Component {
       filter: {
         status: status.toLowerCase(),
         campaign_id: this.props.campaign.id,
-      }
+      },
+      include: user,
     });
     request.then((result) => {
       var posts = keyBy(result.data, 'id');
@@ -122,7 +123,6 @@ class CampaignSingle extends React.Component {
   }
 
   render() {
-    console.log(this.state.signups);
     const posts = this.state.posts;
     const campaign = this.props.campaign;
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -116,7 +116,7 @@ class CampaignSingle extends React.Component {
 
         <PostFilter onChange={this.filterPosts} />
 
-        { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: post.signup.data}} /> : null) }
+        { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} post={post} campaign={campaign} signup={post.signup.data} /> : null) }
 
         <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -134,6 +134,7 @@ class CampaignSingle extends React.Component {
         <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
         </ModalContainer>
+
         <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>
       </div>
     )

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -24,16 +24,15 @@ class CampaignSingle extends React.Component {
   }
 
   componentDidMount() {
-    this.api.get('api/v2/activity', {
+    this.api.get('api/v2/posts', {
       filter: {
         status: 'accepted',
         campaign_id: this.props.campaign.id,
       },
-      include: 'user',
+      include: 'signup,siblings',
     })
     .then(json => this.setState({
-      signups: keyBy(json.data, 'signup_id'),
-      posts: extractPostsFromSignups(json.data),
+      posts: keyBy(json.data, 'id'),
       filter: 'accepted',
       postTotals: json.meta.pagination.total,
       displayHistoryModal: null,
@@ -45,20 +44,19 @@ class CampaignSingle extends React.Component {
 
   // Filter posts based on status.
   filterPosts(status) {
-    let request = this.api.get('api/v2/activity', {
+    let request = this.api.get('api/v2/posts', {
       filter: {
         status: status.toLowerCase(),
         campaign_id: this.props.campaign.id,
       },
-      include: 'user',
+      include: 'signup,siblings',
     });
     request.then((result) => {
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
 
-        newState.signups = keyBy(result.data, 'signup_id');
-        newState.posts = extractPostsFromSignups(result.data);
+        newState.posts = keyBy(result.data, 'id');
         newState.filter = status.toLowerCase();
         newState.postTotals = result.meta.pagination.total;
         newState.nextPage = result.meta.pagination.links.next ? result.meta.pagination.links.next : null;
@@ -131,7 +129,7 @@ class CampaignSingle extends React.Component {
 
         <PostFilter onChange={this.filterPosts} />
 
-        { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} /> : null) }
+        { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: post.signup.data}} /> : null) }
 
         <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -35,7 +35,7 @@ class CampaignSingle extends React.Component {
       signups: keyBy(json.data, 'signup_id'),
       posts: extractPostsFromSignups(json.data),
       filter: 'accepted',
-      // postTotals: json.meta.pagination.total,
+      postTotals: json.meta.pagination.total,
       displayHistoryModal: null,
       historyModalId: null,
       nextPage: json.meta.pagination.links.next ? json.meta.pagination.links.next : null,
@@ -45,22 +45,20 @@ class CampaignSingle extends React.Component {
 
   // Filter posts based on status.
   filterPosts(status) {
-    let request = this.api.get('api/v2/posts', {
+    let request = this.api.get('api/v2/activity', {
       filter: {
         status: status.toLowerCase(),
         campaign_id: this.props.campaign.id,
       },
-      include: user,
+      include: 'user',
     });
     request.then((result) => {
-      var posts = keyBy(result.data, 'id');
-
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
 
-        // newState.signups = signups;
-        newState.posts = posts;
+        newState.signups = keyBy(result.data, 'signup_id');
+        newState.posts = extractPostsFromSignups(result.data);
         newState.filter = status.toLowerCase();
         newState.postTotals = result.meta.pagination.total;
         newState.nextPage = result.meta.pagination.links.next ? result.meta.pagination.links.next : null;

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -122,7 +122,6 @@ class CampaignSingle extends React.Component {
   }
 
   render() {
-    console.log(this.state.json);
     const posts = this.state.posts;
     const campaign = this.props.campaign;
 
@@ -137,7 +136,6 @@ class CampaignSingle extends React.Component {
         <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
         </ModalContainer>
-
         <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>
       </div>
     )

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -24,29 +24,17 @@ class CampaignSingle extends React.Component {
   }
 
   componentDidMount() {
-    this.api.get('api/v2/posts', {
+    this.api.get('api/v2/activity', {
       filter: {
         status: 'accepted',
         campaign_id: this.props.campaign.id,
       }
     })
     .then(json => this.setState({
-      signups: {
-        0: {
-          campaign_id: 10,
-          campaign_run_id: 1744,
-          created_at: "2017-07-26 17:31:56",
-          id: 128,
-          northstar_id: "5978afc27f43c27d8755558c",
-          quantity: 3,
-          source: "campaigns",
-          updated_at: "2017-08-01 20:48:26",
-          why_participated: "because",
-        },
-      },
-      posts: json.data,
+      signups: keyBy(json.data, 'signup_id'),
+      posts: extractPostsFromSignups(json.data),
       filter: 'accepted',
-      postTotals: json.meta.pagination.total,
+      // postTotals: json.meta.pagination.total,
       displayHistoryModal: null,
       historyModalId: null,
       nextPage: json.meta.pagination.links.next ? json.meta.pagination.links.next : null,
@@ -134,10 +122,9 @@ class CampaignSingle extends React.Component {
   }
 
   render() {
+    console.log(this.state.signups);
     const posts = this.state.posts;
     const campaign = this.props.campaign;
-
-    // We need the signup object with all of it's posts. Insteadn of grabbing all of the signups via api, can we do this through database?
 
     return (
       <div className="container">

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -15,7 +15,6 @@ class CampaignSingle extends React.Component {
     super(props);
 
     const posts = extractPostsFromSignups(props.signups);
-
     this.state = {
       signups: keyBy(props.signups, 'id'),
       posts: posts,
@@ -36,23 +35,26 @@ class CampaignSingle extends React.Component {
 
   // Filter posts based on status.
   filterPosts(status) {
-    // @TODO: Make API request to Rogue to get filtered posts and and set the post's filter state based on response.
-    // @TODO: we also need to update the posts/signups?
-    let request = this.api.get('api/v1/reportbacks', {
+    let request = this.api.get('api/v2/posts', {
       filter: {
-        status: status.toLowerCase()
+        status: status.toLowerCase(),
+        campaign_id: this.props.campaign.id,
       }
     });
 
     request.then((result) => {
-      console.log(result);
+      var signups = keyBy(result.data, 'id');
+      // console.log(extractPostsFromSignups(signups));
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
 
-      //   // newState.signups[signup.id].quantity = result.quantity;
+        newState.signups = signups;
+        newState.posts = extractPostsFromSignups(signups);
+      // console.log(status.toLowerCase());
+        newState.filter = this.status.toLowerCase();
 
-      //   return newState;
+        return newState;
       });
     });
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -28,7 +28,8 @@ class CampaignSingle extends React.Component {
       filter: {
         status: 'accepted',
         campaign_id: this.props.campaign.id,
-      }
+      },
+      include: 'user',
     })
     .then(json => this.setState({
       signups: keyBy(json.data, 'signup_id'),
@@ -123,6 +124,7 @@ class CampaignSingle extends React.Component {
   }
 
   render() {
+    console.log(this.state.json);
     const posts = this.state.posts;
     const campaign = this.props.campaign;
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -86,25 +86,25 @@ class CampaignSingle extends React.Component {
 
   // Make API call to GET /posts to get posts by filtered status.
   getPostsByStatus(status, campaignId) {
-  this.api = new RestApiClient;
+    this.api = new RestApiClient;
 
-  this.api.get('api/v2/posts', {
-    filter: {
-      status: status,
-      campaign_id: campaignId,
-    },
-    include: 'signup,siblings',
-  })
-  .then(json => this.setState({
-    posts: keyBy(json.data, 'id'),
-    filter: status,
-    postTotals: json.meta.pagination.total,
-    displayHistoryModal: null,
-    historyModalId: null,
-    nextPage: json.meta.pagination.links.next,
-    prevPage: json.meta.pagination.links.previous,
-  }));
-}
+    this.api.get('api/v2/posts', {
+      filter: {
+        status: status,
+        campaign_id: campaignId,
+      },
+      include: 'signup,siblings',
+    })
+    .then(json => this.setState({
+      posts: keyBy(json.data, 'id'),
+      filter: status,
+      postTotals: json.meta.pagination.total,
+      displayHistoryModal: null,
+      historyModalId: null,
+      nextPage: json.meta.pagination.links.next,
+      prevPage: json.meta.pagination.links.previous,
+    }));
+  }
 
   render() {
     const posts = this.state.posts;

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -31,7 +31,6 @@ class CampaignSingle extends React.Component {
       }
     })
     .then(json => this.setState({
-      // Hard code this for now until GET /posts endpoint is updated
       signups: {
         0: {
           campaign_id: 10,
@@ -137,6 +136,8 @@ class CampaignSingle extends React.Component {
   render() {
     const posts = this.state.posts;
     const campaign = this.props.campaign;
+
+    // We need the signup object with all of it's posts. Insteadn of grabbing all of the signups via api, can we do this through database?
 
     return (
       <div className="container">

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -36,19 +36,23 @@ class CampaignSingle extends React.Component {
 
   // Filter posts based on status.
   filterPosts(status) {
-    console.log(status);
     // @TODO: Make API request to Rogue to get filtered posts and and set the post's filter state based on response.
     // @TODO: we also need to update the posts/signups?
-    let request = this.api.get('reportbacks', filter[status] = status);
-    console.log(request);
+    let request = this.api.get('api/v1/reportbacks', {
+      filter: {
+        status: status.toLowerCase()
+      }
+    });
+
     request.then((result) => {
+      console.log(result);
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
 
-        newState.signups[signup.id].quantity = result.quantity;
+      //   // newState.signups[signup.id].quantity = result.quantity;
 
-        return newState;
+      //   return newState;
       });
     });
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -24,47 +24,12 @@ class CampaignSingle extends React.Component {
   }
 
   componentDidMount() {
-    this.api.get('api/v2/posts', {
-      filter: {
-        status: 'accepted',
-        campaign_id: this.props.campaign.id,
-      },
-      include: 'signup,siblings',
-    })
-    .then(json => this.setState({
-      posts: keyBy(json.data, 'id'),
-      filter: 'accepted',
-      postTotals: json.meta.pagination.total,
-      displayHistoryModal: null,
-      historyModalId: null,
-      nextPage: json.meta.pagination.links.next,
-      prevPage: json.meta.pagination.links.previous,
-    }));
+    this.getPostsByStatus('accepted', this.props.campaign.id);
   }
 
   // Filter posts based on status.
   filterPosts(status) {
-    let request = this.api.get('api/v2/posts', {
-      filter: {
-        status: status.toLowerCase(),
-        campaign_id: this.props.campaign.id,
-      },
-      include: 'signup,siblings',
-    });
-    request.then((result) => {
-      // Update the state
-      this.setState((previousState) => {
-        const newState = {...previousState};
-
-        newState.posts = keyBy(result.data, 'id');
-        newState.filter = status.toLowerCase();
-        newState.postTotals = result.meta.pagination.total;
-        newState.nextPage = result.meta.pagination.links.next;
-        newState.prevPage = result.meta.pagination.links.previous;
-
-        return newState;
-      });
-    });
+    this.getPostsByStatus(status.toLowerCase(), this.props.campaign.id);
   }
 
   // Open the history modal of the given post
@@ -118,6 +83,28 @@ class CampaignSingle extends React.Component {
     // Close the modal
     this.hideHistory();
   }
+
+  // Make API call to GET /posts to get posts by filtered status.
+  getPostsByStatus(status, campaignId) {
+  this.api = new RestApiClient;
+
+  this.api.get('api/v2/posts', {
+    filter: {
+      status: status,
+      campaign_id: campaignId,
+    },
+    include: 'signup,siblings',
+  })
+  .then(json => this.setState({
+    posts: keyBy(json.data, 'id'),
+    filter: status,
+    postTotals: json.meta.pagination.total,
+    displayHistoryModal: null,
+    historyModalId: null,
+    nextPage: json.meta.pagination.links.next,
+    prevPage: json.meta.pagination.links.previous,
+  }));
+}
 
   render() {
     const posts = this.state.posts;

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -37,8 +37,8 @@ class CampaignSingle extends React.Component {
       postTotals: json.meta.pagination.total,
       displayHistoryModal: null,
       historyModalId: null,
-      nextPage: json.meta.pagination.links.next ? json.meta.pagination.links.next : null,
-      prevPage: json.meta.pagination.links.previous ? json.meta.pagination.links.previous : null,
+      nextPage: json.meta.pagination.links.next,
+      prevPage: json.meta.pagination.links.previous,
     }));
   }
 
@@ -59,8 +59,8 @@ class CampaignSingle extends React.Component {
         newState.posts = keyBy(result.data, 'id');
         newState.filter = status.toLowerCase();
         newState.postTotals = result.meta.pagination.total;
-        newState.nextPage = result.meta.pagination.links.next ? result.meta.pagination.links.next : null;
-        newState.prevPage = result.meta.pagination.links.previous ? result.meta.pagination.links.previous : null;
+        newState.nextPage = result.meta.pagination.links.next;
+        newState.prevPage = result.meta.pagination.links.previous;
 
         return newState;
       });

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -36,7 +36,23 @@ class CampaignSingle extends React.Component {
 
   // Filter posts based on status.
   filterPosts(status) {
-    this.setState({ filter: status.toLowerCase() });
+    console.log(status);
+    // @TODO: Make API request to Rogue to get filtered posts and and set the post's filter state based on response.
+    // @TODO: we also need to update the posts/signups?
+    let request = this.api.get('reportbacks', filter[status] = status);
+    console.log(request);
+    request.then((result) => {
+      // Update the state
+      this.setState((previousState) => {
+        const newState = {...previousState};
+
+        newState.signups[signup.id].quantity = result.quantity;
+
+        return newState;
+      });
+    });
+
+    // this.setState({ filter: status.toLowerCase() });
   }
 
   // Open the history modal of the given post
@@ -98,20 +114,15 @@ class CampaignSingle extends React.Component {
     return (
       <div className="container">
         <StatusCounter postTotals={this.state.postTotals} campaign={campaign} />
-        { /* @TODO: we will want this back oncefiltering is back */ }
-        { /* <PostFilter onChange={this.filterPosts} /> */}
 
-      { /* @TODO: remove this heading once filtering is back */}
-        <div className="heading -gamma">
-          Accepted Posts
-        </div>
+        <PostFilter onChange={this.filterPosts} />
 
         { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={false} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} /> : null) }
 
         <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
         </ModalContainer>
-        
+
         <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>
       </div>
     )

--- a/resources/assets/components/InboxItem/InboxTile.js
+++ b/resources/assets/components/InboxItem/InboxTile.js
@@ -8,7 +8,7 @@ class InboxTile extends React.Component {
 
     return (
       <li>
-        <img src={getImageUrlFromProp(post) ? getImageUrlFromProp(post) : post.media['url']}/>
+        <img src={getImageUrlFromProp(post) || post.media['url']}/>
       </li>
     )
   }

--- a/resources/assets/components/InboxItem/InboxTile.js
+++ b/resources/assets/components/InboxItem/InboxTile.js
@@ -8,7 +8,7 @@ class InboxTile extends React.Component {
 
     return (
       <li>
-        <img src={getImageUrlFromProp(post)}/>
+        <img src={getImageUrlFromProp(post) ? getImageUrlFromProp(post) : post.media['url']}/>
       </li>
     )
   }

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -59,9 +59,9 @@ class InboxItem extends React.Component {
     return (
       <div className="container__row inbox-item">
         <div className="container__block -third">
-          <img src={getImageUrlFromProp(post) ? getImageUrlFromProp(post) : post.media['url']}/>
+          <img src={getImageUrlFromProp(post)}/>
           <p>
-            <a href={getImageUrlFromProp(post) ? getImageUrlFromProp(post) : post.media['url']} target="_blank">Original Photo</a> | <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
+            <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a> | <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
           </p>
 
           <ul className="gallery -duo">

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -39,7 +39,7 @@ class InboxItem extends React.Component {
     const post = this.props.details.post;
     const campaign = this.props.details.campaign;
     const signup = this.props.details.signup;
-    console.log(post);
+
     if (post['user']) {
       var first_name = post['user']['first_name'];
       var last_name = post['user']['last_name'];

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -21,7 +21,8 @@ class InboxItem extends React.Component {
   getOtherPosts(post) {
     const post_id = post['id'];
     const signup = this.props.details.signup;
-    var posts = signup.posts.data ? signup.posts.data : signup.posts;
+
+    var posts = signup.posts ? signup.posts : post.siblings.data;
 
     // get array of posts
     const other_posts = clone(posts);

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -41,6 +41,10 @@ class InboxItem extends React.Component {
     const campaign = this.props.campaign;
     const signup = this.props.signup;
 
+    // If post['user'], the data is coming from Campaigns Controller to populate the Campaign Inbox page.
+    // Otherwise, it is data coming from the API.
+    // @TODO see TODO in Campaigns Controller showInbox function to better grab informaiton
+    // and simplify the below so we don't have to use a conditional.
     if (post['user']) {
       var first_name = post['user']['first_name'];
       var last_name = post['user']['last_name'];

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -40,6 +40,20 @@ class InboxItem extends React.Component {
     const campaign = this.props.details.campaign;
     const signup = this.props.details.signup;
 
+    if (post['user']) {
+      var first_name = post['user']['first_name'];
+      var last_name = post['user']['last_name'];
+      var birthdate = calculateAge(post['user']['birthdate']);
+      var email = post['user']['email'];
+      var mobile = post['user']['mobile'];
+    } else if (signup.user) {
+      var first_name = signup.user.data['first_name'];
+      var last_name = signup.user.data['last_name'];
+      var birthdate = calculateAge(signup.user.data['birthdate']);
+      var email = signup.user.data['email'];
+      var mobile = signup.user.data['mobile'];
+    }
+
     return (
       <div className="container__row inbox-item">
         <div className="container__block -third">
@@ -53,12 +67,12 @@ class InboxItem extends React.Component {
           </ul>
         </div>
         <div className="container__block -third">
-          {post['user'] ?
+          {post['user'] || signup.user ?
             <div>
-              <h2>{post['user']['first_name']} {post['user']['last_name']}, {calculateAge(post['user']['birthdate'])}</h2>
+              <h2>{first_name} {last_name}, {birthdate}</h2>
               <ul>
-                <li><em>{post['user']['email']}</em></li>
-                <li><em>{post['user']['mobile']}</em></li>
+                <li><em>{email}</em></li>
+                <li><em>{mobile}</em></li>
               </ul>
             </div>
             : <h2>User Not Found</h2>}

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -20,7 +20,7 @@ class InboxItem extends React.Component {
 
   getOtherPosts(post) {
     const post_id = post['id'];
-    const signup = this.props.details.signup;
+    const signup = this.props.signup;
 
     var posts = signup.posts ? signup.posts : post.siblings.data;
 
@@ -37,9 +37,9 @@ class InboxItem extends React.Component {
   }
 
   render() {
-    const post = this.props.details.post;
-    const campaign = this.props.details.campaign;
-    const signup = this.props.details.signup;
+    const post = this.props.post;
+    const campaign = this.props.campaign;
+    const signup = this.props.signup;
 
     if (post['user']) {
       var first_name = post['user']['first_name'];

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -39,7 +39,7 @@ class InboxItem extends React.Component {
     const post = this.props.details.post;
     const campaign = this.props.details.campaign;
     const signup = this.props.details.signup;
-
+    console.log(post);
     if (post['user']) {
       var first_name = post['user']['first_name'];
       var last_name = post['user']['last_name'];
@@ -53,6 +53,8 @@ class InboxItem extends React.Component {
       var email = signup.user.data['email'];
       var mobile = signup.user.data['mobile'];
     }
+
+    var caption = post['caption'] ? post['caption'] : post.media['caption'];
 
     return (
       <div className="container__row inbox-item">
@@ -92,10 +94,10 @@ class InboxItem extends React.Component {
           <a href="#" onClick={e => this.props.showHistory(post['id'], e)}>Edit | Show History</a>
           <br/>
           <br/>
-          {post['caption'] ?
+          {caption ?
             <div>
               <h4>Photo Caption</h4>
-              <p>{post['caption']}</p>
+              <p>{caption}</p>
             </div>
           : null}
           <h4>Why Statement</h4>

--- a/resources/assets/components/InboxItem/index.js
+++ b/resources/assets/components/InboxItem/index.js
@@ -21,9 +21,10 @@ class InboxItem extends React.Component {
   getOtherPosts(post) {
     const post_id = post['id'];
     const signup = this.props.details.signup;
+    var posts = signup.posts.data ? signup.posts.data : signup.posts;
 
     // get array of posts
-    const other_posts = clone(signup.posts);
+    const other_posts = clone(posts);
 
     // find index that has that post_id and remove
     const big_post = remove(other_posts, function(current_post) {
@@ -42,9 +43,9 @@ class InboxItem extends React.Component {
     return (
       <div className="container__row inbox-item">
         <div className="container__block -third">
-          <img src={getImageUrlFromProp(post)}/>
+          <img src={getImageUrlFromProp(post) ? getImageUrlFromProp(post) : post.media['url']}/>
           <p>
-            <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a> | <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
+            <a href={getImageUrlFromProp(post) ? getImageUrlFromProp(post) : post.media['url']} target="_blank">Original Photo</a> | <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
           </p>
 
           <ul className="gallery -duo">

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -44,33 +44,12 @@ export function getImageUrlFromProp(photoProp) {
 };
 
 export function extractPostsFromSignups(signups) {
-  // If this is coming from the API, posts will be nested under data.
-  if (signups[0].posts.data) {
-    var posts = keyBy(flatMap(signups, signup => {
-      return signup.posts.data;
-    }), 'id');
-  } else {
-    var posts = keyBy(flatMap(signups, signup => {
+    const posts = keyBy(flatMap(signups, signup => {
       return signup.posts;
     }), 'id');
-  }
 
   return posts;
 }
-
-// export function extractSignupFromPost(post) {
-//   if (signups[0].posts.data) {
-//     var posts = keyBy(flatMap(signups, signup => {
-//       return signup.posts.data;
-//     }), 'id');
-//   } else {
-//     var posts = keyBy(flatMap(signups, signup => {
-//       return signup.posts;
-//     }), 'id');
-//   }
-
-//   return signup;
-// }
 
 export function getEditedImageUrl(photoProp) {
   const edited_file_name = `edited_${photoProp.id}.jpeg`;

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -58,6 +58,20 @@ export function extractPostsFromSignups(signups) {
   return posts;
 }
 
+// export function extractSignupFromPost(post) {
+//   if (signups[0].posts.data) {
+//     var posts = keyBy(flatMap(signups, signup => {
+//       return signup.posts.data;
+//     }), 'id');
+//   } else {
+//     var posts = keyBy(flatMap(signups, signup => {
+//       return signup.posts;
+//     }), 'id');
+//   }
+
+//   return signup;
+// }
+
 export function getEditedImageUrl(photoProp) {
   const edited_file_name = `edited_${photoProp.id}.jpeg`;
   var url_parts;

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -31,7 +31,7 @@ export function getImageUrlFromProp(photoProp) {
     photo_url = photoProp['url'];
   }
   else if ('media' in photoProp) {
-    photo_url = photoProp['media']['url'];
+    photo_url = photoProp['media']['original_image_url'];
   }
 
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -4,7 +4,6 @@
  * @param {Function} fn
  */
 import { flatMap, keyBy } from 'lodash';
-import { RestApiClient} from '@dosomething/gateway';
 
 export function ready(fn) {
   if (document.readyState !== 'loading'){

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -44,11 +44,18 @@ export function getImageUrlFromProp(photoProp) {
 };
 
 export function extractPostsFromSignups(signups) {
-    const posts = keyBy(flatMap(signups, signup => {
+  // If this is coming from the API, posts will be nested under data.
+  if (signups[0].posts.data) {
+    var posts = keyBy(flatMap(signups, signup => {
+      return signup.posts.data;
+    }), 'id');
+  } else {
+    var posts = keyBy(flatMap(signups, signup => {
       return signup.posts;
     }), 'id');
+  }
 
-    return posts;
+  return posts;
 }
 
 export function getEditedImageUrl(photoProp) {

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -4,6 +4,7 @@
  * @param {Function} fn
  */
 import { flatMap, keyBy } from 'lodash';
+import { RestApiClient} from '@dosomething/gateway';
 
 export function ready(fn) {
   if (document.readyState !== 'loading'){

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -139,37 +139,6 @@ class ActivityApiTest extends TestCase
     }
 
     /**
-     * Test for retrieving a user's activity when filtering by post status.
-     *
-     * GET /activity?filter[]=
-     * @return void
-     */
-    public function testActivityIndexWithStatusFilter()
-    {
-        factory(Signup::class, 5)->create()
-            ->each(function ($signup) {
-                $signup->posts()->save(factory(Post::class)->create());
-            });
-
-        factory(Signup::class, 2)->create()
-            ->each(function ($signup) {
-                $signup->posts()->save(factory(Post::class, 'accepted')->create());
-            });
-
-        $this->get('api/v2/activity?filter[status]=accepted');
-
-        $this->assertResponseStatus(200);
-
-        $response = $this->decodeResponseJson();
-        $this->assertCount(7, $response['data']);
-
-        // Posts are ordered chronologically, so the first one should have zero accepted posts,
-        // and the last one should have 1 accepted post.
-        $this->assertCount(0, $response['data'][0]['posts']['data']);
-        $this->assertCount(1, $response['data'][6]['posts']['data']);
-    }
-
-    /**
      * Test for retrieving a user's activity with combination of query params
      * where we expect nothing to be returned.
      *

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -139,6 +139,37 @@ class ActivityApiTest extends TestCase
     }
 
     /**
+     * Test for retrieving a user's activity when filtering by post status.
+     *
+     * GET /activity?filter[]=
+     * @return void
+     */
+    public function testActivityIndexWithStatusFilter()
+    {
+        factory(Signup::class, 5)->create()
+            ->each(function ($signup) {
+                $signup->posts()->save(factory(Post::class)->create());
+            });
+
+        factory(Signup::class, 2)->create()
+            ->each(function ($signup) {
+                $signup->posts()->save(factory(Post::class, 'accepted')->create());
+            });
+
+        $this->get('api/v2/activity?filter[status]=accepted');
+
+        $this->assertResponseStatus(200);
+
+        $response = $this->decodeResponseJson();
+        $this->assertCount(7, $response['data']);
+
+        // Posts are ordered chronologically, so the first one should have zero accepted posts,
+        // and the last one should have 1 accepted post.
+        $this->assertCount(0, $response['data'][0]['posts']['data']);
+        $this->assertCount(1, $response['data'][6]['posts']['data']);
+    }
+
+    /**
      * Test for retrieving a user's activity with combination of query params
      * where we expect nothing to be returned.
      *

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -18,8 +18,8 @@ class ActivityApiTest extends TestCase
         factory(Signup::class, 10)->create();
 
         $this->get('api/v2/activity');
-        $this->assertResponseStatus(200);
 
+        $this->assertResponseStatus(200);
         $this->seeJsonStructure([
             'data' => [
                 '*' => [

--- a/tests/Models/PostModelTest.php
+++ b/tests/Models/PostModelTest.php
@@ -42,11 +42,11 @@ class PostModelTest extends TestCase
             });
 
         // Grab any old post.
-        $post = Post::where('signup_id', 4)->first();
+        $post = Signup::all()->first()->posts->first();
 
         // Asking for the siblings of the post, should only give other
         // posts with the same `signup_id` (including itself).
         $this->assertCount(3, $post->siblings);
-        $this->assertEquals(4, $post->siblings[0]->signup_id);
+        $this->assertEquals($post->signup_id, $post->siblings[0]->signup_id);
     }
 }

--- a/tests/Models/PostModelTest.php
+++ b/tests/Models/PostModelTest.php
@@ -28,4 +28,25 @@ class PostModelTest extends TestCase
         $this->assertEquals('2017-08-03 16:52:00', (string) $post->fresh()->updated_at);
         $this->assertEquals('2017-08-03 16:52:00', (string) $signup->fresh()->updated_at);
     }
+
+    /**
+     * Test that the siblings relationship returns other posts.
+     *
+     * @return void
+     */
+    public function testSiblingRelationship()
+    {
+        factory(Signup::class, 5)->create()
+            ->each(function ($signup) {
+                $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->create());
+            });
+
+        // Grab any old post.
+        $post = Post::where('signup_id', 4)->first();
+
+        // Asking for the siblings of the post, should only give other
+        // posts with the same `signup_id` (including itself).
+        $this->assertCount(3, $post->siblings);
+        $this->assertEquals(4, $post->siblings[0]->signup_id);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
- Changes Campaign Single Index page's initial state to be powered by API instead of sending signups from backend (`GET /posts`). 
- Powers filtering by status via the API (`GET /posts`).
- Adds relation to Post model of other related posts under the same signup (siblings).
- Updates Post Transformer to optionally include related posts (siblings) and signup object for `GET /posts`).
- Returns more information about the user in the User Transformer (user's last name, birthdate, email address, mobile number).  
- Returns the original photo url in the Post Transformer. 
- Updates `$include` param to allow for multiple values (e.g. `$include=signup,siblings`).
- Updates Post tests.  
- BONUS: 
    - Adds some missing things to README file for documentation.

#### How should this be reviewed?
- Test `campaigns/:nid` to make sure initial state looks as expected and filtering works properly. 
    - Make sure that all information about the signup and post is exposed correctly! 
    - Don't forget to check the "Original Photo" and "Edited Photo" links and that they're working correctly! 
- Make sure `/campaigns/:nid/inbox` isn't broken. 

#### Any background context you want to provide?
- I think that this breaks pagination? Is this ok for now and we can make another issue to fix this? 
- @DFurnes I don't think we need to do this but should we update the activity test to make sure it includes additional information about the user? Has same functionality so not sure if this is needed! 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/149809538

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.