### PR TITLE
Remove prefix before trying to find the user in cache

### DIFF
--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -81,6 +81,7 @@ class Registrar
     {
         foreach ($users as $key => $value) {
             if ($value === false or $value === null) {
+                $key = $this->cache->unsetPrefix($key);
                 $users[$key] = $this->find($key);
             }
         }


### PR DESCRIPTION
#### What's this PR do?
Unsets prefix in` resolveMissingUsers` method before trying to find them. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.