### PR TITLE
Update post on campaign single page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /vendor
 /node_modules
 /public/storage
-/storage/debugar
+/storage/debugbar
 Homestead.yaml
 Homestead.json
 .env

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -163,7 +163,7 @@ class CampaignInbox extends React.Component {
           { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} post={post} campaign={campaign} signup={this.state.signups[post.signup_id]} />) }
 
           <ModalContainer>
-            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} post={posts[this.state.historyModalId]} campaign={campaign} signup={this.state.signups}/> : null}
+            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} post={posts[this.state.historyModalId]} campaign={campaign} signups={this.state.signups}/> : null}
           </ModalContainer>
         </div>
       )

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -84,9 +84,6 @@ class CampaignInbox extends React.Component {
 
         newState.posts[postId] = result['data'];
 
-        // Keep the user from the initial page load.
-        newState.posts[postId].user = user;
-
         return newState;
       });
     });

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -60,7 +60,6 @@ class CampaignInbox extends React.Component {
     request.then((result) => {
       this.setState((previousState) => {
         const newState = {...previousState};
-
         newState.posts[postId].status = fields.status;
 
         return newState;

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -163,7 +163,7 @@ class CampaignInbox extends React.Component {
           { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} post={post} campaign={campaign} signup={this.state.signups[post.signup_id]} />) }
 
           <ModalContainer>
-            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups }}/> : null}
+            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} post={posts[this.state.historyModalId]} campaign={campaign} signup={this.state.signups}/> : null}
           </ModalContainer>
         </div>
       )

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -75,8 +75,9 @@ class CampaignSingle extends React.Component {
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
-
-        newState.signups[signup.id].quantity = result.quantity;
+        var signupId = signup.signup_id ? signup.signup_id : signup.id;
+        var firstPostId = Object.keys(newState.posts)[0];
+        newState.posts[firstPostId].signup.data.quantity = result.quantity;
 
         return newState;
       });
@@ -118,7 +119,6 @@ class CampaignSingle extends React.Component {
         const user = newState.posts[postId].user;
         const signup = newState.posts[postId].signup.data;
 
-        console.log(newState);
         newState.posts[postId] = result['data'];
 
         // Keep the user and signup from the initial page load.
@@ -189,7 +189,7 @@ class CampaignSingle extends React.Component {
         { map(posts, (post, key) => post.status === this.state.filter ? <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} post={post} campaign={campaign} signup={post.signup.data} /> : null) }
 
         <ModalContainer>
-            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups}}/> : null}
+            {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} post={posts[this.state.historyModalId]} campaign={campaign} signup={posts[this.state.historyModalId].signup.data}/> : null}
         </ModalContainer>
 
         <PagingButtons prev={this.state.prevPage} next={this.state.nextPage}></PagingButtons>

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -75,7 +75,8 @@ class CampaignSingle extends React.Component {
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
-        var signupId = signup.signup_id ? signup.signup_id : signup.id;
+                console.log(newState);
+
         var firstPostId = Object.keys(newState.posts)[0];
         newState.posts[firstPostId].signup.data.quantity = result.quantity;
 
@@ -96,7 +97,6 @@ class CampaignSingle extends React.Component {
     request.then((result) => {
       this.setState((previousState) => {
         const newState = {...previousState};
-
         newState.posts[postId].status = fields.status;
 
         return newState;
@@ -113,17 +113,24 @@ class CampaignSingle extends React.Component {
     };
 
     let response = this.api.post('tags', fields);
+
     response.then((result) => {
       this.setState((previousState) => {
         const newState = {...previousState};
+
         const user = newState.posts[postId].user;
+
         const signup = newState.posts[postId].signup.data;
 
-        newState.posts[postId] = result['data'];
+        // Merge existing post with the newly updated values from API.
+        newState.posts[postId] = {
+          ...newState.posts[postId],
+          ...result['data']
+        };
 
         // Keep the user and signup from the initial page load.
         newState.posts[postId].user = user;
-        // newState.posts[postId].signup.data = signup;
+
 
         return newState;
       });

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -75,7 +75,6 @@ class CampaignSingle extends React.Component {
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
-                console.log(newState);
 
         var firstPostId = Object.keys(newState.posts)[0];
         newState.posts[firstPostId].signup.data.quantity = result.quantity;
@@ -117,9 +116,7 @@ class CampaignSingle extends React.Component {
     response.then((result) => {
       this.setState((previousState) => {
         const newState = {...previousState};
-
         const user = newState.posts[postId].user;
-
         const signup = newState.posts[postId].signup.data;
 
         // Merge existing post with the newly updated values from API.
@@ -127,10 +124,6 @@ class CampaignSingle extends React.Component {
           ...newState.posts[postId],
           ...result['data']
         };
-
-        // Keep the user and signup from the initial page load.
-        newState.posts[postId].user = user;
-
 
         return newState;
       });

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -16,9 +16,9 @@ class HistoryModal extends React.Component {
 	}
 
 	render() {
-  	const post = this.props.details['post'];
-  	const signup = this.props.details.signups[post.signup_id];
-  	const campaign = this.props.details['campaign'];
+  	const post = this.props['post'];
+  	const signup = this.props.signup;
+  	const campaign = this.props['campaign'];
 
 		return (
 			<div className="modal">

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -17,7 +17,7 @@ class HistoryModal extends React.Component {
 
 	render() {
   	const post = this.props['post'];
-  	const signup = this.props.signup;
+  	const signup = this.props.signup ? this.props.signup : this.props.signups[post.signup_id];
   	const campaign = this.props['campaign'];
 
 		return (


### PR DESCRIPTION
#### What's this PR do?
- Allows reviewing (change quantity, tags, and status) of posts on the campaign single view page. 

#### How should this be reviewed?
- Visit campaign single view page. You should now be able to update any post on this page exactly how you're able to in the campaign inbox page. 

#### Any background context you want to provide?
- Note: there are some duplicate functions from CampaignInbox `index.js` in Campaign Single `index.js` (`deletePost`, `updatePost`), and some that are almost the same but slightly tweaked because of the different states on the different pages (`updateQuantity`, `updateTag`). Once we update the CampaignInbox `index.js` to initally load all posts via API similar to the Campaign Single `index.js` view, we should update and combine these functions to live in one place for DRY code. 
- When a post is rejected and you change it to accepted, the post will immediately disappear since it's no longer under the `rejected` filter view. You won't have time to add tags to it unfortunately. Is this ok? cc @ngjo 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/150143243

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.