### PR TITLE
List user signups

### DIFF
--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Http\Controllers\Api;
 
-use Rogue\Models\Signup;
 use Illuminate\Http\Request;
 use Rogue\Services\Registrar;
 use Rogue\Services\CampaignService;
@@ -48,6 +47,6 @@ class CampaignsController extends ApiController
 
         $campaigns = $this->campaignService->findAll($ids);
 
-        return $campaigns->toJson();
+        return $campaigns;
     }
 }

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -3,18 +3,10 @@
 namespace Rogue\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
-use Rogue\Services\Registrar;
 use Rogue\Services\CampaignService;
 
 class CampaignsController extends ApiController
 {
-    /**
-     * Registrar instance
-     *
-     * @var Rogue\Services\Registrar
-     */
-    protected $registrar;
-
     /**
      * Phoenix instance
      *
@@ -28,9 +20,8 @@ class CampaignsController extends ApiController
      * @param Rogue\Services\Registrar $registrar
      * @param Rogue\Services\CampaignService $campaignService
      */
-    public function __construct(Registrar $registrar, CampaignService $campaignService)
+    public function __construct(CampaignService $campaignService)
     {
-        $this->registrar = $registrar;
         $this->campaignService = $campaignService;
     }
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rogue\Http\Controllers\Api;
+
+use Rogue\Models\Signup;
+use Illuminate\Http\Request;
+use Rogue\Services\Registrar;
+use Rogue\Services\CampaignService;
+
+class CampaignsController extends ApiController
+{
+    /**
+     * Registrar instance
+     *
+     * @var Rogue\Services\Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Phoenix instance
+     *
+     * @var Rogue\Services\CampaignService
+     */
+    protected $campaignService;
+
+    /**
+     * Constructor
+     *
+     * @param Rogue\Services\Registrar $registrar
+     * @param Rogue\Services\CampaignService $campaignService
+     */
+    public function __construct(Registrar $registrar, CampaignService $campaignService)
+    {
+        $this->registrar = $registrar;
+        $this->campaignService = $campaignService;
+    }
+
+    /**
+     * Retrieve all campaigns
+     */
+    public function index(Request $request)
+    {
+        $ids = [];
+
+        if ($request->query('ids')) {
+            $ids = explode(',', $request->query('ids'));
+        }
+
+        $campaigns = $this->campaignService->findAll($ids);
+
+        return $campaigns;
+    }
+}

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -48,6 +48,6 @@ class CampaignsController extends ApiController
 
         $campaigns = $this->campaignService->findAll($ids);
 
-        return $campaigns;
+        return $campaigns->toJson();
     }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -36,12 +36,17 @@ Route::group(['middleware' => 'web'], function () {
     // Tags
     Route::post('tags', 'TagsController@store');
 
+<<<<<<< HEAD
     // Images
     Route::get('/images/{post}', 'ImagesController@show');
 
     // Users
     Route::get('users', ['as' => 'users.index', 'uses' => 'UsersController@index']);
     Route::get('users/{id}', ['as' => 'users.show', 'uses' => 'UsersController@show']);
+=======
+    // users
+    Route::get('users', 'UsersController@index');
+>>>>>>> Add search bar to users page
     Route::get('search', ['as' => 'users.search', 'uses' => 'UsersController@search']);
 });
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -80,4 +80,7 @@ Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api', 'log.received.r
 
     // tags
     Route::post('tags', 'Api\TagsController@store');
+
+    // Campaigns
+    Route::get('campaigns', 'Api\CampaignsController@index');
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -36,17 +36,12 @@ Route::group(['middleware' => 'web'], function () {
     // Tags
     Route::post('tags', 'TagsController@store');
 
-<<<<<<< HEAD
     // Images
     Route::get('/images/{post}', 'ImagesController@show');
 
     // Users
     Route::get('users', ['as' => 'users.index', 'uses' => 'UsersController@index']);
     Route::get('users/{id}', ['as' => 'users.show', 'uses' => 'UsersController@show']);
-=======
-    // users
-    Route::get('users', 'UsersController@index');
->>>>>>> Add search bar to users page
     Route::get('search', ['as' => 'users.search', 'uses' => 'UsersController@search']);
 });
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -52,7 +52,7 @@ class CampaignService
      * Finds a group of campagins in Rogue/Phoenix.
      *
      * @param  array $ids
-     * @return collection $campaigns|null
+     * @return collection $campaigns
      */
     public function findAll($ids = [])
     {
@@ -77,7 +77,7 @@ class CampaignService
             return collect($campaigns);
         }
 
-        return collect();
+        return collect($this->phoenix->getAllCampaigns());
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -4,6 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+    "hash": "6ff3a84f35c2b480c029fbc012979f7e",
     "content-hash": "fb4ea42677dc6c188903e0b4d881c395",
     "packages": [
         {
@@ -84,7 +85,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-08-14T19:22:37+00:00"
+            "time": "2017-08-14 19:22:37"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -140,7 +141,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-01-18T06:57:07+00:00"
+            "time": "2016-01-18 06:57:07"
         },
         {
             "name": "barryvdh/laravel-debugbar",
@@ -189,7 +190,7 @@
                 "profiler",
                 "webprofiler"
             ],
-            "time": "2017-07-21T11:56:48+00:00"
+            "time": "2017-07-21 11:56:48"
         },
         {
             "name": "classpreloader/classpreloader",
@@ -243,7 +244,7 @@
                 "class",
                 "preload"
             ],
