### PR TITLE
Fixes a few issues with grabbing users from cache

### DIFF
--- a/app/Repositories/CacheRepository.php
+++ b/app/Repositories/CacheRepository.php
@@ -113,7 +113,7 @@ class CacheRepository
     public function unsetPrefix($string)
     {
         if (property_exists($this, 'prefix')) {
-            return str_replace('campaign:', '', $string);
+            return str_replace($this->prefix . ':', '', $string);
         } else {
             return $string;
         }

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -81,8 +81,7 @@ class Registrar
     {
         foreach ($users as $key => $value) {
             if ($value === false or $value === null) {
-                $key = $this->cache->unsetPrefix($key);
-                $users[$key] = $this->find($key);
+                $users[$key] = $this->find($this->cache->unsetPrefix($key));
             }
         }
 

--- a/resources/views/users/partials/_table_users.blade.php
+++ b/resources/views/users/partials/_table_users.blade.php
@@ -13,11 +13,13 @@
                 </thead>
                 <tbody>
                     @foreach ($users as $user)
-                        <tr class="table__row">
-                            <td class="table__cell"><a href={{ "/users/" . $user->id }}>{{ $user->first_name or 'Anonymous' }} {{ $user->last_name or '' }}</a></td>
-                            <td class="table__cell">{{ $user->email or ''}}</td>
-                            <td class="table__cell">{{ $user->mobile or ''}}</td>
-                        </tr>
+                        @if ($user)
+                            <tr class="table__row">
+                                <td class="table__cell"><a href={{ "/users/" . $user->id }}>{{ $user->first_name or 'Anonymous' }} {{ $user->last_name or '' }}</a></td>
+                                <td class="table__cell">{{ $user->email or ''}}</td>
+                                <td class="table__cell">{{ $user->mobile or ''}}</td>
+                            </tr>
+                        @endif
                     @endforeach
                 </tbody>
             </table>


### PR DESCRIPTION
#### What's this PR do?
Fixes some issues I was seeing on QA when grabbing users from the cache

* In `CacheRepository.php` we were always assuming things were keyed with the "campaign:" prefix but users are stored with the "user:" prefix. [change here](https://github.com/DoSomething/rogue/compare/user-cache-fix?expand=1#diff-963df936abc332d74d55c56a3dc9e2fcR116)

* The `$users` array was keyed with prefixes but we were trying to store a value using a non-prefixed key. [change here](https://github.com/DoSomething/rogue/compare/user-cache-fix?expand=1#diff-4cf63b529baa5ae9c5b6aa21e80856a4R84)

* There was a user on QA that is truly not being found. I can't find them in aurora QA either (id: 5543c0cf469c64ec7d8b45f3) . So this checks for the user before trying to render them in the template. [Change here](https://github.com/DoSomething/rogue/compare/user-cache-fix?expand=1#diff-a2a54c94d1fbecb4e6e05f13b88fc1d6R16)

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Sorry for jumping in here I am trying to get this all sorted out before sprint review!

#### Relevant tickets
🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.