### PR TITLE
Add Glide for on-demand image processing.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 ROGUE_API_KEY=abc123
 
+# Feature Flags
+DS_ENABLE_GLIDE=true
+
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Exception\HttpResponseException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use League\Glide\Filesystem\FileNotFoundException as GlideNotFoundException;
 
 class Handler extends ExceptionHandler
 {
@@ -48,6 +50,9 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $e)
     {
         // Re-cast specific exceptions or uniquely render them:
+        if ($e instanceof GlideNotFoundException) {
+            $e = new NotFoundHttpException('That image could not be found.');
+        }
         if ($e instanceof AuthorizationException) {
             return parent::render($request, $e);
         }

--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -43,6 +43,11 @@ class ImagesController extends Controller
             'cache' => $this->filesystem->getDriver(),
             'cache_path_prefix' => '.cache',
             'base_url' => 'images',
+            'defaults' => [
+                'w' => 400,
+                'h' => 400,
+                'fit' => 'crop',
+            ]
         ]);
 
         return $server->getImageResponse($post->getMediaPath(), $request->all());

--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rogue\Http\Controllers;
+
+use League\Glide\Responses\LaravelResponseFactory;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use League\Glide\ServerFactory;
+use Illuminate\Http\Request;
+use Rogue\Models\Post;
+
+class ImagesController extends Controller
+{
+    /**
+     * The Laravel filesystem adapter.
+     *
+     * @var \Illuminate\Filesystem\FilesystemAdapter
+     */
+    protected $filesystem;
+
+    /**
+     * Create a controller instance.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  Post $post
+     * @param  Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Post $post, Request $request)
+    {
+        // Create the Glide server.
+        $server = ServerFactory::create([
+            'response' => new LaravelResponseFactory($request),
+            'source' => $this->filesystem->getDriver(),
+            'cache' => $this->filesystem->getDriver(),
+            'cache_path_prefix' => '.cache',
+            'base_url' => 'images',
+        ]);
+
+        return $server->getImageResponse($post->getMediaPath(), $request->all());
+    }
+}

--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -2,13 +2,13 @@
 
 namespace Rogue\Http\Controllers;
 
-use League\Glide\Responses\LaravelResponseFactory;
-use Illuminate\Contracts\Filesystem\Filesystem;
+use Rogue\Models\Post;
+use Illuminate\Http\Request;
+use League\Glide\ServerFactory;
 use League\Flysystem\Memory\MemoryAdapter;
 use League\Flysystem\Filesystem as Flysystem;
-use League\Glide\ServerFactory;
-use Illuminate\Http\Request;
-use Rogue\Models\Post;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use League\Glide\Responses\LaravelResponseFactory;
 
 class ImagesController extends Controller
 {
@@ -48,7 +48,7 @@ class ImagesController extends Controller
                 'w' => 400,
                 'h' => 400,
                 'fit' => 'crop',
-            ]
+            ],
         ]);
 
         return $server->getImageResponse($post->getMediaPath(), $request->all());

--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -4,6 +4,8 @@ namespace Rogue\Http\Controllers;
 
 use League\Glide\Responses\LaravelResponseFactory;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use League\Flysystem\Memory\MemoryAdapter;
+use League\Flysystem\Filesystem as Flysystem;
 use League\Glide\ServerFactory;
 use Illuminate\Http\Request;
 use Rogue\Models\Post;
@@ -39,9 +41,8 @@ class ImagesController extends Controller
         // Create the Glide server.
         $server = ServerFactory::create([
             'response' => new LaravelResponseFactory($request),
+            'cache' => new Flysystem(new MemoryAdapter()),
             'source' => $this->filesystem->getDriver(),
-            'cache' => $this->filesystem->getDriver(),
-            'cache_path_prefix' => '.cache',
             'base_url' => 'images',
             'defaults' => [
                 'w' => 400,

--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -38,6 +38,10 @@ class ImagesController extends Controller
      */
     public function show(Post $post, Request $request)
     {
+        if (! config('features.glide')) {
+            abort(501, 'Glide image URLs are not enabled in this environment.');
+        }
+
         // Create the Glide server.
         $server = ServerFactory::create([
             'response' => new LaravelResponseFactory($request),

--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -49,6 +49,7 @@ class ImagesController extends Controller
             'source' => $this->filesystem->getDriver(),
             'base_url' => 'images',
             'defaults' => [
+                'or' => 'auto',
                 'w' => 400,
                 'h' => 400,
                 'fit' => 'crop',

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -25,18 +25,22 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('campaigns/{id}/inbox', 'CampaignsController@showInbox');
     Route::get('campaigns/{id}', 'CampaignsController@showCampaign');
 
+    // Users
     Route::get('users', 'UsersController@index');
 
-    // posts
+    // Posts
     Route::post('posts', 'PostController@store');
     Route::get('posts', 'PostController@index');
     Route::delete('posts/{id}', 'PostController@destroy');
 
-    // reviews
+    // Reviews
     Route::put('reviews', 'ReviewsController@reviews');
 
-    // tags
+    // Tags
     Route::post('tags', 'TagsController@store');
+
+    // Images
+    Route::get('/images/{post}', 'ImagesController@show');
 });
 
 // Legacy API Routes

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -80,6 +80,7 @@ class Post extends Model
     public function getMediaUrl()
     {
         if ($this->url === 'default') {
+            // @TODO: We should either return a placeholder, or `null`.
             return 'default';
         }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -97,11 +97,24 @@ class Post extends Model
 
     /**
      * Return the filesystem path for this post.
+     *
+     * @return string|null
      */
     public function getMediaPath()
     {
-        $path = str_replace('/storage//', '', $this->url);
+        // We store local URLs prefixed with `/storage` when using the "public" adapter.
+        if (config('filesystems.default') == 'public') {
+            return str_replace('/storage/', '', $this->url);
+        }
 
-        return $path;
+        // For S3, we store a full AWS URL, sometimes prefixed by bucket directory.
+        if (config('filesystems.default') == 's3') {
+            $path = parse_url($this->url, PHP_URL_PATH);
+            $path = str_replace('/'. config('filesystems.disks.s3.bucket') . '/', '', $path);
+
+            return $path;
+        }
+
+        return null;
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -84,8 +84,12 @@ class Post extends Model
             return 'default';
         }
 
+        // If Glide is enabled, provide the default image URL.
+        if (config('features.glide')) {
+            return url('images/' . $this->id);
+        }
+
         // Ask the storage driver for the path to the image for this post.
-        // @TODO: Update this to provide a default Glide URL!
         $path = Storage::url('uploads/reportback-items/edited_' . $this->id . '.jpeg');
 
         return url($path);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -89,4 +89,14 @@ class Post extends Model
 
         return url($path);
     }
+
+    /**
+     * Return the filesystem path for this post.
+     */
+    public function getMediaPath()
+    {
+        $path = str_replace('/storage//', '', $this->url);
+
+        return $path;
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "doctrine/dbal": "^2.5",
         "intervention/image": "^2.3",
         "rtconner/laravel-tagging": "~2.2",
-        "barryvdh/laravel-debugbar": "^2.3"
+        "barryvdh/laravel-debugbar": "^2.3",
+        "league/glide-laravel": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "intervention/image": "^2.3",
         "rtconner/laravel-tagging": "~2.2",
         "barryvdh/laravel-debugbar": "^2.3",
-        "league/glide-laravel": "^1.0"
+        "league/glide-laravel": "^1.0",
+        "league/flysystem-memory": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "03d8915972a0964ab2560a77b99ee62e",
+    "content-hash": "61174c4408cabeb8e5d24520367df07f",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1624,6 +1624,57 @@
             ],
             "description": "Flysystem adapter for the AWS S3 SDK v3.x",
             "time": "2017-04-28T10:21:54+00:00"
+        },
+        {
+            "name": "league/flysystem-memory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-memory.git",
+                "reference": "1cabecd08a8caec92a96a953c0d93b5ce83b07a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-memory/zipball/1cabecd08a8caec92a96a953c0d93b5ce83b07a2",
+                "reference": "1cabecd08a8caec92a96a953c0d93b5ce83b07a2",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Memory\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Leppanen",
+                    "email": "chris.leppanen@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "An in-memory adapter for Flysystem.",
+            "homepage": "https://github.com/thephpleague/flysystem-memory",
+            "keywords": [
+                "Flysystem",
+                "adapter",
+                "memory"
+            ],
+            "time": "2016-06-04T03:57:11+00:00"
         },
         {
             "name": "league/fractal",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb15fd92943154fbfb7a9ac5b8fc705b",
+    "content-hash": "03d8915972a0964ab2560a77b99ee62e",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1687,6 +1687,152 @@
                 "rest"
             ],
             "time": "2015-10-07T14:48:58+00:00"
+        },
+        {
+            "name": "league/glide",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/glide.git",
+                "reference": "8077f529a07ded3eed6c5dcf7f688249b626ddf3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/glide/zipball/8077f529a07ded3eed6c5dcf7f688249b626ddf3",
+                "reference": "8077f529a07ded3eed6c5dcf7f688249b626ddf3",
+                "shasum": ""
+            },
+            "require": {
+                "intervention/image": "^2.1",
+                "league/flysystem": "^1.0",
+                "php": "^5.4 | ^7.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9",
+                "phpunit/php-token-stream": "^1.4",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Glide\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "http://reinink.ca"
+                }
+            ],
+            "description": "Wonderfully easy on-demand image manipulation library with an HTTP based API.",
+            "homepage": "http://glide.thephpleague.com",
+            "keywords": [
+                "ImageMagick",
+                "editing",
+                "gd",
+                "image",
+                "imagick",
+                "league",
+                "manipulation",
+                "processing"
+            ],
+            "time": "2017-05-09T17:41:49+00:00"
+        },
+        {
+            "name": "league/glide-laravel",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/glide-laravel.git",
+                "reference": "b525e33e32940f3b047d6ca357131aba0e973e72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/glide-laravel/zipball/b525e33e32940f3b047d6ca357131aba0e973e72",
+                "reference": "b525e33e32940f3b047d6ca357131aba0e973e72",
+                "shasum": ""
+            },
+            "require": {
+                "league/glide-symfony": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Glide\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "http://reinink.ca"
+                }
+            ],
+            "description": "Glide adapter for Laravel",
+            "homepage": "http://glide.thephpleague.com",
+            "time": "2015-12-26T15:40:35+00:00"
+        },
+        {
+            "name": "league/glide-symfony",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/glide-symfony.git",
+                "reference": "2dc271c959aa86c060261e2a93c493a54f98efbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/glide-symfony/zipball/2dc271c959aa86c060261e2a93c493a54f98efbb",
+                "reference": "2dc271c959aa86c060261e2a93c493a54f98efbb",
+                "shasum": ""
+            },
+            "require": {
+                "league/glide": "^1.0",
+                "symfony/http-foundation": "^2.3|^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Glide\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "http://reinink.ca"
+                }
+            ],
+            "description": "Glide adapter for Symfony",
+            "homepage": "http://glide.thephpleague.com",
+            "time": "2016-07-01T16:05:08+00:00"
         },
         {
             "name": "league/oauth2-client",

--- a/config/features.php
+++ b/config/features.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Feature Flags
+    |--------------------------------------------------------------------------
+    |
+    | This file is a custom addition to Rogue for storing feature flags, so
+    | features can be conditionally toggled on and off per environment.
+    |
+    */
+
+    'glide' => env('DS_ENABLE_GLIDE'),
+
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,5 +28,6 @@
         <env name="STORAGE_DRIVER" value="public"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_DATABASE" value="rogue_test"/>
+        <env name="DS_ENABLE_GLIDE" value="false"/>
     </php>
 </phpunit>

--- a/tests/Http/Api/ReactionsApiTest.php
+++ b/tests/Http/Api/ReactionsApiTest.php
@@ -37,7 +37,7 @@ class ReactionsApiTest extends TestCase
         ]);
 
         // React (unlike) again to the same post with the same user.
