### PR TITLE
Fix 500 on validation error.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -47,21 +47,19 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $e)
     {
         // Re-cast specific exceptions or uniquely render them:
         if ($e instanceof GlideNotFoundException) {
             $e = new NotFoundHttpException('That image could not be found.');
-        }
-        if ($e instanceof AuthorizationException) {
+        } elseif ($e instanceof AuthorizationException) {
             return parent::render($request, $e);
-        }
-        if ($e instanceof AuthenticationException) {
+        } elseif ($e instanceof AuthenticationException) {
             return $this->unauthenticated($request, $e);
-        } elseif ($e instanceof ValidationException || $e instanceof NorthstarValidationException) {
-            return $this->invalidated($request, $e);
+        } elseif ($e instanceof ValidationException) {
+            return $this->convertValidationExceptionToResponse($e, $request);
         } elseif ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException('That resource could not be found.');
         }


### PR DESCRIPTION
#### What's this PR do?
The Handler's `invalidated` method was changed to `convertValidationExceptionToResponse` in one of the Laravel updates. This should allow us to actually render validation errors, rather than dying.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
We can probably simplify this further in the future so we don't have to handle so many cases specially ourselves. Let's make a backlog refactor ticket!

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.