### PR TITLE
Cache fix

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -95,6 +95,7 @@ class CampaignService
     {
         foreach ($campaigns as $key => $value) {
             if ($value === false or $value === null) {
+                $key = (int) $this->cache->unsetPrefix($key);
                 $campaigns[$key] = $this->find($key);
             }
         }

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -42,6 +42,7 @@ class CampaignService
     public function find($id)
     {
         $campaign = $this->cache->retrieve($id);
+
         if (! $campaign) {
             $campaign = $this->phoenix->getCampaign($id);
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -96,7 +96,7 @@ class CampaignService
     {
         foreach ($campaigns as $key => $value) {
             if ($value === false or $value === null) {
-                $key = (int) $this->cache->unsetPrefix($key);
+                $key = $this->cache->unsetPrefix($key);
                 $campaigns[$key] = $this->find($key);
             }
         }


### PR DESCRIPTION
#### What's this PR do?
Unsets prefix in `resolveMissingCampaigns` function in order to correctly grab from cache (`retrieve` method applies the prefix so we need to strip to just the campaign `id`). 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Fixes bug in #374 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.