-            "time": "2016-09-16T12:50:15+00:00"
+            "time": "2016-09-16 12:50:15"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -276,7 +277,7 @@
                 "MIT"
             ],
             "description": "implementation of xdg base directory specification for php",
-            "time": "2014-10-24T07:27:01+00:00"
+            "time": "2014-10-24 07:27:01"
         },
         {
             "name": "doctrine/annotations",
@@ -344,7 +345,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-02-24T16:22:25+00:00"
+            "time": "2017-02-24 16:22:25"
         },
         {
             "name": "doctrine/cache",
@@ -414,7 +415,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2017-07-22T12:49:21+00:00"
+            "time": "2017-07-22 12:49:21"
         },
         {
             "name": "doctrine/collections",
@@ -481,7 +482,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2017-01-03T10:49:41+00:00"
+            "time": "2017-01-03 10:49:41"
         },
         {
             "name": "doctrine/common",
@@ -554,7 +555,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2017-07-22T08:35:12+00:00"
+            "time": "2017-07-22 08:35:12"
         },
         {
             "name": "doctrine/dbal",
@@ -625,37 +626,37 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-07-22T20:44:48+00:00"
+            "time": "2017-07-22 20:44:48"
         },
         {
             "name": "doctrine/inflector",
-            "version": "v1.2.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
-                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "4.*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -692,7 +693,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2017-07-22T12:18:28+00:00"
+            "time": "2015-11-06 14:35:42"
         },
         {
             "name": "doctrine/lexer",
@@ -746,7 +747,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "dosomething/gateway",
@@ -796,7 +797,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2017-08-14T19:32:43+00:00"
+            "time": "2017-08-14 19:32:43"
         },
         {
             "name": "giggsey/libphonenumber-for-php",
@@ -858,7 +859,7 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2016-11-23T15:39:02+00:00"
+            "time": "2016-11-23 15:39:02"
         },
         {
             "name": "giggsey/locale",
@@ -907,7 +908,7 @@
                 }
             ],
             "description": "Locale functions required by libphonenumber-for-php",
-            "time": "2017-04-07T18:45:42+00:00"
+            "time": "2017-04-07 18:45:42"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -972,7 +973,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-06-22T18:50:49+00:00"
+            "time": "2017-06-22 18:50:49"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1023,7 +1024,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20T10:07:11+00:00"
+            "time": "2016-12-20 10:07:11"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1088,7 +1089,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2017-03-20 17:10:46"
         },
         {
             "name": "intervention/image",
@@ -1158,7 +1159,7 @@
                 "thumbnail",
                 "watermark"
             ],
-            "time": "2017-07-03T15:50:40+00:00"
+            "time": "2017-07-03 15:50:40"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -1201,7 +1202,7 @@
                     "homepage": "http://www.acci.cz"
                 }
             ],
-            "time": "2014-04-08T15:00:19+00:00"
+            "time": "2014-04-08 15:00:19"
         },
         {
             "name": "jakub-onderka/php-console-highlighter",
@@ -1245,7 +1246,7 @@
                     "homepage": "http://www.acci.cz/"
                 }
             ],
-            "time": "2015-04-20T18:58:01+00:00"
+            "time": "2015-04-20 18:58:01"
         },
         {
             "name": "jeremeamia/SuperClosure",
@@ -1303,7 +1304,7 @@
                 "serialize",
                 "tokenizer"
             ],
-            "time": "2016-12-07T09:37:55+00:00"
+            "time": "2016-12-07 09:37:55"
         },
         {
             "name": "laravel/framework",
@@ -1433,7 +1434,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-08-26T11:44:52+00:00"
+            "time": "2016-08-26 11:44:52"
         },
         {
             "name": "lcobucci/jwt",
@@ -1491,7 +1492,7 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2016-10-31T20:09:32+00:00"
+            "time": "2016-10-31 20:09:32"
         },
         {
             "name": "league/flysystem",
@@ -1574,7 +1575,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-08-06T17:41:04+00:00"
+            "time": "2017-08-06 17:41:04"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -1621,7 +1622,7 @@
                 }
             ],
             "description": "Flysystem adapter for the AWS S3 SDK v3.x",
-            "time": "2017-06-30T06:29:25+00:00"
+            "time": "2017-06-30 06:29:25"
         },
         {
             "name": "league/flysystem-memory",
@@ -1672,7 +1673,7 @@
                 "adapter",
                 "memory"
             ],
-            "time": "2016-06-04T03:57:11+00:00"
+            "time": "2016-06-04 03:57:11"
         },
         {
             "name": "league/fractal",
@@ -1735,7 +1736,7 @@
                 "league",
                 "rest"
             ],
-            "time": "2015-10-07T14:48:58+00:00"
+            "time": "2015-10-07 14:48:58"
         },
         {
             "name": "league/glide",
@@ -1796,7 +1797,7 @@
                 "manipulation",
                 "processing"
             ],
-            "time": "2017-05-09T17:41:49+00:00"
+            "time": "2017-05-09 17:41:49"
         },
         {
             "name": "league/glide-laravel",
@@ -1838,7 +1839,7 @@
             ],
             "description": "Glide adapter for Laravel",
             "homepage": "http://glide.thephpleague.com",
-            "time": "2015-12-26T15:40:35+00:00"
+            "time": "2015-12-26 15:40:35"
         },
         {
             "name": "league/glide-symfony",
@@ -1881,7 +1882,7 @@
             ],
             "description": "Glide adapter for Symfony",
             "homepage": "http://glide.thephpleague.com",
