### PR TITLE
Newer posts first on single view page

### DIFF
--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -55,7 +55,7 @@ trait PostRequests
      */
     public function index(Request $request)
     {
-        $query = $this->newQuery(Post::class)->with('signup')->withCount('reactions');
+        $query = $this->newQuery(Post::class)->with('signup')->withCount('reactions')->orderBy('created_at', 'desc');
 
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Post::$indexes);

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -82,6 +82,8 @@ Example Response:
 GET /api/v2/posts
 ```
 
+Posts are returned in reverse chronological order.
+
 ### Optional Query Parameters
 - **limit**
   - Set the number of records to return in a single response.

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { map, sample } from 'lodash';
+import { map, sample, find } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
 
 import { extractPostsFromSignups } from '../../helpers';
@@ -29,8 +29,10 @@ class CampaignInbox extends React.Component {
       return (
         <div className="container">
           {
-            map(posts, (post, key) =>
-              <Post key={key}
+            map(this.props.postIds, (key, value) => {
+              var post = find(posts, {'id': key});
+
+              return <Post key={key}
                 post={post}
                 user={signups[post.signup_id].user.data}
                 signup={signups[post.signup_id]}
@@ -42,7 +44,7 @@ class CampaignInbox extends React.Component {
                 showSiblings={true}
                 showQuantity={true}
                 allowHistory={true} />
-            )
+            })
           }
 
           <ModalContainer>

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { map, orderBy, find } from 'lodash';
+import { map, find } from 'lodash';
 import { RestApiClient} from '@dosomething/gateway';
 import { extractSignupsFromPosts } from '../../helpers';
 
@@ -91,7 +91,6 @@ class CampaignSingle extends React.Component {
 
   render() {
     const posts = this.props.posts;
-    const postOrder = map(orderBy(posts, 'created_at', 'desc'), 'id');
     const campaign = this.props.campaign;
     const signups = this.props.signups;
 
@@ -105,7 +104,7 @@ class CampaignSingle extends React.Component {
           <div className="spinner"></div>
         :
 
-          map(postOrder, (key, value) => {
+          map(this.props.postIds, (key, value) => {
             var post = find(posts, {'id': key});
 
             return <Post key={key}

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { map } from 'lodash';
+import { map, orderBy, find } from 'lodash';
 import { RestApiClient} from '@dosomething/gateway';
 import { extractSignupsFromPosts } from '../../helpers';
 
@@ -91,8 +91,10 @@ class CampaignSingle extends React.Component {
 
   render() {
     const posts = this.props.posts;
+    const postOrder = map(orderBy(posts, 'created_at', 'desc'), 'id');
     const campaign = this.props.campaign;
     const signups = this.props.signups;
+    const props = this.props;
 
     return (
       <div className="container">
@@ -103,22 +105,24 @@ class CampaignSingle extends React.Component {
         {this.props.loading || this.state.loadingNewPosts ?
           <div className="spinner"></div>
         :
-          map(posts, (post, key) =>
-            <Post key={key}
+
+          map(postOrder, function (key, value) {
+            var post = find(posts, {'id': key});
+
+            return <Post key={key}
               post={post}
               user={signups[post.signup_id].user.data}
               signup={signups[post.signup_id]}
               campaign={campaign}
-              onUpdate={this.props.updatePost}
-              onTag={this.props.updateTag}
-              deletePost={this.props.deletePost}
-              showHistory={this.props.showHistory}
+              onUpdate={props.updatePost}
+              onTag={props.updateTag}
+              deletePost={props.deletePost}
+              showHistory={props.showHistory}
               showSiblings={true}
               showQuantity={true}
-              allowHistory={true} />
-          )
+              allowHistory={true} />;
+          })
         }
-
 
         <ModalContainer>
           {this.props.displayHistoryModal ?

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -94,7 +94,6 @@ class CampaignSingle extends React.Component {
     const postOrder = map(orderBy(posts, 'created_at', 'desc'), 'id');
     const campaign = this.props.campaign;
     const signups = this.props.signups;
-    const props = this.props;
 
     return (
       <div className="container">
@@ -106,7 +105,7 @@ class CampaignSingle extends React.Component {
           <div className="spinner"></div>
         :
 
-          map(postOrder, function (key, value) {
+          map(postOrder, (key, value) => {
             var post = find(posts, {'id': key});
 
             return <Post key={key}
@@ -114,10 +113,10 @@ class CampaignSingle extends React.Component {
               user={signups[post.signup_id].user.data}
               signup={signups[post.signup_id]}
               campaign={campaign}
-              onUpdate={props.updatePost}
-              onTag={props.updateTag}
-              deletePost={props.deletePost}
-              showHistory={props.showHistory}
+              onUpdate={this.props.updatePost}
+              onTag={this.props.updateTag}
+              deletePost={this.props.deletePost}
+              showHistory={this.props.showHistory}
               showSiblings={true}
               showQuantity={true}
               allowHistory={true} />;

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -62,6 +62,7 @@ const reviewComponent = (Component, data) => {
       this.setState({
         campaign: data.campaign,
         posts: posts,
+        postIds: map(orderBy(posts, 'created_at', 'desc'), 'id'),
         signups: extractSignupsFromPosts(posts),
         filter: status,
         postTotals: apiResponse.meta.pagination.total,

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { keyBy } from 'lodash';
+import { keyBy, orderBy, map } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
 import { extractPostsFromSignups, extractSignupsFromPosts } from '../../helpers';
 
@@ -45,6 +45,7 @@ const reviewComponent = (Component, data) => {
       .then(json => this.setState({
         campaign: data.campaign,
         posts: keyBy(json.data, 'id'),
+        postIds: map(orderBy(json.data, 'created_at', 'desc'), 'id'),
         signups: extractSignupsFromPosts(keyBy(json.data, 'id')),
         filter: status,
         postTotals: json.meta.pagination.total,

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { keyBy, orderBy, map } from 'lodash';
+import { keyBy, map } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
 import { extractPostsFromSignups, extractSignupsFromPosts } from '../../helpers';
 
@@ -45,7 +45,7 @@ const reviewComponent = (Component, data) => {
       .then(json => this.setState({
         campaign: data.campaign,
         posts: keyBy(json.data, 'id'),
-        postIds: map(orderBy(json.data, 'created_at', 'desc'), 'id'),
+        postIds: map(json.data, 'id'),
         signups: extractSignupsFromPosts(keyBy(json.data, 'id')),
         filter: status,
         postTotals: json.meta.pagination.total,
@@ -62,7 +62,7 @@ const reviewComponent = (Component, data) => {
       this.setState({
         campaign: data.campaign,
         posts: posts,
-        postIds: map(orderBy(posts, 'created_at', 'desc'), 'id'),
+        postIds: map(posts, 'id'),
         signups: extractSignupsFromPosts(posts),
         filter: status,
         postTotals: apiResponse.meta.pagination.total,


### PR DESCRIPTION
#### What's this PR do?
All `GET /posts` endpoints return newer posts first. Anywhere using `keyBy` or `map` or anything like that on this data that doesn't have the changes made below shouldn't see any change in the order of the posts. This endpoint needed to return the posts in order because otherwise they will end up sorted per page and not overall.

Then, instead of mapping over all the posts and then creating a `<Post>` for each one, we map over an array of the correctly ordered post IDs and then grab the corresponding information from the list of full posts to build the `<Post>`.

Also, for some reason `this` was out of scope once I made these changes so I declared `props = this.props` as well. That seemed a little weird to me.

#### How should this be reviewed?
Is everything in the right order? Did that break anything else?

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/150689090)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.