### PR TITLE
App Container refactor

### DIFF
--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -17,15 +17,10 @@ ready(() => {
     CampaignOverview: CampaignOverview,
   });
 
-  const overviewContainer = document.getElementById('overviewContainer');
   const inboxContainer = document.getElementById('inboxContainer');
   const singleCampaignContainer = document.getElementById('singleCampaignContainer');
   const userOverviewContainer = document.getElementById('userOverviewContainer');
   const signupContainer = document.getElementById('signupContainer');
-
-  // if (overviewContainer) {
-  //   ReactDom.render(<CampaignOverview {...window.STATE} />, overviewContainer);
-  // }
 
   if (inboxContainer) {
     ReactDom.render(<CampaignInbox {...window.STATE} />, inboxContainer);

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -12,17 +12,11 @@ import CampaignSingle from './components/CampaignSingle';
 import CampaignOverview from './components/CampaignOverview';
 
 ready(() => {
-
   mountContainer({
     CampaignOverview: CampaignOverview,
     CampaignInbox: CampaignInbox,
     CampaignSingle: CampaignSingle,
     UserOverview: UserOverview,
+    Signup: Signup,
   });
-
-  const signupContainer = document.getElementById('signupContainer');
-
-  if (signupContainer) {
-    ReactDom.render(<Signup {...window.STATE} />, signupContainer);
-  }
 });

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -15,16 +15,12 @@ ready(() => {
 
   mountContainer({
     CampaignOverview: CampaignOverview,
+    CampaignInbox: CampaignInbox,
   });
 
-  const inboxContainer = document.getElementById('inboxContainer');
   const singleCampaignContainer = document.getElementById('singleCampaignContainer');
   const userOverviewContainer = document.getElementById('userOverviewContainer');
   const signupContainer = document.getElementById('signupContainer');
-
-  if (inboxContainer) {
-    ReactDom.render(<CampaignInbox {...window.STATE} />, inboxContainer);
-  }
 
   if (singleCampaignContainer) {
     ReactDom.render(<CampaignSingle {...window.STATE} historyModalId={null} />, singleCampaignContainer);

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -3,23 +3,29 @@ import './app.scss';
 
 import React from 'react';
 import ReactDom from 'react-dom';
+import mountContainer from './utilities/MountContainer';
 
-import CampaignOverview from './components/CampaignOverview';
-import CampaignInbox from './components/CampaignInbox';
-import CampaignSingle from './components/CampaignSingle';
 import Signup from './components/Signup';
 import UserOverview from './components/UserOverview';
+import CampaignInbox from './components/CampaignInbox';
+import CampaignSingle from './components/CampaignSingle';
+import CampaignOverview from './components/CampaignOverview';
 
 ready(() => {
+
+  mountContainer({
+    CampaignOverview: CampaignOverview,
+  });
+
   const overviewContainer = document.getElementById('overviewContainer');
   const inboxContainer = document.getElementById('inboxContainer');
   const singleCampaignContainer = document.getElementById('singleCampaignContainer');
   const userOverviewContainer = document.getElementById('userOverviewContainer');
   const signupContainer = document.getElementById('signupContainer');
 
-  if (overviewContainer) {
-    ReactDom.render(<CampaignOverview {...window.STATE} />, overviewContainer);
-  }
+  // if (overviewContainer) {
+  //   ReactDom.render(<CampaignOverview {...window.STATE} />, overviewContainer);
+  // }
 
   if (inboxContainer) {
     ReactDom.render(<CampaignInbox {...window.STATE} />, inboxContainer);

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -16,15 +16,11 @@ ready(() => {
   mountContainer({
     CampaignOverview: CampaignOverview,
     CampaignInbox: CampaignInbox,
+    CampaignSingle: CampaignSingle,
   });
 
-  const singleCampaignContainer = document.getElementById('singleCampaignContainer');
   const userOverviewContainer = document.getElementById('userOverviewContainer');
   const signupContainer = document.getElementById('signupContainer');
-
-  if (singleCampaignContainer) {
-    ReactDom.render(<CampaignSingle {...window.STATE} historyModalId={null} />, singleCampaignContainer);
-  }
 
   if (userOverviewContainer) {
     ReactDom.render(<UserOverview {...window.STATE} />, userOverviewContainer);

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -17,14 +17,10 @@ ready(() => {
     CampaignOverview: CampaignOverview,
     CampaignInbox: CampaignInbox,
     CampaignSingle: CampaignSingle,
+    UserOverview: UserOverview,
   });
 
-  const userOverviewContainer = document.getElementById('userOverviewContainer');
   const signupContainer = document.getElementById('signupContainer');
-
-  if (userOverviewContainer) {
-    ReactDom.render(<UserOverview {...window.STATE} />, userOverviewContainer);
-  }
 
   if (signupContainer) {
     ReactDom.render(<Signup {...window.STATE} />, signupContainer);

--- a/resources/assets/utilities/MountContainer.js
+++ b/resources/assets/utilities/MountContainer.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+/**
+ * Mount any container component to a server rendered page.
+ * @param {object} components - React components to attempt to mount
+ */
+function mountContainer(components) {
+  const reactElement = document.querySelector('[data-container]');
+  const container = reactElement.getAttribute('data-container');
+
+  if (components[container]) {
+    ReactDOM.render(React.createElement(components[container], {...window.STATE}), reactElement);
+  }
+}
+
+export default mountContainer;

--- a/resources/assets/utilities/MountContainer.js
+++ b/resources/assets/utilities/MountContainer.js
@@ -7,10 +7,13 @@ import ReactDOM from 'react-dom';
  */
 function mountContainer(components) {
   const reactElement = document.querySelector('[data-container]');
-  const container = reactElement.getAttribute('data-container');
 
-  if (components[container]) {
-    ReactDOM.render(React.createElement(components[container], {...window.STATE}), reactElement);
+  if (reactElement) {
+    const container = reactElement.getAttribute('data-container');
+
+    if (components[container]) {
+      ReactDOM.render(React.createElement(components[container], {...window.STATE}), reactElement);
+    }
   }
 }
 

--- a/resources/views/pages/campaign_inbox.blade.php
+++ b/resources/views/pages/campaign_inbox.blade.php
@@ -10,7 +10,7 @@
             </div>
         </div>
 	    <div class='container -padded'>
-	        <div id='inboxContainer' class='wrapper'>
+	        <div class='wrapper' data-container="CampaignInbox">
 	            Loading...
 	        </div>
 	    </div>

--- a/resources/views/pages/campaign_overview.blade.php
+++ b/resources/views/pages/campaign_overview.blade.php
@@ -5,7 +5,7 @@
     @include('layouts.header', ['header' => 'Campaign Overview', 'subtitle' => ''])
 
     <div class="container -padded">
-        <div id="overviewContainer" class="wrapper">
+        <div class="wrapper" data-container="CampaignOverview">
             Loading...
         </div>
     </div>

--- a/resources/views/pages/campaign_single.blade.php
+++ b/resources/views/pages/campaign_single.blade.php
@@ -5,7 +5,7 @@
     @include('layouts.header', ['header' => $state['campaign']['title']])
 
         <div class="container -padded">
-            <div id="singleCampaignContainer" class="wrapper">
+            <div class="wrapper" data-container="CampaignSingle">
                 <div id="status-counter"></div>
                 <div id="status-filter"></div>
                 <div id="posts">

--- a/resources/views/signups/show.blade.php
+++ b/resources/views/signups/show.blade.php
@@ -4,7 +4,7 @@
     @include('layouts.header', ['header' => $campaign['title'], 'subtitle' => ''])
 
     <div class="container -padded">
-        <div id="signupContainer" class="wrapper">
+        <div class="wrapper" data-container="Signup">
             Loading...
         </div>
     </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -4,7 +4,7 @@
     @include('layouts.header', ['header' => 'User', 'subtitle' => ''])
 
     <div class="container -padded">
-        <div id="userOverviewContainer" class="wrapper">
+        <div class="wrapper" data-container="UserOverview">
             Loading...
         </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?

Refactors how we were adding React components to the server rendered paged. 

Before we were looking for the element to add a react container component to by searching for an `id` prop on the server rendered HTML. This ended up being a lot of conditional statements to see if the element was on the page before adding the component. 

Now, in the server rendered HTML, we add a `data-container` attribute and set the value to equal the name of the component to add to the page. And then, when we load in the JS we look for the `data-container` attribute and use it's value to add the correct element to the page.

#### How should this be reviewed?

👀  commit-by-commit should be easy to follow. 

#### Any background context you want to provide?

Right now, this only assumes that there one HTML element on the page to add a react container component to. This is because we really are just loading in a base container "App" per blade view and then doing all the rendering work via react so doesn't seem like we need to add multiple components to any page as of now. If this changes, we can always update this to be more dynamic. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/150273936

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.