-            "time": "2016-07-01T16:05:08+00:00"
+            "time": "2016-07-01 16:05:08"
         },
         {
             "name": "league/oauth2-client",
@@ -1948,7 +1949,7 @@
                 "oauth2",
                 "single sign on"
             ],
-            "time": "2017-04-25T14:43:14+00:00"
+            "time": "2017-04-25 14:43:14"
         },
         {
             "name": "maknz/slack",
@@ -1997,7 +1998,7 @@
                 "laravel",
                 "slack"
             ],
-            "time": "2015-06-03T03:35:16+00:00"
+            "time": "2015-06-03 03:35:16"
         },
         {
             "name": "maknz/slack-laravel",
@@ -2038,7 +2039,7 @@
                 "laravel",
                 "slack"
             ],
-            "time": "2016-06-25T06:08:23+00:00"
+            "time": "2016-06-25 06:08:23"
         },
         {
             "name": "maximebf/debugbar",
@@ -2099,7 +2100,7 @@
                 "debug",
                 "debugbar"
             ],
-            "time": "2017-01-05T08:46:19+00:00"
+            "time": "2017-01-05 08:46:19"
         },
         {
             "name": "monolog/monolog",
@@ -2177,7 +2178,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-06-19T01:22:40+00:00"
+            "time": "2017-06-19 01:22:40"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -2221,7 +2222,7 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2017-01-23T04:29:33+00:00"
+            "time": "2017-01-23 04:29:33"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -2276,7 +2277,7 @@
                 "json",
                 "jsonpath"
             ],
-            "time": "2016-12-03T22:08:25+00:00"
+            "time": "2016-12-03 22:08:25"
         },
         {
             "name": "nesbot/carbon",
@@ -2329,7 +2330,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16T07:55:07+00:00"
+            "time": "2017-01-16 07:55:07"
         },
         {
             "name": "nikic/php-parser",
@@ -2380,7 +2381,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-09-16T12:04:44+00:00"
+            "time": "2016-09-16 12:04:44"
         },
         {
             "name": "paragonie/random_compat",
@@ -2428,7 +2429,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:22:52+00:00"
+            "time": "2017-03-13 16:22:52"
         },
         {
             "name": "predis/predis",
@@ -2478,7 +2479,7 @@
                 "predis",
                 "redis"
             ],
-            "time": "2016-06-16T16:22:20+00:00"
+            "time": "2016-06-16 16:22:20"
         },
         {
             "name": "psr/http-message",
@@ -2528,7 +2529,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "psr/log",
@@ -2575,7 +2576,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "psy/psysh",
@@ -2647,7 +2648,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2016-03-09T05:03:14+00:00"
+            "time": "2016-03-09 05:03:14"
         },
         {
             "name": "rtconner/laravel-tagging",
@@ -2702,7 +2703,7 @@
                 "tagging",
                 "tags"
             ],
-            "time": "2017-04-28T16:27:45+00:00"
+            "time": "2017-04-28 16:27:45"
         },
         {
             "name": "spatie/db-dumper",
@@ -2752,7 +2753,7 @@
                 "mysqldump",
                 "spatie"
             ],
-            "time": "2016-06-14T13:23:01+00:00"
+            "time": "2016-06-14 13:23:01"
         },
         {
             "name": "spatie/laravel-backup",
@@ -2815,7 +2816,7 @@
                 "laravel-backup",
                 "spatie"
             ],
-            "time": "2017-02-18T09:54:12+00:00"
+            "time": "2017-02-18 09:54:12"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -2869,7 +2870,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2017-05-01T15:54:03+00:00"
+            "time": "2017-05-01 15:54:03"
         },
         {
             "name": "symfony/console",
@@ -2929,7 +2930,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30T07:22:48+00:00"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/debug",
@@ -2986,7 +2987,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30T07:22:48+00:00"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -3049,7 +3050,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-09T14:53:08+00:00"
+            "time": "2017-06-09 14:53:08"
         },
         {
             "name": "symfony/finder",
@@ -3098,7 +3099,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29T05:40:00+00:00"
+            "time": "2016-06-29 05:40:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -3151,7 +3152,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-17T13:54:30+00:00"
+            "time": "2016-07-17 13:54:30"
         },
         {
             "name": "symfony/http-kernel",
@@ -3233,7 +3234,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30T09:10:37+00:00"
+            "time": "2016-07-30 09:10:37"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3292,7 +3293,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T14:24:12+00:00"
+            "time": "2017-06-09 14:24:12"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -3348,7 +3349,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T08:25:21+00:00"
+            "time": "2017-06-09 08:25:21"
         },
         {
             "name": "symfony/polyfill-util",
@@ -3400,7 +3401,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2017-06-09T08:25:21+00:00"
+            "time": "2017-06-09 08:25:21"
         },
         {
             "name": "symfony/process",
@@ -3449,7 +3450,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28T11:13:34+00:00"
+            "time": "2016-07-28 11:13:34"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -3509,7 +3510,7 @@
                 "http-message",
                 "psr-7"
             ],
