### PR TITLE
Reverse! Use "tags" not "tagged"

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -35,7 +35,7 @@ class PostTransformer extends TransformerAbstract
                 'original_image_url' => $post->url,
                 'caption' => $post->caption,
             ],
-            'tagged' => $post->tagSlugs(),
+            'tags' => $post->tagSlugs(),
             'status' => $post->status,
             'source' => $post->source,
             'remote_addr' => $post->remote_addr,

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -119,7 +119,7 @@ Example Response:
                 "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_2984.jpeg",
                 "caption": null
             },
-            "tagged": [],
+            "tags": [],
             "reactions": [],
             "status": "accepted",
             "source": null,
@@ -135,7 +135,7 @@ Example Response:
                 "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_3655.jpeg",
                 "caption": "Perhaps you CAN be of some assistance, Bill"
             },
-            "tagged": [],
+            "tags": [],
             "status": "accepted",
             "source": null,
             "remote_addr": "207.110.19.130, 207.110.19.130",


### PR DESCRIPTION
#### What's this PR do?
- Updated documentation
- Use `tags` instead of `tagged` (frontend expects this currently)

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This will require a small update to the Rogue image tagging script in Phoenix.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.