### PR TITLE
always use /posts web route

### DIFF
--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -59,7 +59,7 @@ class CampaignSingle extends React.Component {
   getPostsByStatus(status, campaignId) {
     this.setState({ loadingNewPosts: true });
 
-    this.api.get('api/v2/posts', {
+    this.api.get('posts', {
       filter: {
         status: status,
         campaign_id: campaignId,
@@ -76,7 +76,7 @@ class CampaignSingle extends React.Component {
   getPostsByTag(tagSlug, campaignId) {
     this.setState({ loadingNewPosts: true });
 
-    this.api.get('api/v2/posts', {
+    this.api.get('posts', {
       filter: {
         tag: tagSlug,
         campaign_id: campaignId,

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -48,7 +48,7 @@ class CampaignSingle extends React.Component {
     let path = splitEndpoint.slice(-1)[0];
     let queryString = (path.split('?'))[1];
 
-    this.api.get('api/v2/posts', queryString)
+    this.api.get('posts', queryString)
     .then(json => {
       this.setState({loadingNewPosts: false });
       this.props.setNewPosts(json);


### PR DESCRIPTION
#### What's this PR do?

Always use the `GET /posts` web proxy route when grabbing posts for the frontend. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Fixes issues with user info not showing when filtering, or paginating. 

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.