### PR TITLE
Include reaction information with GET /posts

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -25,6 +25,11 @@ class PostTransformer extends TransformerAbstract
      */
     public function transform(Post $post)
     {
+        $reacted = false;
+        if ($post->relationLoaded('reactions')) {
+            $reacted = $post->reactions->isNotEmpty();
+        }
+
         return [
             'id' => $post->id,
             'signup_id' => $post->signup_id,
@@ -36,8 +41,8 @@ class PostTransformer extends TransformerAbstract
             ],
             'tags' => $post->tagSlugs(),
             'reactions' => [
-                'reacted' => $post->reactions->isNotEmpty(),
-                'total' => isset($post->reactions_count) ? $post->reactions_count : 'unavailable',
+                'reacted' => $reacted,
+                'total' => isset($post->reactions_count) ? $post->reactions_count : null,
             ],
             'status' => $post->status,
             'source' => $post->source,

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -30,12 +30,15 @@ class PostTransformer extends TransformerAbstract
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
             'media' => [
-
                 'url' => $post->getMediaUrl(),
                 'original_image_url' => $post->url,
                 'caption' => $post->caption,
             ],
             'tags' => $post->tagSlugs(),
+            'reactions' => [
+                'reacted' => $post->reactions->isNotEmpty() ? true : false,
+                'total' => $post->reactions_count,
+            ],
             'status' => $post->status,
             'source' => $post->source,
             'remote_addr' => $post->remote_addr,

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -36,8 +36,8 @@ class PostTransformer extends TransformerAbstract
             ],
             'tags' => $post->tagSlugs(),
             'reactions' => [
-                'reacted' => $post->reactions->isNotEmpty() ? true : false,
-                'total' => $post->reactions_count,
+                'reacted' => $post->reactions->isNotEmpty(),
+                'total' => isset($post->reactions_count) ? $post->reactions_count : 'unavailable',
             ],
             'status' => $post->status,
             'source' => $post->source,

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -126,7 +126,10 @@ Example Response:
                 "caption": null
             },
             "tags": [],
-            "reactions": [],
+            "reactions": {
+                "reacted": true,
+                "total": 2
+            },
             "status": "accepted",
             "source": null,
             "remote_addr": "52.3.68.224, 52.3.68.224",
@@ -142,6 +145,10 @@ Example Response:
                 "caption": "Perhaps you CAN be of some assistance, Bill"
             },
             "tags": [],
+            "reactions": {
+                "reacted": false,
+                "total": 8
+            },
             "status": "accepted",
             "source": null,
             "remote_addr": "207.110.19.130, 207.110.19.130",


### PR DESCRIPTION
#### What's this PR do?
Added reaction information to the `PostTransformer`. The information included is the number of reactions on the post and and `reacted`. `Reacted` tells whether or not the `as_user` included in the request has reacted to the post. It is `false` if the user did not react or if no user was provided.

#### How should this be reviewed?
👀  This includes additional information in the response (as opposed to altering existing data) so shouldn't break anything.

#### Any background context you want to provide?
This was needed to get the correct reaction data on the user profile in Phoenix.

I went a little bit down a rabbit hole because my local reaction data was funky so wasn't showing up.

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/151011784)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.