### PR TITLE
Tag loading state bug

### DIFF
--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -128,7 +128,7 @@ class Post extends React.Component {
         {/* Review block and meta data */}
         <div className="container__block -third">
           <div className="container__row">
-            <ReviewBlock post={post} onUpdate={this.props.onUpdate} onTag={this.props.onTag} deletePost={this.props.deletePost} />
+            <ReviewBlock post={this.props.post} onUpdate={this.props.onUpdate} onTag={this.props.onTag} deletePost={this.props.deletePost} />
           </div>
           <div className="container__row">
             <MetaInformation title="Meta" details={{

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -75,7 +75,7 @@ class Post extends React.Component {
     return (
       <div className="post container__row">
         {/* Post Images */}
-        <div className="container__block -third">
+        <div className="container__block -third images">
           {this.state.loading ?
             <div className="is-loading">
               <div className="spinner"></div>

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -20,10 +20,16 @@ class Post extends React.Component {
 
     this.state = {
       loading: false,
-      post: this.props.post
+      post: this.props.post,
     };
 
     this.api = new RestApiClient;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.post !== this.state.post) {
+      this.setState({ post: nextProps.post });
+    }
   }
 
   rotate(event) {
@@ -128,7 +134,7 @@ class Post extends React.Component {
         {/* Review block and meta data */}
         <div className="container__block -third">
           <div className="container__row">
-            <ReviewBlock post={this.props.post} onUpdate={this.props.onUpdate} onTag={this.props.onTag} deletePost={this.props.deletePost} />
+            <ReviewBlock post={post} onUpdate={this.props.onUpdate} onTag={this.props.onTag} deletePost={this.props.deletePost} />
           </div>
           <div className="container__row">
             <MetaInformation title="Meta" details={{

--- a/resources/assets/components/Post/post.scss
+++ b/resources/assets/components/Post/post.scss
@@ -28,7 +28,7 @@
     height: 300px;
   }
 
-  .is-loading {
+  .images .is-loading {
     display: table;
     width: 300px;
     height: 300px;

--- a/resources/assets/components/Tags/tags.scss
+++ b/resources/assets/components/Tags/tags.scss
@@ -15,12 +15,7 @@
   margin: 10px 10px 0 0;
   border-radius: 5px;
 
-  &:hover {
-    background: $blue;
-    color: $white;
-  }
-
-  &:active, &.is-active {
+  &:active, &.is-active, &is-loading {
     background: $blue;
     color: $white;
   }


### PR DESCRIPTION
#### What's this PR do?
Fixes bugs around tagging.

These bugs were introduced with the rotation work. 

We pass in a `post` prop to the `Post` component and everytime a tag gets clicked we re-render the post based on the `post` property. 

The issue was after the rotation work, I set a `state.props` property so that we can update the media url when the rotation was finished. 

Now, when the `post` prop was updated, the state never got the change, so the tags did not update their active/inactive styles.

This uses `componentWillReceiveProps` to update `state.post` when we send in new props. 

Also fixing some styling things that seemed weird with the loading/not-loading states.

#### How should this be reviewed?

commit-by-commit 👀 


#### Any background context you want to provide?

It might be worth a little refactor of the `Post` and `Tags` components so this is a little bit more understandable, but this helps us fix the immediate bug. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/151230061

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.