### PR TITLE
Use new tags to not include excluded posts

### DIFF
--- a/app/Http/Controllers/Api/ReportbackController.php
+++ b/app/Http/Controllers/Api/ReportbackController.php
@@ -42,7 +42,9 @@ class ReportbackController extends ApiController
             // Only return posts that have been approved by a campaign lead...
             ->where('status', 'accepted')
             // ...and haven't been hidden from the gallery.
-            ->withoutTags(['Hide In Gallery']);
+            ->whereDoesntHave('tags', function ($query) {
+                $query->where('tag_slug', '=', 'hide-in-gallery');
+            });
 
         // @TODO: Use `FiltersRequests` trait here!
         $filters = $request->query('filter');


### PR DESCRIPTION
#### What's this PR do?
Instead of using the `withoutTags` scope from the old tagging package, use a Laravel method, `whereDoesntHave` .

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
I missed this on my first pass!

#### Relevant tickets
:cowboy_hat_face: 

#### Checklist
- [ ] Tested on staging.
