### PR TITLE
Only tag post if it exists

### DIFF
--- a/database/migrations/2017_08_21_212932_move_tagging_tagged_to_post_tag.php
+++ b/database/migrations/2017_08_21_212932_move_tagging_tagged_to_post_tag.php
@@ -16,7 +16,9 @@ class MoveTaggingTaggedToPostTag extends Migration
 
         foreach ($tags as $tag) {
             $post = Post::find($tag->taggable_id);
-            $post->tag($tag->tag_name);
+            if ($post) {
+                $post->tag($tag->tag_name);
+            }
         }
     }
 


### PR DESCRIPTION
#### What's this PR do?
Quick fix to this migration!

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Deleted posts can still have tags, so we want to make sure the post exists before trying to apply a tag.

#### Relevant tickets
:cowboy_hat_face: 

#### Checklist
- [ ] Tested on staging.
