### PR TITLE
Show edited image

### DIFF
--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -81,7 +81,7 @@ class Post extends React.Component {
               <div className="spinner"></div>
             </div>
           :
-            <img className="post__image" src={getImageUrlFromProp(post)}/>
+            <img className="post__image" src={getEditedImageUrl(post)}/>
           }
           <div className="admin-tools">
             <div className="admin-tools__links">

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -35,7 +35,7 @@ export function getImageUrlFromProp(photoProp) {
     photo_url = photoProp['url'];
   }
   else if ('media' in photoProp) {
-    photo_url = photoProp['media']['url'];
+    photo_url = photoProp['media']['original_image_url'];
   }
 
 


### PR DESCRIPTION
#### What's this PR do?
I introduced a bug in my last PR where I updated `getImageUrlFromProp()` to return the "edited" url, or the URL we process separately to make it smaller and cropped. This caused us to use the edited image wherever we called `getImageUrlFromProp()` which messed up the "original photo" link.

This updates the logic to pull large tile image in a Post from `getEditedUrl()` so we are using that to render the image and grabbing the actual original image url for the "original photo" link.

👀 
#### Any background context you want to provide?

When we turn on Glide, we can then use the Glide API to grab the correct image for display, but for now, I am using the edited image URL. 

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.