### PR TITLE
Allow null values to be provided for source.

### DIFF
--- a/app/Http/Requests/SignupRequest.php
+++ b/app/Http/Requests/SignupRequest.php
@@ -27,7 +27,7 @@ class SignupRequest extends Request
             'campaign_run_id' => 'required|int',
             'quantity' => 'int',
             'why_participated' => 'string',
-            'source' => 'string',
+            'source' => 'string|nullable',
         ];
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request includes a quick fix for signups not working on Phoenix.

#### How should this be reviewed?
I ran out of time to add a test case, but if we decide this is expected behavior we should add one!

#### Any background context you want to provide?
Laravel now requires the [`nullable` validator](https://laravel.com/docs/5.4/validation#rule-nullable) now if you want JSON fields to be optional, so this broke as a result of that upgrade. It's also worth thinking if we want to provide a fallback value for this [in Phoenix](https://github.com/DoSomething/phoenix/blob/6e80ae77499c1fd8b30508c1bad7ab6e8dd6d192/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc#L168).

(And in the future, we could set `source` by the Northstar client in the token!)

#### Relevant tickets
Fixes 🐛

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.