### PR TITLE
Save campaigns in cache with prefix in ID

### DIFF
--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -9,9 +9,9 @@ class CacheRepository
     /**
      * Instantiate a new CacheRepository.
      */
-    public function __construct()
+    public function __construct($prefix)
     {
-        $this->prefix = 'campaign';
+        $this->prefix = $prefix;
     }
 
     /**

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -60,7 +60,7 @@ class CacheRepository
      * @param  string  $string
      * @return string
      */
-    public function applyPrefix($string)
+    protected function applyPrefix($string)
     {
         if (property_exists($this, 'prefix')) {
             return $this->prefix . ':' . $string;

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -37,7 +37,7 @@ class CacheRepository
         $idsWithPrefix = [];
 
         foreach ($keys as $key => $id) {
-            array_push($idsWithPrefix, $this->setPrefix($id));
+            array_push($idsWithPrefix, $this->applyPrefix($id));
         }
 
         $retrieved = [];
@@ -55,12 +55,12 @@ class CacheRepository
     }
 
     /**
-     * Set a prefix on supplied string used as cache key.
+     * Apply a prefix on supplied string used as cache key.
      *
      * @param  string  $string
      * @return string
      */
-    public function setPrefix($string)
+    public function applyPrefix($string)
     {
         if (property_exists($this, 'prefix')) {
             return $this->prefix . ':' . $string;
@@ -92,7 +92,7 @@ class CacheRepository
     public function storeMany(array $values, $minutes = 15)
     {
         foreach ($values as $key => $value) {
-            $keyWithPrefix = $this->setPrefix($key);
+            $keyWithPrefix = $this->applyPrefix($key);
             $values[$keyWithPrefix] = $values[$key];
             unset($values[$key]);
         }

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -22,6 +22,8 @@ class CacheRepository
      */
     public function retrieve($key)
     {
+        $key = $this->applyPrefix($key);
+
         return Cache::get($key);
     }
 
@@ -79,6 +81,8 @@ class CacheRepository
      */
     public function store($key, $value, $minutes = 15)
     {
+        $key = $this->applyPrefix($key);
+
         Cache::put($key, $value, $minutes);
     }
 

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -34,16 +34,21 @@ class CacheRepository
      */
     public function retrieveMany(array $keys)
     {
+        $idsWithPrefix = [];
+
+        foreach ($keys as $key => $id) {
+            array_push($idsWithPrefix, $this->setPrefix($id));
+        }
+
         $retrieved = [];
 
-        $data = Cache::many($keys);
+        $data = Cache::many($idsWithPrefix);
 
         foreach ($data as $item) {
             if ($item) {
                 $retrieved[] = $item;
             }
         }
-
         if (count($retrieved)) {
             return $data;
         }
@@ -86,6 +91,12 @@ class CacheRepository
      */
     public function storeMany(array $values, $minutes = 15)
     {
+        foreach ($values as $key => $value) {
+            $keyWithPrefix = $this->setPrefix($key);
+            $values[$keyWithPrefix] = $values[$key];
+            unset($values[$key]);
+        }
+
         Cache::putMany($values, $minutes);
     }
 

--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -7,6 +7,14 @@ use Illuminate\Support\Facades\Cache;
 class CacheRepository
 {
     /**
+     * Instantiate a new CacheRepository.
+     */
+    public function __construct()
+    {
+        $this->prefix = 'campaign';
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -42,7 +42,6 @@ class CampaignService
     public function find($id)
     {
         $campaign = $this->cache->retrieve($id);
-
         if (! $campaign) {
             $campaign = $this->phoenix->getCampaign($id);
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -25,12 +25,11 @@ class CampaignService
      * Create new Registrar instance.
      *
      * @param Phoenix $phoenix
-     * @param CacheRepository $cache
      */
-    public function __construct(Phoenix $phoenix, CacheRepository $cache)
+    public function __construct(Phoenix $phoenix)
     {
         $this->phoenix = $phoenix;
-        $this->cache = $cache;
+        $this->cache = new CacheRepository('campaign');
     }
 
     /**

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -79,8 +79,10 @@ class CampaignService
                 $campaigns = $this->resolveMissingCampaigns($campaigns);
                 $campaigns = collect(array_values($campaigns));
             }
+
             return collect($campaigns);
         }
+
         return collect($this->phoenix->getAllCampaigns());
     }
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -64,13 +64,7 @@ class CampaignService
     public function findAll($ids = [])
     {
         if ($ids) {
-            $idsWithPrefix = [];
-
-            foreach ($ids as $key => $id) {
-                array_push($idsWithPrefix, $this->cache->setPrefix($id));
-            }
-
-            $campaigns = $this->cache->retrieveMany($idsWithPrefix);
+            $campaigns = $this->cache->retrieveMany($ids);
 
             if (! $campaigns) {
                 $campaigns = $this->getBatchedCollection($ids);
@@ -78,11 +72,6 @@ class CampaignService
                 if (count($campaigns)) {
                     $group = $campaigns->keyBy('id')->all();
 
-                    foreach ($group as $key => $value) {
-                        $keyWithPrefix = $this->cache->setPrefix($key);
-                        $group[$keyWithPrefix] = $group[$key];
-                        unset($group[$key]);
-                    }
                     // Cache campaigns for a day.
                     $this->cache->storeMany($group, 1440);
                 }

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -11,12 +11,11 @@ class Registrar
      * Create new Registrar instance.
      *
      * @param Northstar $northstar
-     * @param CacheRepository $cache
      */
-    public function __construct(Northstar $northstar, CacheRepository $cache)
+    public function __construct(Northstar $northstar)
     {
         $this->northstar = $northstar;
-        $this->cache = $cache;
+        $this->cache = new CacheRepository('user');
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7067900ccbd3bbbfccde45d6bfbe2160",
+    "content-hash": "ac61c720a87d4b0742aa2957c7c0bdad",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.33.2",
+            "version": "3.33.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "027bf2f1489bc6af98cb81494f0612d1f405ff27"
+                "reference": "2820644f411fa261f126727c1c00de15227b9520"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/027bf2f1489bc6af98cb81494f0612d1f405ff27",
-                "reference": "027bf2f1489bc6af98cb81494f0612d1f405ff27",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2820644f411fa261f126727c1c00de15227b9520",
+                "reference": "2820644f411fa261f126727c1c00de15227b9520",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-08-16T17:24:08+00:00"
+            "time": "2017-08-18T18:04:40+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -2691,16 +2691,16 @@
         },
         {
             "name": "spatie/db-dumper",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/db-dumper.git",
-                "reference": "cbfb3679d0a91ec56caa63ed8de3052c6792376a"
+                "reference": "e3fdf7a5f545c2d6fe3c349a4c58394d03ba1c9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/cbfb3679d0a91ec56caa63ed8de3052c6792376a",
-                "reference": "cbfb3679d0a91ec56caa63ed8de3052c6792376a",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/e3fdf7a5f545c2d6fe3c349a4c58394d03ba1c9b",
+                "reference": "e3fdf7a5f545c2d6fe3c349a4c58394d03ba1c9b",
                 "shasum": ""
             },
             "require": {
@@ -2737,7 +2737,7 @@
                 "mysqldump",
                 "spatie"
             ],
-            "time": "2017-05-25T20:43:25+00:00"
+            "time": "2017-08-18T11:48:03+00:00"
         },
         {
             "name": "spatie/laravel-backup",
@@ -3819,16 +3819,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "b03f285a333f51e58c95cce54109a4a9ed691436"
+                "reference": "424a840dc3bedcdeea510b42e056c77c2d6c4bef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/b03f285a333f51e58c95cce54109a4a9ed691436",
-                "reference": "b03f285a333f51e58c95cce54109a4a9ed691436",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/424a840dc3bedcdeea510b42e056c77c2d6c4bef",
+                "reference": "424a840dc3bedcdeea510b42e056c77c2d6c4bef",
                 "shasum": ""
             },
             "require": {
@@ -3867,7 +3867,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-04-06T16:18:34+00:00"
+            "time": "2017-08-17T21:21:00+00:00"
         }
     ],
     "packages-dev": [
@@ -3924,58 +3924,6 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
-            "name": "facebook/webdriver",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "eadb0b7a7c3e6578185197fd40158b08c3164c83"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/eadb0b7a7c3e6578185197fd40158b08c3164c83",
-                "reference": "eadb0b7a7c3e6578185197fd40158b08c3164c83",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "ext-zip": "*",
-                "php": "^5.5 || ~7.0",
-                "symfony/process": "^2.8 || ^3.1"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "php-mock/php-mock-phpunit": "^1.1",
-                "phpunit/phpunit": "4.6.* || ~5.0",
-                "satooshi/php-coveralls": "^1.0",
-                "squizlabs/php_codesniffer": "^2.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-community": "1.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Facebook\\WebDriver\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "A PHP client for Selenium WebDriver",
-            "homepage": "https://github.com/facebook/php-webdriver",
-            "keywords": [
-                "facebook",
-                "php",
-                "selenium",
-                "webdriver"
-            ],
-            "time": "2017-04-28T14:54:49+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -4118,152 +4066,6 @@
                 "testing"
             ],
             "time": "2017-02-08T22:32:37+00:00"
-        },
-        {
-            "name": "laravel/dusk",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/dusk.git",
-                "reference": "6b81e97ae1ce384e3d8dbd020b2b9751c1449889"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/dusk/zipball/6b81e97ae1ce384e3d8dbd020b2b9751c1449889",
-                "reference": "6b81e97ae1ce384e3d8dbd020b2b9751c1449889",
-                "shasum": ""
-            },
-            "require": {
-                "facebook/webdriver": "~1.0",
-                "illuminate/console": "~5.4",
-                "illuminate/support": "~5.4",
-                "nesbot/carbon": "~1.20",
-                "php": ">=5.6.4",
-                "symfony/console": "~3.2",
-                "symfony/process": "~3.2"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.6",
-                "phpunit/phpunit": "^5.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laravel\\Dusk\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "Laravel Dusk provides simple end-to-end testing and browser automation.",
-            "keywords": [
-                "laravel",
-                "testing",
-                "webdriver"
-            ],
-            "time": "2017-04-23T17:13:04+00:00"
-        },
-        {
-            "name": "maknz/slack",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/maknz/slack.git",
-                "reference": "7f21fefc70c76b304adc1b3a780c8740dfcfb595"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/maknz/slack/zipball/7f21fefc70c76b304adc1b3a780c8740dfcfb595",
-                "reference": "7f21fefc70c76b304adc1b3a780c8740dfcfb595",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "0.9.*",
-                "phpunit/phpunit": "4.2.*"
-            },
-            "suggest": {
-                "illuminate/support": "Required for Laravel support"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Maknz\\Slack\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "maknz",
-                    "email": "github@mak.geek.nz"
-                }
-            ],
-            "description": "A simple PHP package for sending messages to Slack, with a focus on ease of use and elegant syntax. Includes Laravel support out of the box.",
-            "keywords": [
-                "laravel",
-                "slack"
-            ],
-            "time": "2015-06-03T03:35:16+00:00"
-        },
-        {
-            "name": "maknz/slack-laravel",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/maknz/slack-laravel.git",
-                "reference": "d62741f731c963c71272159b38f8209ce57ff85b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/maknz/slack-laravel/zipball/d62741f731c963c71272159b38f8209ce57ff85b",
-                "reference": "d62741f731c963c71272159b38f8209ce57ff85b",
-                "shasum": ""
-            },
-            "require": {
-                "maknz/slack": "~1.0",
-                "php": ">=5.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Maknz\\Slack\\Laravel\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "maknz",
-                    "email": "github@mak.geek.nz"
-                }
-            ],
-            "description": "Laravel 4 and 5 integration for the maknz/slack package, including facades and service providers.",
-            "keywords": [
-                "laravel",
-                "slack"
-            ],
-            "time": "2016-06-25T06:08:23+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -4783,16 +4585,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "ecb0b2cdaa0add708fe6f329ef65ae0c5225130b"
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ecb0b2cdaa0add708fe6f329ef65ae0c5225130b",
-                "reference": "ecb0b2cdaa0add708fe6f329ef65ae0c5225130b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
                 "shasum": ""
             },
             "require": {
@@ -4828,7 +4630,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-03T14:17:41+00:00"
+            "time": "2017-08-20T05:47:52+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/tests/Services/CampaignServiceTest.php
+++ b/tests/Services/CampaignServiceTest.php
@@ -35,9 +35,10 @@ class CampaignServiceTest extends TestCase
             ]);
 
         $campaignService = $this->app->make(CampaignService::class);
+        $cache = new CacheRepository('campaign');
 
         // Test that the campaign is not in cache.
-        $campaign = Cache::get($testCampaign['id']);
+        $campaign = $cache->retrieve($testCampaign['id']);
         $this->assertNull($campaign);
 
         // If it's not in cache we should make the call to phoenix
@@ -45,7 +46,7 @@ class CampaignServiceTest extends TestCase
         // for future requests.
         $campaign = $campaignService->find($testCampaign['id']);
         $this->assertEquals($campaign, $testCampaign);
-        $this->assertEquals(Cache::get($testCampaign['id']), $testCampaign);
+        $this->assertEquals($cache->retrieve($testCampaign['id']), $testCampaign);
     }
 
     /**
@@ -78,7 +79,7 @@ class CampaignServiceTest extends TestCase
             ->andReturn(['data' => $testCampaigns]);
 
         $campaignService = $this->app->make(CampaignService::class);
-        $cache = $this->app->make(CacheRepository::class);
+        $cache = new CacheRepository('campaign');
 
         // Test that the campaign is not in cache.
         $campaigns = $cache->retrieveMany($testIds);


### PR DESCRIPTION
#### What's this PR do?
Store campaigns in cache with the prefix `campaign:` to fix this issue: 
```
[2017-08-21 14:48:25] thor.ERROR: ErrorException: Cannot use a scalar value as an array in /var/www/rogue/releases/20170821143532/app/Services/CampaignService.php:246
```

#### How should this be reviewed?
👀  and `/campaigns` and `/campaigns/:nid` pages should work exactly the same when hit. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/150409500

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.