### PR TITLE
Transform and send signups & posts to Blink.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ APP_URL=http://localhost
 ROGUE_API_KEY=abc123
 
 # Feature Flags
+DS_ENABLE_BLINK=false
 DS_ENABLE_GLIDE=true
 
 DB_CONNECTION=mysql
@@ -42,3 +43,7 @@ NORTHSTAR_AUTH_SECRET=northstarAuthSecret
 
 PHOENIX_URI=https://staging.dosomething.org
 PHOENIX_API_VERSION=v1
+
+BLINK_URL=
+BLINK_USERNAME=
+BLINK_PASSWORD=

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -133,4 +133,28 @@ class Post extends Model
     {
         return $this->hasMany(self::class, 'signup_id', 'signup_id');
     }
+
+    /**
+     * Transform the post model for Blink.
+     *
+     * @return array
+     */
+    public function toBlinkPayload()
+    {
+        return [
+            'id' => $this->id,
+            'signup_id' => $this->signup_id,
+            'campaign_id' => $this->campaign_id,
+            'campaign_run_id' => $this->campaign_run_id,
+            'northstar_id' => $this->northstar_id,
+            'url' => $this->getMediaUrl(),
+            'caption' => $this->caption,
+            'status' => $this->status,
+            'remote_addr' => $this->remote_addr,
+            'source' => $this->source,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+            'deleted_at' => $this->deleted_at ? $this->deleted_at->toIso8601String() : null,
+        ];
+    }
 }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -88,4 +88,24 @@ class Signup extends Model
     {
         return $query->withCount(['accepted', 'pending', 'rejected']);
     }
+
+    /**
+     * Transform the signup model for Blink.
+     *
+     * @return array
+     */
+    public function toBlinkPayload()
+    {
+        return [
+            'id' => $this->id,
+            'northstar_id' => $this->northstar_id,
+            'campaign_id' => $this->campaign_id,
+            'campaign_run_id' => $this->campaign_run_id,
+            'quantity' => $this->quantity,
+            'why_participated' => $this->why_participated,
+            'source' => $this->source,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Providers;
 
+use DoSomething\Gateway\Blink;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        // @TODO: This should be registered in Gateway's service provider!
+        $this->app->singleton(Blink::class, function () {
+            return new Blink(config('services.blink'));
+        });
     }
 }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -115,7 +115,7 @@ class PostRepository
      * @param \Rogue\Models\Signup $signup
      * @param array $data
      *
