### PR TITLE
Fixes filter bug and returns value only for specified campaign 

### DIFF
--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -58,7 +58,7 @@ class CampaignSingle extends React.Component {
     });
 
     let formattedFilters = {
-      'campaignId': this.props.campaign.id,
+      'campaign_id': this.props.campaign.id,
       'status': filters.status,
     };
 


### PR DESCRIPTION
#### What's this PR do?
Changes case of `campaign_id` filter to be in expected case (instead of camelCase). This fixes the bug we were seeing where the filters would return ALL pending posts instead of just pending posts (and other filters) for a specific campaign. 

#### How should this be reviewed?
👀  and make sure that filtered results are for only the campaign page you're on. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/151224000

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.