### PR TITLE
Return "tagged" not "tags"

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -35,8 +35,7 @@ class PostTransformer extends TransformerAbstract
                 'original_image_url' => $post->url,
                 'caption' => $post->caption,
             ],
-            // @TODO: include tags
-            'tags' => $post->tagSlugs(),
+            'tagged' => $post->tagSlugs(),
             'status' => $post->status,
             'source' => $post->source,
             'remote_addr' => $post->remote_addr,


### PR DESCRIPTION
#### What's this PR do?
I goofed this when I did the new tagging stuff, but in the documentation we have `tagged` so we should return that.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This didn't break the tagging script, but it wouldn't work as expected.

#### Checklist
- [ ] Tested on staging.
