### PR TITLE
Do not register debugbar on production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -28,5 +28,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(Blink::class, function () {
             return new Blink(config('services.blink'));
         });
+
+        // Ensure that debugbar doesn't register on production.
+        if ($this->app->environment() !== 'production') {
+            $this->app->register(\Barryvdh\Debugbar\ServiceProvider::class);
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -177,7 +177,6 @@ return [
          * Third-party Service Providers...
          */
         Aws\Laravel\AwsServiceProvider::class,
-        Barryvdh\Debugbar\ServiceProvider::class,
         DoSomething\Gateway\Laravel\GatewayServiceProvider::class,
         Intervention\Image\ImageServiceProvider::class,
         Laravel\Tinker\TinkerServiceProvider::class,


### PR DESCRIPTION
#### What's this PR do?
Fixes an issue where debugbar seems to be running on production sometimes. 

This is an issue that has been reported by other devs and the suggested fix is to just only register the service provider on non-production environments explicitly: https://github.com/barryvdh/laravel-debugbar/issues/635#issuecomment-306058405

#### How should this be reviewed?
👀  

On my local, I changed my `APP_ENV` to `production` to make sure that it didn't load in debugbar on requests. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/150442834

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.