### PR TITLE
Tagging fix

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -36,7 +36,7 @@ class PostTransformer extends TransformerAbstract
                 'caption' => $post->caption,
             ],
             // @TODO: include tags
-            'tags' => $post->tagNames(),
+            'tags' => $post->tagSlugs(),
             'status' => $post->status,
             'source' => $post->source,
             'remote_addr' => $post->remote_addr,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -89,6 +89,14 @@ class Post extends Model
     }
 
     /**
+     * Get the tags associated with this post.
+     */
+    public function tagSlugs()
+    {
+        return $this->tags()->pluck('tag_slug');
+    }
+
+    /**
      * Get the URL for the media for this post.
      */
     public function getMediaUrl()

--- a/resources/assets/components/ReviewBlock/index.js
+++ b/resources/assets/components/ReviewBlock/index.js
@@ -21,7 +21,7 @@ class ReviewBlock extends React.Component {
           <li><button className="button delete -tertiary" onClick={e => this.props.deletePost(post['id'], e)}>Delete</button></li>
         </ul>
         {post.status === 'accepted' ?
-          <Tags id={post.id} tagged={post.tagged} onTag={this.props.onTag} />
+          <Tags id={post.id} tagged={post.tags} onTag={this.props.onTag} />
         : null}
       </div>
     )


### PR DESCRIPTION
#### What's this PR do?
🐛  Tagging broke on a few views - this fixes that: 

* With the new tag changes we now return a `tag` property on posts instead of a `tagged` property. Fixed the `Tags` component to work with that. 
* Also we used to return the `tag_slug` not the `tag_name` and then that was used to compare to see if a post had that tag or not. I added a `tagSlugs()` method on `Posts` to grab slugs and updated the transformer to return these instead. This is allows us to do tag logic without having to worry about user facing values (like labels with 👻  in them)

#### How should this be reviewed?

👁 

#### Any background context you want to provide?

Some better unit and frontend testing should help with little stuff like this. 

#### Relevant tickets

🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.