-            "time": "2016-09-14T18:37:20+00:00"
+            "time": "2016-09-14 18:37:20"
         },
         {
             "name": "symfony/routing",
@@ -3584,7 +3585,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-29T05:40:00+00:00"
+            "time": "2016-06-29 05:40:00"
         },
         {
             "name": "symfony/translation",
@@ -3648,7 +3649,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30T07:22:48+00:00"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/var-dumper",
@@ -3711,7 +3712,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-07-26T08:03:56+00:00"
+            "time": "2016-07-26 08:03:56"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -3761,7 +3762,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2016-09-01T10:05:43+00:00"
+            "time": "2016-09-01 10:05:43"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -3813,7 +3814,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-04-06T16:18:34+00:00"
+            "time": "2017-04-06 16:18:34"
         }
     ],
     "packages-dev": [
@@ -3869,7 +3870,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "fzaninotto/faker",
@@ -3917,7 +3918,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29T12:21:54+00:00"
+            "time": "2016-04-29 12:21:54"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -3962,7 +3963,7 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11T14:41:42+00:00"
+            "time": "2015-05-11 14:41:42"
         },
         {
             "name": "mockery/mockery",
@@ -4027,7 +4028,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-02-28T12:52:32+00:00"
+            "time": "2017-02-28 12:52:32"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4081,7 +4082,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2015-12-27 11:43:31"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -4126,7 +4127,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
+            "time": "2017-08-08 06:39:58"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4173,7 +4174,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "time": "2017-06-03 08:32:36"
         },
         {
             "name": "phpspec/prophecy",
@@ -4236,7 +4237,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-03-02 20:05:34"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4298,7 +4299,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4345,7 +4346,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4386,7 +4387,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -4435,7 +4436,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2017-02-26 11:10:40"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -4484,7 +4485,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-02-27 10:12:30"
         },
         {
             "name": "phpunit/phpunit",
@@ -4556,7 +4557,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2017-06-21 08:07:12"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -4612,7 +4613,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "sebastian/comparator",
@@ -4676,7 +4677,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2017-01-29 09:50:25"
         },
         {
             "name": "sebastian/diff",
@@ -4728,7 +4729,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-05-22 07:24:03"
         },
         {
             "name": "sebastian/environment",
@@ -4778,7 +4779,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
@@ -4845,7 +4846,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2016-06-17 09:04:28"
         },
         {
             "name": "sebastian/global-state",
@@ -4896,7 +4897,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/recursion-context",
@@ -4949,7 +4950,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2016-10-03 07:41:43"
         },
         {
             "name": "sebastian/version",
@@ -4984,7 +4985,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "symfony/css-selector",
@@ -5037,7 +5038,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29T05:40:00+00:00"
+            "time": "2016-06-29 05:40:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -5093,7 +5094,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30T07:22:48+00:00"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/yaml",
@@ -5148,7 +5149,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-23T12:43:26+00:00"
+            "time": "2017-07-23 12:43:26"
         },
         {
             "name": "webmozart/assert",
@@ -5198,7 +5199,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -1,0 +1,176 @@
+# Campaigns
+
+A proxy endpoint for grabbing campaign content from phoenix-ashes. Currently, only supports filtering results by campaign ids.
+
+```
+GET /api/v2/campaigns
+```
+
+Note: Only campaigns with a campaign type of `campaign` are returned (e.g. `sms_game` campaigns [are filtered](https://github.com/DoSomething/LetsDoThis-iOS/issues/813#issuecomment-189545768))
+### Optional Query Parameters
+
+- **ids** _(string|csv)_
+  - Specify the campaign(s) to return
+  - ex: `/campaigns?ids=123,456,789`
+
+Example Response:
+
+```
+[
+    {
+        "id": "1454",
+        "title": "Soldier Statements ",
+        "campaign_runs": {
+            "current": {
+                "en": {
+                    "id": "1856"
+                }
+            },
+            "past": []
+        },
+        "language": {
+            "language_code": "en",
+            "prefix": "us"
+        },
+        "translations": {
+            "original": "en",
+            "en": {
+                "language_code": "en",
+                "prefix": "us"
+            }
+        },
+        "tagline": "Make a sign sharing a soldier's experience in the service.",
+        "status": "active",
+        "type": "campaign",
+        "created_at": "1410195902",
+        "updated_at": "1502734451",
+        "time_commitment": 0,
+        "cover_image": {
+            "default": {
+                "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/images/SoldierStories_hero_square.jpg?itok=IWr6CAl1",
+                "sizes": {
+                    "landscape": {
+                        "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/1440x810/public/images/SoldierStories_hero_landscape2.jpg?itok=YtZzUJmy"
+                    },
+                    "square": {
+                        "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/images/SoldierStories_hero_square.jpg?itok=IWr6CAl1"
+                    }
+                },
+                "type": "image",
+                "dark_background": false
+            },
+            "alternate": null
+        },
+        "staff_pick": false,
+        "competition": false,
+        "facts": {
+            "problem": "America’s soldiers are often isolated when they return home. They’re afraid others won’t understand or will be upset by stories of their experiences in the service.",
+            "solution": "Human connection and social support promotes emotional healing. You can provide that by interviewing a soldier in your life.",
+            "sources": [
+                {
+                    "formatted": "<p>Caplan, Paula J. (2011a). When Johnny and Jane Come Marching Home: How All of Us Can Help Veterans. Cambridge, MA: MIT Press.</p>\n"
+                },
+                {
+                    "formatted": "<p>Watters, Ethan. (2010). The Americanization of mental illness. New York Times \nMagazine. January 8.</p>\n"
+                }
+            ]
+        },
+        "solutions": {
+            "copy": {
+                "raw": "Help a soldier connect by asking them about their time in the service. Work together to create a powerful statement based on your conversation.",
+                "formatted": "<p>Help a soldier connect by asking them about their time in the service. Work together to create a powerful statement based on your conversation.</p>\n"
+            },
+            "support_copy": {
+                "raw": "Cupcake ipsum dolor sit amet chocolate bar chocolate bar\r\n\r\nLemon drops chocolate bar fruitcake lollipop.",
+                "formatted": "<p>Cupcake ipsum dolor sit amet chocolate bar chocolate bar</p>\n\n<p>Lemon drops chocolate bar fruitcake lollipop.</p>\n"
+            }
+        },
+        "pre_step": {
+            "header": "Ask Away!",
+            "copy": {
+                "raw": "Ask the soldier if you can take notes or record the interview. You'll use these stories to create a sign with a one-sentence summary of something the soldier experienced. See the action guide in Stuff You Need for examples.",
+                "formatted": "<p>Ask the soldier if you can take notes or record the interview. You'll use these stories to create a sign with a one-sentence summary of something the soldier experienced. See the action guide in Stuff You Need for examples.</p>\n"
+            }
+        },
+        "latest_news": {
+            "latest_news": null
+        },
+        "causes": {
+            "primary": null,
+            "secondary": null
+        },
+        "action_types": {
+            "primary": null,
+            "secondary": null
+        },
+        "action_guides": [
+            {
+                "id": "1453",
+                "title": "Questions to Avoid",
+                "subtitle": null,
+                "description": "These questions you shouldn't ask",
+                "intro": {
+                    "title": "Questions not to ask: ",
+                    "copy": {
+                        "raw": "Some topics and questions are tough for a soldier or veteran to talk about, so it's best to be aware of what's insensitive or inappropriate.\r\n\r\n**DON'T (under any circumstances) ask:**   \r\n*  Did you kill anyone?    \r\n*  Did any of your friends die?  \r\n*  How could you leave your family?  \r\n*  What's the worst thing that happened to you over there?  \r\n*  Do you have PTSD?   \r\n*  Do you regret serving?",
+                        "formatted": "<p>Some topics and questions are tough for a soldier or veteran to talk about, so it's best to be aware of what's insensitive or inappropriate.</p>\n\n<p><strong>DON'T (under any circumstances) ask:</strong><br />\n*  Did you kill anyone?<br />\n*  Did any of your friends die?<br />\n*  How could you leave your family?<br />\n*  What's the worst thing that happened to you over there?<br />\n*  Do you have PTSD?<br />\n*  Do you regret serving?</p>\n"
+                    }
+                },
+                "additional_text": {
+                    "title": null,
+                    "copy": {
+                        "raw": "  ",
+                        "formatted": ""
+                    }
+                },
+                "created_at": "1410195851",
+                "updated_at": "1445888544"
+            }
+        ],
+        "attachments": [],
+        "issue": null,
+        "tags": [
+            {
+                "id": "667",
+                "name": "hot"
+            }
+        ],
+        "timing": {
+            "high_season": null,
+            "low_season": null
+        },
+        "services": {
+            "mobile_commons": {
+                "opt_in_path_id": null,
+                "friends_opt_in_path_id": null
+            },
+            "mailchimp": {
+                "grouping_id": null,
+                "group_name": null
+            }
+        },
+        "affiliates": {
+            "partners": [
+                {
+                    "name": "Amex",
+                    "sponsor": true,
+                    "copy": null,
+                    "uri": null,
+                    "media": {
+                        "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/wmax-423px/public/partners/AXP_2C_grad.gif?itok=qS2Fz62q",
+                        "type": "image"
+                    }
+                }
+            ]
+        },
+        "reportback_info": {
+            "copy": "Let's see a pic of your soldier or veteran with their Soldier Statement! ",
+            "confirmation_message": "Nice! Thank you for reaching out to our service members.",
+            "noun": "Soldiers",
+            "verb": "Interviewed"
+        },
+        "uri": "http://dev.dosomething.org:8888/api/v1/campaigns/1454",
+        "magic_link_copy": null
+    }
+]
+```

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -2,11 +2,13 @@ import React from 'react';
 import { map } from 'lodash';
 // @TODO - InboxTile should be a higher level component now that we are using it elsewhere.
 import InboxTile from '../InboxItem/InboxTile';
+import { RestApiClient } from '@dosomething/gateway';
 import { extractPostsFromSignups } from '../../helpers';
 
 class SignupCard extends React.Component {
   render() {
     const signup = this.props.signup;
+    const campaign = this.props.campaign;
 
     const posts = map(signup.posts.data, (post, index) => {
       return <InboxTile key={index} details={post} />;
@@ -16,7 +18,7 @@ class SignupCard extends React.Component {
         <article className="container__row signup-card">
           <div className="container__block -half">
             <div className="container__row">
-              <h2 className="heading">{signup.campaign_id}</h2>
+              <h2 className="heading">{campaign ? campaign.title : signup.campaign_id}</h2>
             </div>
             <div className="container__row">
               <h4 className="heading">Why Statement</h4>
@@ -30,7 +32,7 @@ class SignupCard extends React.Component {
                   <div className="quantity">{signup.quantity}</div>
                 </div>
                 <div className="figure__body">
-                   rb noun verb
+                   {campaign ? `${campaign.reportback_info.noun} ${campaign.reportback_info.verb}` : '' }
                 </div>
               </div>
             : null }

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -10,7 +10,7 @@ class SignupCard extends React.Component {
   render() {
     const signup = this.props.signup;
     const campaign = this.props.campaign;
-    const gallerySize = this.props.gallerySize;
+    const gallerySize = 4;
 
     const extraPostCount = signup.posts.data.length - gallerySize;
 
@@ -36,14 +36,14 @@ class SignupCard extends React.Component {
                   <div className="quantity">{signup.quantity}</div>
                 </div>
                 <div className="figure__body">
-                   {campaign ? `${campaign.reportback_info.noun} ${campaign.reportback_info.verb}` : '' }
+                   <h4 className="reportback-noun-verb">{campaign ? `${campaign.reportback_info.noun} ${campaign.reportback_info.verb}` : '' }</h4>
                 </div>
               </div>
             : null }
             {posts.length ?
               <div className="container__row">
                 <h4>Items</h4>
-                <ul className="gallery -quintet">
+                <ul className="gallery">
                   {posts}
                   {extraPostCount > 0 ?
                     <li className="figure__media">

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class SignupCard extends React.Component {
+  render() {
+    const signup = this.props.signup;
+
+    return (
+      <div className="container__block">
+        <h2>{signup.campaign_id}</h2>
+      </div>
+    )
+  }
+}
+
+export default SignupCard;

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { map } from 'lodash';
+import './signup-card.scss';
 // @TODO - InboxTile should be a higher level component now that we are using it elsewhere.
 import InboxTile from '../InboxItem/InboxTile';
 import { RestApiClient } from '@dosomething/gateway';
@@ -9,17 +10,16 @@ class SignupCard extends React.Component {
   render() {
     const signup = this.props.signup;
     const campaign = this.props.campaign;
+    const gallerySize = this.props.gallerySize;
 
-    const borderStyle = {
-      border: '1px solid #ddd',
-    };
+    const extraPostCount = signup.posts.data.length - gallerySize;
 
-    const posts = map(signup.posts.data, (post, index) => {
+    const posts = signup.posts.data.slice(0, gallerySize).map((post, index) => {
       return <InboxTile key={index} details={post} />;
     });
 
     return (
-        <article className="container__row signup-card" style={borderStyle}>
+        <article className="container__row signup-card">
           <div className="container__block -half">
             <div className="container__row">
               <h2 className="heading">{campaign ? campaign.title : signup.campaign_id}</h2>
@@ -40,10 +40,19 @@ class SignupCard extends React.Component {
                 </div>
               </div>
             : null }
-            <div className="container__row">
-              <h4>Items</h4>
-              <ul className="gallery -quartet">{posts}</ul>
-            </div>
+            {posts.length ?
+              <div className="container__row">
+                <h4>Items</h4>
+                <ul className="gallery -quintet">
+                  {posts}
+                  {extraPostCount > 0 ?
+                    <li className="figure__media">
+                      <div className="quantity">+{extraPostCount}</div>
+                    </li>
+                  : null}
+                </ul>
+              </div>
+            : null }
           </div>
         </article>
     )

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -10,12 +10,16 @@ class SignupCard extends React.Component {
     const signup = this.props.signup;
     const campaign = this.props.campaign;
 
+    const borderStyle = {
+      border: '1px solid #ddd',
+    };
+
     const posts = map(signup.posts.data, (post, index) => {
       return <InboxTile key={index} details={post} />;
     });
 
     return (
-        <article className="container__row signup-card">
+        <article className="container__row signup-card" style={borderStyle}>
           <div className="container__block -half">
             <div className="container__row">
               <h2 className="heading">{campaign ? campaign.title : signup.campaign_id}</h2>

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -1,13 +1,45 @@
 import React from 'react';
+import { map } from 'lodash';
+// @TODO - InboxTile should be a higher level component now that we are using it elsewhere.
+import InboxTile from '../InboxItem/InboxTile';
+import { extractPostsFromSignups } from '../../helpers';
 
 class SignupCard extends React.Component {
   render() {
     const signup = this.props.signup;
 
+    const posts = map(signup.posts.data, (post, index) => {
+      return <InboxTile key={index} details={post} />;
+    });
+
     return (
-      <div className="container__block">
-        <h2>{signup.campaign_id}</h2>
-      </div>
+        <article className="container__row signup-card">
+          <div className="container__block -half">
+            <div className="container__row">
+              <h2 className="heading">{signup.campaign_id}</h2>
+            </div>
+            <div className="container__row">
+              <h4 className="heading">Why Statement</h4>
+              <p>{signup.why_participated}</p>
+            </div>
+          </div>
+          <div className="container__block -half">
+            { signup.quantity ?
+              <div className="container__row figure -left -center">
+                <div className="figure__media">
+                  <div className="quantity">{signup.quantity}</div>
+                </div>
+                <div className="figure__body">
+                   rb noun verb
+                </div>
+              </div>
+            : null }
+            <div className="container__row">
+              <h4>Items</h4>
+              <ul className="gallery -quartet">{posts}</ul>
+            </div>
+          </div>
+        </article>
     )
   }
 }

--- a/resources/assets/components/SignupCard/signup-card.scss
+++ b/resources/assets/components/SignupCard/signup-card.scss
@@ -1,9 +1,5 @@
 @import '~@dosomething/forge/scss/toolkit';
 
-$tablet: "(min-width: 760px)" !default;
-$base-spacing: 24px !default;
-$light-gray: #ddd !default;
-
 .signup-card {
   border: 2px solid $light-gray;
 

--- a/resources/assets/components/SignupCard/signup-card.scss
+++ b/resources/assets/components/SignupCard/signup-card.scss
@@ -1,0 +1,34 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+$tablet: "(min-width: 760px)" !default;
+$base-spacing: 24px !default;
+$light-gray: #ddd !default;
+
+.signup-card {
+  border: 2px solid $light-gray;
+
+  .gallery {
+    @include clearfix;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    > li {
+      margin: gutter() 0;
+      padding: 0 gutter();
+      overflow: hidden;
+    }
+
+    &.-quintet {
+      > li {
+        @include media($tablet) {
+          @include span(3 of 15);
+
+          &:nth-of-type(5n + 1) {
+            clear: both;
+          }
+        }
+      }
+    }
+  }
+}

--- a/resources/assets/components/SignupCard/signup-card.scss
+++ b/resources/assets/components/SignupCard/signup-card.scss
@@ -7,6 +7,10 @@ $light-gray: #ddd !default;
 .signup-card {
   border: 2px solid $light-gray;
 
+  .reportback-noun-verb {
+    color: $purple;
+  }
+
   .gallery {
     @include clearfix;
     list-style-type: none;
@@ -17,16 +21,16 @@ $light-gray: #ddd !default;
       margin: gutter() 0;
       padding: 0 gutter();
       overflow: hidden;
-    }
 
-    &.-quintet {
-      > li {
-        @include media($tablet) {
-          @include span(3 of 15);
+      @include media($tablet) {
+        @include span(3 of 15);
 
-          &:nth-of-type(5n + 1) {
-            clear: both;
-          }
+        &:first-child {
+          padding-left: 0px;
+        }
+
+        &:nth-of-type(5n + 1) {
+          clear: both;
         }
       }
     }

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -15,6 +15,7 @@ class UserOverview extends React.Component {
 
   componentDidMount() {
     this.getUserSignups(this.props.user.id);
+    this.getCampaigns([]);
   }
 
   /**
@@ -30,6 +31,20 @@ class UserOverview extends React.Component {
       }
     }).then(json => this.setState({
       signups: json.data
+    }));
+  }
+
+  /**
+   * Gets campaigns associated with signups.
+   *
+   * @param {Array} ids
+   * @return {Object}
+   */
+  getCampaigns(ids) {
+    this.api.get('api/v2/campaigns', {
+      ids: "1454,1424"
+    }).then(json => this.setState({
+      campaigns: json
     }));
   }
 

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -83,7 +83,7 @@ class UserOverview extends React.Component {
         <div className="container__block">
           {this.state.campaigns ?
             map(this.state.signups, (signup, index) => {
-              return <SignupCard key={index} signup={signup} campaign={this.state.campaigns[signup.campaign_id]}/>;
+              return <SignupCard key={index} signup={signup} campaign={this.state.campaigns[signup.campaign_id]} gallerySize={4} />;
             })
           : <div className="spinner"></div> }
         </div>

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -83,7 +83,7 @@ class UserOverview extends React.Component {
         <div className="container__block">
           {this.state.campaigns ?
             map(this.state.signups, (signup, index) => {
-              return <SignupCard key={index} signup={signup} campaign={this.state.campaigns[signup.campaign_id]} gallerySize={4} />;
+              return <SignupCard key={index} signup={signup} campaign={this.state.campaigns[signup.campaign_id]} />;
             })
           : <div className="spinner"></div> }
         </div>

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { map } from 'lodash';
+import { map, keyBy } from 'lodash';
 import SignupCard from '../SignupCard';
 import { RestApiClient } from '@dosomething/gateway';
 import { calculateAge, displayName, displayCityState } from '../../helpers';
@@ -47,7 +47,7 @@ class UserOverview extends React.Component {
     this.api.get('api/v2/campaigns', {
       ids: ids.join()
     }).then(json => this.setState({
-      campaigns: json
+      campaigns: keyBy(json, 'id'),
     }));
   }
 
@@ -55,10 +55,6 @@ class UserOverview extends React.Component {
     const user = this.props.user;
     const cityState = displayCityState(user.addr_city, user.addr_state);
     const name = displayName(user.first_name, user.last_name);
-
-    const signupCards = map(this.state.signups, (signup, index) => {
-      return <SignupCard key={index} signup={signup} />;
-    });
 
     return (
       <div>
@@ -85,7 +81,11 @@ class UserOverview extends React.Component {
         </div>
 
         <div className="container__block">
-          {signupCards}
+          {this.state.campaigns ?
+            map(this.state.signups, (signup, index) => {
+              return <SignupCard key={index} signup={signup} campaign={this.state.campaigns[signup.campaign_id]}/>;
+            })
+          : <div className="spinner"></div> }
         </div>
       </div>
     )

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { map } from 'lodash';
+import SignupCard from '../SignupCard';
 import { RestApiClient } from '@dosomething/gateway';
 import { calculateAge, displayName, displayCityState } from '../../helpers';
 
@@ -36,6 +38,10 @@ class UserOverview extends React.Component {
     const cityState = displayCityState(user.addr_city, user.addr_state);
     const name = displayName(user.first_name, user.last_name);
 
+    const signupCards = map(this.state.signups, (signup, index) => {
+      return <SignupCard key={index} signup={signup} />;
+    });
+
     return (
       <div>
         <div className="container__block">
@@ -58,6 +64,10 @@ class UserOverview extends React.Component {
         </div>
         <div className="container__block">
           <h2 className="heading -emphasized -padded"><span>Campaigns</span></h2>
+        </div>
+
+        <div className="container__block">
+          {signupCards}
         </div>
       </div>
     )

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -14,8 +14,7 @@ class UserOverview extends React.Component {
   }
 
   componentDidMount() {
-    this.getUserSignups(this.props.user.id);
-    this.getCampaigns([]);
+    this.getUserActivity(this.props.user.id);
   }
 
   /**
@@ -24,13 +23,17 @@ class UserOverview extends React.Component {
    * @param {String} id
    * @return {Object}
    */
-  getUserSignups(id) {
+  getUserActivity(id) {
     this.api.get('api/v2/activity', {
       filter: {
         northstar_id: id,
       }
     }).then(json => this.setState({
       signups: json.data
+    }, () => {
+      // After we grab the signups, get the campaign objects for each signup.
+      const ids = map(this.state.signups, 'campaign_id');
+      this.getCampaigns(ids);
     }));
   }
 
@@ -42,7 +45,7 @@ class UserOverview extends React.Component {
    */
   getCampaigns(ids) {
     this.api.get('api/v2/campaigns', {
-      ids: "1454,1424"
+      ids: ids.join()
     }).then(json => this.setState({
       campaigns: json
     }));

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -1,7 +1,36 @@
 import React from 'react';
+import { RestApiClient } from '@dosomething/gateway';
 import { calculateAge, displayName, displayCityState } from '../../helpers';
 
 class UserOverview extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {},
+
+    this.api = new RestApiClient;
+  }
+
+  componentDidMount() {
+    this.getUserSignups(this.props.user.id);
+  }
+
+  /**
+   * Gets the user activity for the specified user and update state.
+   *
+   * @param {String} id
+   * @return {Object}
+   */
+  getUserSignups(id) {
+    this.api.get('api/v2/activity', {
+      filter: {
+        northstar_id: id,
+      }
+    }).then(json => this.setState({
+      signups: json.data
+    }));
+  }
+
   render() {
     const user = this.props.user;
     const cityState = displayCityState(user.addr_city, user.addr_state);
@@ -26,6 +55,9 @@ class UserOverview extends React.Component {
             <span>Source: {user.source}<br/></span>
             <span>Northstar ID: {user.id}<br/></span>
           </p>
+        </div>
+        <div className="container__block">
+          <h2 className="heading -emphasized -padded"><span>Campaigns</span></h2>
         </div>
       </div>
     )

--- a/resources/views/search/search.blade.php
+++ b/resources/views/search/search.blade.php
@@ -3,12 +3,8 @@
         {{ csrf_field() }}
 
         <li>
-<<<<<<< HEAD
             {{-- @NOTE: The inline-style here is just temporary for now. We should look into this possibly being a react component. --}}
             <input class="text-field -search" type="text" name="query" placeholder="Search by email, mobile, Northstar ID..." style="min-width: 400px;" />
-=======
-            <input class="text-field -search" type="text" name="query" placeholder="Search"  />
->>>>>>> Add search bar to users page
         </li>
 
         <li>

--- a/resources/views/search/search.blade.php
+++ b/resources/views/search/search.blade.php
@@ -3,8 +3,12 @@
         {{ csrf_field() }}
 
         <li>
+<<<<<<< HEAD
             {{-- @NOTE: The inline-style here is just temporary for now. We should look into this possibly being a react component. --}}
             <input class="text-field -search" type="text" name="query" placeholder="Search by email, mobile, Northstar ID..." style="min-width: 400px;" />
+=======
+            <input class="text-field -search" type="text" name="query" placeholder="Search"  />
+>>>>>>> Add search bar to users page
         </li>
 
         <li>

--- a/resources/views/users/partials/_table_users.blade.php
+++ b/resources/views/users/partials/_table_users.blade.php
@@ -14,7 +14,7 @@
                 <tbody>
                     @foreach ($users as $user)
                         <tr class="table__row">
-                            <td class="table__cell"><a href="#">{{ $user->first_name or 'Anonymous' }} {{ $user->last_name or '' }}</a></td>
+                            <td class="table__cell"><a href={{ "/users/" . $user->id }}>{{ $user->first_name or 'Anonymous' }} {{ $user->last_name or '' }}</a></td>
                             <td class="table__cell">{{ $user->email or ''}}</td>
                             <td class="table__cell">{{ $user->mobile or ''}}</td>
                         </tr>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.master')
 
 @section('main_content')
-
     @include('layouts.header', ['header' => 'User', 'subtitle' => ''])
 
     <div class="container -padded">
@@ -9,5 +8,4 @@
             Loading...
         </div>
     </div>
-
 @stop

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rogue\Models\User;
+use Rogue\Services\Phoenix;
 use DoSomething\Gateway\Northstar;
 
 class UserTest extends TestCase
@@ -10,6 +11,10 @@ class UserTest extends TestCase
      */
     public function testAuthenticatedUserDoesntGetRedirectedHome()
     {
+        $this->mock(Phoenix::class)
+            ->shouldReceive('getAllCampaigns')
+            ->andReturn(collect());
+
         $this->actingAsAdmin()
             ->visit('/campaigns');
 


### PR DESCRIPTION
#### What's this PR do?
This PR flushes out the User page showing all of a users signups. 

* Implements layout, style, and functionality for a `SignupCard` component that show info for each signup. 
  - One thing to note: we grab the campaigns for each signup after the signups have been set on the state. We don't render signups on the page until everything is available, in the meantime we display a spinner indicating we are grabbing data.
* Creates a proxy endpoint at `/api/v2/campaigns` that grabs campaign info from the phoenix api 

![image](https://user-images.githubusercontent.com/1700409/29322631-2b8b0adc-81ac-11e7-8fb5-d9706214e37d.png)

#### How should this be reviewed?

I think i messed up a lot of the commit history when rebasing since I started this branch off of a branch that wasn't merged in yet. 

Best bet is to pull down this branch and test that you can load a user page and see data on the page. 

Most of the code for the layout and functionality is in `UserOverview/index.js` and `Api/CampaignsController.php`

Styling work is done in `signup-card.scss`

#### Any background context you want to provide?

Part 2 of user search work. 

#### Relevant tickets

https://www.pivotaltracker.com/story/show/150173773

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.