### PR TITLE
Fix issue where extra '/' was added to URL.

### DIFF
--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -37,7 +37,7 @@ class AWS
 
         // Add a unique timestamp (e.g. uploads/folder/filename-1456498664.jpeg) to
         // uploads to prevent AWS cache giving the user an old upload.
-        $path = '/uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
+        $path = 'uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
 
         // Push file to S3.
         $success = Storage::put($path, $data);
@@ -65,7 +65,7 @@ class AWS
             throw new UnprocessableEntityHttpException('Invalid file type. Upload a JPEG, PNG or GIF.');
         }
 
-        $path = '/uploads/reportback-items/' . $filename . '.' . $extension;
+        $path = 'uploads/reportback-items/' . $filename . '.' . $extension;
 
         // Push file to S3.
         $success = Storage::put($path, $data);


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue where we were storing file URLs with an extra `/` in them, since c9bece96fbaff284da37a8f789491d9c2e0c13f2 got deployed earlier today.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
We can fix the (relatively few) affected database records by hand. Images were still saved correctly.

#### Relevant tickets
Fixes N/A.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.