### PR TITLE
only updates why_participated if it is present

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -120,7 +120,11 @@ class PostRepository
     public function update($signup, $data)
     {
         if (array_key_exists('updated_at', $data)) {
-            $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated', 'updated_at']));
+            if ($data['why_participated']) {
+                $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated', 'updated_at']));
+            } else {
+                $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'updated_at']));
+            }
 
             $signup->save(['timestamps' => false]);
 
@@ -129,15 +133,14 @@ class PostRepository
             $event->updated_at = $data['updated_at'];
             $event->save(['timestamps' => false]);
         } else {
-            $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
+            if ($data['why_participated']) {
+                $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
+            } else {
+                $signup->fill(array_only($data, ['quantity', 'quantity_pending']));
+            }
 
             // Triggers model event that logs the updated signup in the events table.
             $signup->save();
-        }
-
-        // If there is a file, create a new post.
-        if (array_key_exists('file', $data)) {
-            return $this->create($data, $signup->id);
         }
 
         return $signup;

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -121,17 +121,8 @@ class PostRepository
     {
         if (array_key_exists('updated_at', $data)) {
             // Only update if the key is set (is not null).
-            $arrayKeysToUpdate = ['why_participated', 'quantity'];
-
-            foreach ($arrayKeysToUpdate as $key => $value) {
-                if (! $data[$value]) {
-                    $key = array_search($value, $arrayKeysToUpdate);
-                    unset($arrayKeysToUpdate[$key]);
-                }
-            }
-
-            array_push($arrayKeysToUpdate, 'updated_at');
-            array_push($arrayKeysToUpdate, 'quantity_pending');
+            $nonNullArrayKeys = array_filter($data);
+            $arrayKeysToUpdate = array_keys($nonNullArrayKeys);
 
             $signup->fill(array_only($data, $arrayKeysToUpdate));
 
@@ -143,15 +134,8 @@ class PostRepository
             $event->save(['timestamps' => false]);
         } else {
             // Only update if the key is set (is not null).
-            $arrayKeysToUpdate = ['why_participated', 'quantity'];
-
-            foreach ($arrayKeysToUpdate as $key => $value) {
-                if (! $data[$value]) {
-                    $key = array_search($value, $arrayKeysToUpdate);
-                    unset($arrayKeysToUpdate[$key]);
-                }
-            }
-            array_push($arrayKeysToUpdate, 'quantity_pending');
+            $nonNullArrayKeys = array_filter($data);
+            $arrayKeysToUpdate = array_keys($nonNullArrayKeys);
 
             $signup->fill(array_only($data, $arrayKeysToUpdate));
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -143,6 +143,11 @@ class PostRepository
             $signup->save();
         }
 
+        // If there is a file, create a new post.
+        if (array_key_exists('file', $data)) {
+            return $this->create($data, $signup->id);
+        }
+
         return $signup;
     }
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -120,11 +120,20 @@ class PostRepository
     public function update($signup, $data)
     {
         if (array_key_exists('updated_at', $data)) {
-            if ($data['why_participated']) {
-                $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated', 'updated_at']));
-            } else {
-                $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'updated_at']));
+            // Only update if the key is set (is not null).
+            $arrayKeysToUpdate = ['why_participated', 'quantity'];
+
+            foreach ($arrayKeysToUpdate as $key => $value) {
+                if (! $data[$value]) {
+                    $key = array_search($value, $arrayKeysToUpdate);
+                    unset($arrayKeysToUpdate[$key]);
+                }
             }
+
+            array_push($arrayKeysToUpdate, 'updated_at');
+            array_push($arrayKeysToUpdate, 'quantity_pending');
+
+            $signup->fill(array_only($data, $arrayKeysToUpdate));
 
             $signup->save(['timestamps' => false]);
 
@@ -133,11 +142,18 @@ class PostRepository
             $event->updated_at = $data['updated_at'];
             $event->save(['timestamps' => false]);
         } else {
-            if ($data['why_participated']) {
-                $signup->fill(array_only($data, ['quantity', 'quantity_pending', 'why_participated']));
-            } else {
-                $signup->fill(array_only($data, ['quantity', 'quantity_pending']));
+            // Only update if the key is set (is not null).
+            $arrayKeysToUpdate = ['why_participated', 'quantity'];
+
+            foreach ($arrayKeysToUpdate as $key => $value) {
+                if (! $data[$value]) {
+                    $key = array_search($value, $arrayKeysToUpdate);
+                    unset($arrayKeysToUpdate[$key]);
+                }
             }
+            array_push($arrayKeysToUpdate, 'quantity_pending');
+
+            $signup->fill(array_only($data, $arrayKeysToUpdate));
 
             // Triggers model event that logs the updated signup in the events table.
             $signup->save();


### PR DESCRIPTION
#### What's this PR do?
This first checks to see if `why_participated` is present before overriding the existing value in the database. 

#### How should this be reviewed?
Hit `POST /api/v2/posts` endpoint with `why_participated` value blank. Make sure it doesn't wipe the value out in the database and that the `why_participated` value returned in the JSON is from the original answer. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/150341552

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.