### PR TITLE
Some little test updates.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "project",
   "require": {
-    "php": ">=5.5.9",
+    "php": "~7.0.0",
     "laravel/framework": "5.4.*",
     "laravel/tinker": "^1.0",
     "aws/aws-sdk-php-laravel": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac61c720a87d4b0742aa2957c7c0bdad",
+    "content-hash": "9ab9dba00cdf4f573e061ce177de6444",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -5454,7 +5454,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.9"
+        "php": "~7.0.0"
     },
     "platform-dev": []
 }

--- a/storage/framework/testing/.gitignore
+++ b/storage/framework/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -6,6 +6,7 @@ use Mockery;
 use Carbon\Carbon;
 use Rogue\Models\User;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Laravel\BrowserKitTesting\TestCase as BaseTestCase;
 
 class BrowserKitTestCase extends BaseTestCase
@@ -40,6 +41,9 @@ class BrowserKitTestCase extends BaseTestCase
 
         // Reset mocked time, if set.
         Carbon::setTestNow(null);
+
+        // Fake the storage driver.
+        Storage::fake('public');
 
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -58,21 +58,6 @@ class BrowserKitTestCase extends BaseTestCase
     }
 
     /**
-     * Assert that a soft-deleted record exists in the database.
-     *
-     * @param $table
-     * @param $id
-     * @return $this
-     */
-    public function seeSoftDeletedRecord($table, $id)
-    {
-        $this->seeInDatabase($table, ['id' => $id, 'url' => null])
-            ->notSeeInDatabase($table, ['id' => $id, 'deleted_at' => null]);
-
-        return $this;
-    }
-
-    /**
      * "Freeze" time so we can make assertions based on it.
      *
      * @param string $time

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Http;
 
+use Tests\TestCase;
 use Rogue\Models\Post;
 use Rogue\Models\User;
-use Tests\BrowserKitTestCase;
 
-class PostTest extends BrowserKitTestCase
+class PostTest extends TestCase
 {
     /**
      * Test that posts get soft-deleted when hitting the DELETE endpoint.
@@ -17,10 +17,11 @@ class PostTest extends BrowserKitTestCase
     {
         $post = factory(Post::class)->create();
 
-        $this->actingAsAdmin()->delete('posts/' . $post->id);
+        $response = $this->actingAsAdmin()->delete('posts/' . $post->id);
 
-        $this->assertResponseStatus(200);
-        $this->seeSoftDeletedRecord('posts', $post->id);
+        $response->assertStatus(200);
+
+        $this->assertSoftDeleted('posts', ['id' => $post->id]);
     }
 
     /**
@@ -33,8 +34,8 @@ class PostTest extends BrowserKitTestCase
         $user = factory(User::class)->make();
         $post = factory(Post::class)->create();
 
-        $this->actingAs($user)->delete('posts/' . $post->id);
+        $response = $this->actingAs($user)->delete('posts/' . $post->id);
 
-        $this->assertResponseStatus(403);
+        $response->assertStatus(403);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,7 @@ namespace Tests;
 use Mockery;
 use Carbon\Carbon;
 use Rogue\Models\User;
-use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -41,6 +41,9 @@ class TestCase extends BaseTestCase
         // Reset mocked time, if set.
         Carbon::setTestNow(null);
 
+        // Fake the storage driver.
+        Storage::fake('public');
+
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
     }
@@ -55,21 +58,6 @@ class TestCase extends BaseTestCase
         $user = factory(User::class, 'admin')->create();
 
         return $this->actingAs($user);
-    }
-
-    /**
-     * Assert that a soft-deleted record exists in the database.
-     *
-     * @param $table
-     * @param $id
-     * @return $this
-     */
-    public function seeSoftDeletedRecord($table, $id)
-    {
-        $this->seeInDatabase($table, ['id' => $id, 'url' => null])
-            ->notSeeInDatabase($table, ['id' => $id, 'deleted_at' => null]);
-
-        return $this;
     }
 
     /**
@@ -98,18 +86,6 @@ class TestCase extends BaseTestCase
         $this->app->instance($class, $mock);
 
         return $mock;
-    }
-
-    /**
-     * Creates a mock file.
-     *
-     * @return UploadedFile
-     */
-    public function mockFile()
-    {
-        $uploadPath = $this->faker->file(storage_path('fixtures'));
-
-        return new UploadedFile($uploadPath, basename($uploadPath), 'image/jpeg');
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request is just a little grab-bag of test touch ups:

7️⃣ Adds a PHP version constraint to our `composer.json`. This will prevent us from accidentally running Composer with a different PHP version and getting the wrong dependencies.

🚥 Updates `PostTest` and `PostApiTest` to use the new Laravel 5.4 test syntax, including the [`UploadedFile` fake](https://laravel.com/docs/5.4/mocking#storage-fake) and [`assertSoftDeleted` assertion](https://laravel.com/docs/5.4/database-testing#available-assertions) (each replacing our own homegrown implementations).

🗄 Fakes the storage adapter for tests so we don't keep writing files to the disk every time we run the test suite (otherwise the `public/storage` directory keeps growing and growing).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I'm gonna make a card to update the rest of our tests to use the new syntax, but this is a start! 😄

#### Relevant tickets
N/A 🙊

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.