-     * @return \Rogue\Models\Post
+     * @return Signup|Post
      */
     public function update($signup, $data)
     {
@@ -171,7 +171,7 @@ class PostRepository
      *
      * @param array $data
      *
-     * @return
+     * @return Post
      */
     public function reviews($data)
     {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -7,7 +7,6 @@ use Rogue\Services\AWS;
 use Rogue\Models\Review;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
-use DoSomething\Gateway\Blink;
 use Intervention\Image\Facades\Image;
 
 class PostRepository
@@ -27,13 +26,6 @@ class PostRepository
     protected $registrar;
 
     /**
-     * Blink API client.
-     *
-     * @var \DoSomething\Gateway\Blink
-     */
-    protected $blink;
-
-    /**
      * Array of properties needed for cropping and rotating.
      *
      * @var array
@@ -45,13 +37,11 @@ class PostRepository
      *
      * @param AWS $aws
      * @param Registrar $registrar
-     * @param Blink $blink
      */
-    public function __construct(AWS $aws, Registrar $registrar, Blink $blink)
+    public function __construct(AWS $aws, Registrar $registrar)
     {
         $this->aws = $aws;
         $this->registrar = $registrar;
-        $this->blink = $blink;
     }
 
     /**
@@ -116,19 +106,13 @@ class PostRepository
             $this->crop($data, $post->id);
         }
 
-        // Save the new post in Customer.io, via Blink.
-        if (config('features.blink')) {
-            $payload = $post->toBlinkPayload();
-            $this->blink->userSignupPost($payload);
-        }
-
         return $post;
     }
 
     /**
      * Update an existing Post and Signup.
      *
-     * @param \Rogue\Models\Post $signup
+     * @param \Rogue\Models\Signup $signup
      * @param array $data
      *
      * @return \Rogue\Models\Post

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -93,7 +93,7 @@ class PostRepository
 
         // Edit the image if there is one
         if (isset($data['file'])) {
-            $editedImage = $this->crop($data, $post->id);
+            $this->crop($data, $post->id);
         }
 
         return $post;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -3,27 +3,9 @@
 namespace Rogue\Repositories;
 
 use Rogue\Models\Signup;
-use DoSomething\Gateway\Blink;
 
 class SignupRepository
 {
-    /**
-     * Blink API client.
-     *
-     * @var \DoSomething\Gateway\Blink
-     */
-    protected $blink;
-
-    /**
-     * Create a SignupRepository.
-     *
-     * @param Blink $blink
-     */
-    public function __construct(Blink $blink)
-    {
-        $this->blink = $blink;
-    }
-
     /**
      * Create a signup.
      *
@@ -56,12 +38,6 @@ class SignupRepository
             $event->save(['timestamps' => false]);
         } else {
             $signup->save();
-        }
-
-        // Save the new signup in Customer.io, via Blink.
-        if (config('features.blink')) {
-            $payload = $signup->toBlinkPayload();
-            $this->blink->userSignup($payload);
         }
 
         return $signup;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -3,9 +3,27 @@
 namespace Rogue\Repositories;
 
 use Rogue\Models\Signup;
+use DoSomething\Gateway\Blink;
 
 class SignupRepository
 {
+    /**
+     * Blink API client.
+     *
+     * @var \DoSomething\Gateway\Blink
+     */
+    protected $blink;
+
+    /**
+     * Create a SignupRepository.
+     *
+     * @param Blink $blink
+     */
+    public function __construct(Blink $blink)
+    {
+        $this->blink = $blink;
+    }
+
     /**
      * Create a signup.
      *
@@ -38,6 +56,12 @@ class SignupRepository
             $event->save(['timestamps' => false]);
         } else {
             $signup->save();
+        }
+
+        // Save the new signup in Customer.io, via Blink.
+        if (config('features.blink')) {
+            $payload = $signup->toBlinkPayload();
+            $this->blink->userSignup($payload);
         }
 
         return $signup;

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -67,12 +67,12 @@ class PostService
      */
     public function update($signup, $data, $transactionId)
     {
-        $post = $this->repository->update($signup, $data);
+        $postOrSignup = $this->repository->update($signup, $data);
 
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 
-        return $post;
+        return $postOrSignup;
     }
 
     /**

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -63,7 +63,7 @@ class PostService
      * @param \Rogue\Models\Signup $signup
      * @param array $data
      * @param string $transactionId
-     * @return \Rogue\Models\Post
+     * @return \Rogue\Models\Post|\Rogue\Models\Signup
      */
     public function update($signup, $data, $transactionId)
     {

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Services;
 
+use DoSomething\Gateway\Blink;
 use Rogue\Repositories\PostRepository;
 
 class PostService
@@ -14,13 +15,22 @@ class PostService
     protected $repository;
 
     /**
+     * Blink API client.
+     *
+     * @var \DoSomething\Gateway\Blink
+     */
+    protected $blink;
+
+    /**
      * Constructor
      *
-     * @param \Rogue\Repositories\PostRepository $posts
+     * @param PostRepository $posts
+     * @param Blink $blink
      */
-    public function __construct(PostRepository $posts)
+    public function __construct(PostRepository $posts, Blink $blink)
     {
         $this->repository = $posts;
+        $this->blink = $blink;
     }
 
     /**
@@ -29,11 +39,17 @@ class PostService
      * @param array $data
      * @param int $signupId
      * @param string $transactionId
-     * @return Illuminate\Database\Eloquent\Model $model
+     * @return \Rogue\Models\Post
      */
     public function create($data, $signupId, $transactionId)
     {
         $post = $this->repository->create($data, $signupId);
+
+        // Save the new post in Customer.io, via Blink.
+        if (config('features.blink')) {
+            $payload = $post->toBlinkPayload();
+            $this->blink->userSignupPost($payload);
+        }
 
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
@@ -47,8 +63,7 @@ class PostService
      * @param \Rogue\Models\Signup $signup
      * @param array $data
      * @param string $transactionId
-     *
-     * @return \Illuminate\Database\Eloquent\Model $model
+     * @return \Rogue\Models\Post
      */
     public function update($signup, $data, $transactionId)
     {

--- a/config/features.php
+++ b/config/features.php
@@ -14,4 +14,6 @@ return [
 
     'glide' => env('DS_ENABLE_GLIDE'),
 
+    'blink' => env('DS_ENABLE_BLINK'),
+
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -39,6 +39,12 @@ return [
         'version' => env('PHOENIX_API_VERSION'),
     ],
 
+    'blink' => [
+        'url' => env('BLINK_URL'),
+        'user' => env('BLINK_USERNAME'),
+        'password' => env('BLINK_PASSWORD'),
+    ],
+
     'ses' => [
         'key' => env('SES_KEY'),
         'secret' => env('SES_SECRET'),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_DATABASE" value="rogue_test"/>
         <env name="DS_ENABLE_GLIDE" value="false"/>
+        <env name="DS_ENABLE_BLINK" value="true"/>
     </php>
 </phpunit>

--- a/tests/Http/Api/PostApiTest.php
+++ b/tests/Http/Api/PostApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Http\Api;
 
 use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
+use DoSomething\Gateway\Blink;
 use Illuminate\Support\Facades\Storage;
 
 class PostApiTest extends BrowserKitTestCase
@@ -26,6 +27,11 @@ class PostApiTest extends BrowserKitTestCase
         $url = 'https://ds-rogue-prod.s3.amazonaws.com/uploads/reportback-items/edited_1.jpeg';
         Storage::shouldReceive('put')->andReturn(true);
         Storage::shouldReceive('url')->andReturn($url);
+
+        // Mock the Blink API calls.
+        $this->mock(Blink::class)
+            ->shouldReceive('userSignup')
+            ->shouldReceive('userSignupPost');
 
         // Create the post!
         $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
@@ -87,6 +93,9 @@ class PostApiTest extends BrowserKitTestCase
         $url = 'https://ds-rogue-prod.s3.amazonaws.com/uploads/reportback-items/edited_1.jpeg';
         Storage::shouldReceive('put')->andReturn(true);
         Storage::shouldReceive('url')->andReturn($url);
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
         $this->withRogueApiKey()->json('POST', 'api/v2/posts', [

--- a/tests/Http/Api/SignupApiTest.php
+++ b/tests/Http/Api/SignupApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Http\Api;
 
 use Tests\BrowserKitTestCase;
+use DoSomething\Gateway\Blink;
 
 class SignupApiTest extends BrowserKitTestCase
 {
@@ -17,6 +18,9 @@ class SignupApiTest extends BrowserKitTestCase
         $northstarId = '54fa272b469c64d7068b456a';
         $campaignId = $this->faker->randomNumber(4);
         $campaignRunId = $this->faker->randomNumber(4);
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignup');
 
         $this->withRogueApiKey()->json('POST', 'api/v2/signups', [
             'northstar_id'     => $northstarId,


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for persisting new signups & reportbacks in Customer.io, via Blink. This is handled using a feature flag, so that we can disable it when running Rogue locally.

#### How should this be reviewed?
I've added assertions that the relevant Blink methods are called in relevant test suites.

#### Any background context you want to provide?
📮

#### Relevant tickets
[#149209459](https://www.pivotaltracker.com/story/show/149209459), [#149862583](https://www.pivotaltracker.com/story/show/149862583)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.