### PR TITLE
Force tests to run with local storage adapter.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,3 @@
-S3_KEY=yourS3Key
-S3_SECRET=yourS3Secret
-S3_BUCKET=yourS3Bucket
-S3_REGION=yourS3Region
-S3_URL=yourS3Url
-
-AWS_ACCESS_KEY_ID=yourAwsAccessKey
-AWS_SECRET_KEY=yourAwsSecret
-AWS_REGION=yourAwsRegion
-
 APP_ENV=local
 APP_KEY=SomeRandomString
 APP_DEBUG=true
@@ -22,9 +12,9 @@ DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 
-CACHE_DRIVER=file
-SESSION_DRIVER=file
-STORAGE_DRIVER=local
+CACHE_DRIVER=redis
+SESSION_DRIVER=redis
+STORAGE_DRIVER=public
 QUEUE_DRIVER=sync
 
 REDIS_HOST=127.0.0.1
@@ -37,6 +27,11 @@ MAIL_PORT=2525
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
+
+S3_KEY=yourS3Key
+S3_SECRET=yourS3Secret
+S3_BUCKET=yourS3Bucket
+S3_URL=yourS3Url
 
 NORTHSTAR_URL=https://northstar-qa.dosomething.org
 NORTHSTAR_AUTH_ID=northstarAuthId

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,7 @@
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
+        <env name="STORAGE_DRIVER" value="public"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_DATABASE" value="rogue_test"/>
     </php>


### PR DESCRIPTION
#### What's this PR do?
This will always override PHPUnit to use the local "public" storage adapter, rather than creating images on our shared S3 bucket.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
References #349.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.