### PR TITLE
Don't keyBy before getting the order

### DIFF
--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -62,7 +62,7 @@ const reviewComponent = (Component, data) => {
       this.setState({
         campaign: data.campaign,
         posts: posts,
-        postIds: map(posts, 'id'),
+        postIds: map(apiResponse.data, 'id'),
         signups: extractSignupsFromPosts(posts),
         filter: status,
         postTotals: apiResponse.meta.pagination.total,


### PR DESCRIPTION
#### What's this PR do?
The data I tested this with locally wasn't the best example because the correct order for it was also numerical order! I was mistakenly getting the order of posts based on the already `keyBy`-ed `posts`. Instead, use the API Response itself which will be in the correct order.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Just a little oopsie.

#### Checklist
- [ ] Tested on staging.