### PR TITLE
Include quantity and why_participated in Blink payload

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -158,6 +158,8 @@ class Post extends Model
         return [
             'id' => $this->id,
             'signup_id' => $this->signup_id,
+            'quantity' => $this->signup->quantity,
+            'why_participated' => $this->signup->why_participated,
             'campaign_id' => $this->campaign_id,
             'campaign_run_id' => $this->campaign_run_id,
             'northstar_id' => $this->northstar_id,


### PR DESCRIPTION
#### What's this PR do?
Added 2 more fields to the payload we sent to Blink for Posts (quantity and why_participated) that we grab off of the signup.

#### How should this be reviewed?
Will this send the correct information to Blink?

#### Any background context you want to provide?
Nope!

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/150860659)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.