### PR TITLE
Add Tag model, relationship with posts, table and pivot table

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -75,6 +75,14 @@ class Post extends Model
     }
 
     /**
+     * Get the tags associated with this post.
+     */
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+
+    /**
      * Get the URL for the media for this post.
      */
     public function getMediaUrl()

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rogue\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    //
+}

--- a/database/migrations/2017_08_15_150325_create_tags_and_post_tag_tables.php
+++ b/database/migrations/2017_08_15_150325_create_tags_and_post_tag_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTagsAndPostTagTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id')->comment('Primary key.');
+            $table->string('tag_name');
+            $table->string('tag_slug');
+            $table->timestamps();
+        });
+
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->integer('post_id');
+            $table->integer('tag_id');
+            $table->primary(['post_id', 'tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            Schema::drop('tags');
+        });
+
+        Schema::table('post_tag', function (Blueprint $table) {
+            Schema::drop('post_tag');
+        });
+    }
+}

--- a/database/migrations/2017_08_15_150325_create_tags_and_post_tag_tables.php
+++ b/database/migrations/2017_08_15_150325_create_tags_and_post_tag_tables.php
@@ -23,6 +23,7 @@ class CreateTagsAndPostTagTables extends Migration
             $table->integer('post_id');
             $table->integer('tag_id');
             $table->primary(['post_id', 'tag_id']);
+            $table->timestamps();
         });
     }
 


### PR DESCRIPTION
#### What's this PR do?
This adds new things, but doesn't change how anything works currently.

Added:
- Tag model
- Database migration to add tags table and pivot table with posts. Includes timestamps only on the Tags table and not on the pivot table. On the current tagging tables (`tagging_tagged`, `tagging_tags`) we do not have timestamps either.
- Posts relationship with Tag model

#### How should this be reviewed?
Where do we want timestamps? Nowhere? Both tables?

#### Any background context you want to provide?
Background discussion can be found in this issue: https://github.com/DoSomething/rogue/issues/353.

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/150239872)

#### Checklist
- [ ] Tested on staging.