### PR TITLE
Send payload to blink even when updating a post

### DIFF
--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -28,8 +28,6 @@ trait PostRequests
         if (! $updating) {
             $signup = $this->signups->create($request->all());
 
-            // Send the data to the PostService class which will handle determining
-            // which type of post we are dealing with and which repostitory to use to actually create the post.
             $post = $this->posts->create($request->all(), $signup->id, $transactionId);
 
             $code = 200;

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -72,7 +72,6 @@ class PostService
         // Save the new post in Customer.io, via Blink.
         if (config('features.blink')) {
             $payload = $postOrSignup->toBlinkPayload();
-            dd($payload);
             $this->blink->userSignupPost($payload);
         }
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -71,7 +71,8 @@ class PostService
 
         // Save the new post in Customer.io, via Blink.
         if (config('features.blink')) {
-            $payload = $post->toBlinkPayload();
+            $payload = $postOrSignup->toBlinkPayload();
+            dd($payload);
             $this->blink->userSignupPost($payload);
         }
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -69,6 +69,12 @@ class PostService
     {
         $postOrSignup = $this->repository->update($signup, $data);
 
+        // Save the new post in Customer.io, via Blink.
+        if (config('features.blink')) {
+            $payload = $post->toBlinkPayload();
+            $this->blink->userSignupPost($payload);
+        }
+
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 


### PR DESCRIPTION
#### What's this PR do?

We were only making the blink request in the post->create method and not in the post->update method. 

This surfaced a weird logic issue we have in our post creation code where we consider an "update" when a user submits a new post to an existing signup. We only consider it a "create" when we are creating both the signup and the post at the same time. So what ended up happening was we were only sending to blink when we sent over the signup and the post content at the same time (or created the signup on the fly with the post). 

This logic seems flawed and we should look at it, but in an interest to unblock the messaging team, I have added the blink integration to both update and create methods. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
See above. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/150827279

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.