### PR TITLE
Move homepage into web group

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -11,11 +11,11 @@
 |
 */
 
-Route::get('/', function () {
-    return view('pages.home');
-})->middleware('guest');
-
 Route::group(['middleware' => 'web'], function () {
+    Route::get('/', function () {
+        return view('pages.home');
+    })->middleware('guest');
+
     // Authentication
     Route::get('login', 'Auth\AuthController@getLogin');
     Route::get('logout', 'Auth\AuthController@getLogout');


### PR DESCRIPTION
#### What's this PR do?
Hitting the homepage didn't behave as expected (never thought anyone was logged in so always showed the "Log In" view) because that route was not in the `web` group. My understanding is that only routes in the `web` group will have access to session information, which is needed to call `Auth::guard($guard)`, which is what we check to see if anyone is logged in in the [`RedirectIfAuthenticated.php`](https://github.com/DoSomething/rogue/blob/master/app/Http/Middleware/RedirectIfAuthenticated.php#L20) middleware.

#### How should this be reviewed?
👀  Make sure the behavior is the same as always for anyone not logged in. Once you are logged in (as an admin), you should be able to hit the homepage or click the DoSomething logo in the top left corner and be redirected to the `/campaigns` page.

#### Any background context you want to provide?
The middleware was fine, the route just did not live in the right place!

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/150849212)

#### Checklist
- [ ] Tested on staging.