### PR TITLE
Fixes user birthdate bug (if no birthdate, displays age as 47)

### DIFF
--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { map, startCase, keyBy} from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
-import { displayCityState } from '../../helpers';
 
 // Components
 import Post from '../Post';

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { map, startCase, keyBy} from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
-import { calculateAge, displayName, displayCityState } from '../../helpers';
+import { displayCityState } from '../../helpers';
 
 // Components
 import Post from '../Post';

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -4,7 +4,6 @@ import SignupCard from '../SignupCard';
 import { RestApiClient } from '@dosomething/gateway';
 import MetaInformation from '../MetaInformation';
 import UserInformation from '../Users/UserInformation';
-import { calculateAge, displayName, displayCityState } from '../../helpers';
 
 class UserOverview extends React.Component {
   constructor(props) {
@@ -55,8 +54,6 @@ class UserOverview extends React.Component {
 
   render() {
     const user = this.props.user;
-    const cityState = displayCityState(user.addr_city, user.addr_state);
-    const name = displayName(user.first_name, user.last_name);
 
     return (
       <div>

--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { map } from 'lodash';
-import { calculateAge, displayName, displayCityState } from '../../helpers';
+import { displayUserInfo, displayCityState } from '../../helpers';
 
 const UserInformation = (props) => (
   <div>
     {props.user ?
       <div className="container -padded">
-        <h2 className="heading">{displayName(props.user.first_name, props.user.last_name)}, {calculateAge(props.user.birthdate)}</h2>
+        <h2 className="heading">{displayUserInfo(props.user.first_name, props.user.last_name, props.user.birthdate)}</h2>
         <p>
           {props.user.email ? <span>{props.user.email}<br/></span>: null}
           {props.user.mobile ? <span>{props.user.mobile}<br/></span> : null }

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -92,13 +92,12 @@ export function getEditedImageUrl(photoProp) {
  */
 export function displayUserInfo(firstName, lastName, birthDate) {
   let displayName = firstName;
-
   if (lastName) {
     displayName = `${displayName} ${lastName}`;
   }
 
   if (birthDate) {
-    let age = this.calculateAge(birthDate);
+    let age = calculateAge(birthDate);
     return displayName + ', ' + age;
   }
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -14,11 +14,15 @@ export function ready(fn) {
 }
 
 export function calculateAge(date) {
-	const birthdate = new Date(date);
-	const today = Date.now();
-	const age = Math.floor((today - birthdate) / 31536000000);
+  let formattedAge = null;
 
-	return age;
+  if (date) {
+  	const birthdate = new Date(date);
+  	const today = Date.now();
+  	formattedAge = Math.floor((today - birthdate) / 31536000000);
+  }
+
+  return formattedAge;
 };
 
 export function getImageUrlFromProp(photoProp) {
@@ -80,16 +84,22 @@ export function getEditedImageUrl(photoProp) {
 };
 
 /**
- * Returns a readable display name.
+ * Returns a readable display name and age (if provided).
  *
  * @param {String} firstName
  * @param {String} lastName
+ * @param {Date} birthDate
  */
-export function displayName(firstName, lastName) {
+export function displayUserInfo(firstName, lastName, birthDate) {
   let displayName = firstName;
 
   if (lastName) {
     displayName = `${displayName} ${lastName}`;
+  }
+
+  if (birthDate) {
+    let age = this.calculateAge(birthDate);
+    return displayName + ', ' + age;
   }
 
   return displayName;


### PR DESCRIPTION
#### What's this PR do?
- Fixes user birthdate bug (if no birthdate, displays age as 47)
  - Changes `displayName` to `displayUserInfo`
    - Now takes in birthdate as well. If there is a birthdate, it will calculate the user's age and add ", [age]" following display name. 
  - Cleans up and deletes helpers from files where we no longer use them. 

#### How should this be reviewed?
- Check out all pages that list user information (name and age on post). Make sure that if there is no birthdate, the age 47 doesn't appear (also shouldn't have a comma after the name). 
- Did I break any pages that use the user information?

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/149209251

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.