-         $this->withRogueApiKey()->post('api/v2/reactions', [
+        $this->withRogueApiKey()->post('api/v2/reactions', [
             'northstar_id' => $northstarId,
             'post_id' => $post->id,
         ]);


### PR DESCRIPTION
#### What's this PR do?
This pull request adds [Glide](http://glide.thephpleague.com) to allow us to create cropped images for posts on-demand. This removes the need for costly image processing when a user uploads an image, and means we can ask for differently formatted images in different places (perhaps small square images for a gallery, but a larger un-cropped image on a permalink page).

#### How should this be reviewed?
If you pull this branch down to your local and add `DS_ENABLE_GLIDE=true` to your `.env`, you can experiment [with the included filters](http://glide.thephpleague.com/1.0/api/quick-reference/). For example:

```php
'http://rogue.dev/images/1' // default small crop
'http://rogue.dev/images/1?w=500&h=500&fit=crop' // larger square crop
'http://rogue.dev/images/1?w=250&h=400&fit=crop&filt=sepia' // woah, crazy!
```

#### Any background context you want to provide?
When we want to enable this, we can toggle the `DS_ENABLE_GLIDE` feature flag. We'll want to make sure Fastly is properly caching images & do some thorough testing on Thor first.

#### Relevant tickets
[#149661097](https://www.pivotaltracker.com/story/show/149661097)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.