### PR TITLE
Add query string to posts

### DIFF
--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Controllers;
 
+use Carbon\Carbon;
 use Rogue\Models\Post;
 use Rogue\Services\AWS;
 use Illuminate\Http\Request;
@@ -99,8 +100,8 @@ class ImagesController extends Controller
         $editedImage = $this->aws->storeImageData((string) $editedImage, 'edited_' . $post->id);
 
         return response()->json([
-            'url' => $editedImage,
-            'original_image_url' => $originalImage,
+            'url' => $editedImage . '?time='. Carbon::now()->timestamp,
+            'original_image_url' => $originalImage . '?time='. Carbon::now()->timestamp,
         ]);
     }
 

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -35,9 +35,12 @@ class PostTransformer extends TransformerAbstract
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
+            // Add cache-busting query string to urls to make sure we get the
+            // most recent version of the image.
+            // @NOTE - Remove if we get rid of rotation.
             'media' => [
-                'url' => $post->getMediaUrl() . '?time='. Carbon::now(),
-                'original_image_url' => $post->url . '?time='. Carbon::now(),
+                'url' => $post->getMediaUrl() . '?time='. Carbon::now()->timestamp,
+                'original_image_url' => $post->url . '?time='. Carbon::now()->timestamp,
                 'caption' => $post->caption,
             ],
             'tags' => $post->tagSlugs(),

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -35,8 +35,8 @@ class PostTransformer extends TransformerAbstract
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
             'media' => [
-                'url' => $post->getMediaUrl(),
-                'original_image_url' => $post->url,
+                'url' => $post->getMediaUrl() . '?time='. Carbon::now(),
+                'original_image_url' => $post->url . '?time='. Carbon::now(),
                 'caption' => $post->caption,
             ],
             'tags' => $post->tagSlugs(),

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Transformers;
 
+use Carbon\Carbon;
 use Rogue\Models\Post;
 use League\Fractal\TransformerAbstract;
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -158,6 +158,7 @@ class CampaignSingle extends React.Component {
               onTag={this.props.updateTag}
               deletePost={this.props.deletePost}
               showHistory={this.props.showHistory}
+              rotate={this.props.rotate}
               showSiblings={true}
               showQuantity={true}
               allowHistory={true} />;

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { remove, map, clone } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
-import { getImageUrlFromProp, getEditedImageUrl, displayCaption } from '../../helpers';
+import { getImageUrlFromPost, getEditedImageUrl, displayCaption } from '../../helpers';
 
 import './post.scss';
 
@@ -66,21 +66,21 @@ class Post extends React.Component {
       <div className="post container__row">
         {/* Post Images */}
         <div className="container__block -third images">
-          {this.state.loading ?
-            <div className="is-loading">
-              <div className="spinner"></div>
-            </div>
-          :
-            <img className="post__image" src={getEditedImageUrl(post)}/>
-          }
+          <div className="post__image">
+            <img src={getImageUrlFromPost(post, 'edited')}/>
+          </div>
           <div className="admin-tools">
             <div className="admin-tools__links">
-              <a href={getImageUrlFromProp(post)} target="_blank">Original Photo</a>
+              <a href={getImageUrlFromPost(post, 'original')} target="_blank">Original Photo</a>
               <br />
-              <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
+              <a href={getImageUrlFromPost(post, 'edited')} target="_blank">Edited Photo</a>
             </div>
             <div className="admin-tools__rotate">
-              <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
+              {this.state.loading ?
+                <div className="spinner"></div>
+              :
+                <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
+              }
             </div>
           </div>
           {this.props.showSiblings ?

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -75,13 +75,15 @@ class Post extends React.Component {
               <br />
               <a href={getImageUrlFromPost(post, 'edited')} target="_blank">Edited Photo</a>
             </div>
-            <div className="admin-tools__rotate">
-              {this.state.loading ?
-                <div className="spinner"></div>
-              :
-                <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
-              }
-            </div>
+            {this.props.rotate ?
+              <div className="admin-tools__rotate">
+                {this.state.loading ?
+                  <div className="spinner"></div>
+                :
+                  <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
+                }
+              </div>
+            }
           </div>
           {this.props.showSiblings ?
             <ul className="gallery -duo">

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -83,7 +83,7 @@ class Post extends React.Component {
                   <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
                 }
               </div>
-            }
+            : null}
           </div>
           {this.props.showSiblings ?
             <ul className="gallery -duo">

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -80,7 +80,7 @@ class Post extends React.Component {
                 {this.state.loading ?
                   <div className="spinner"></div>
                 :
-                  <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
+                  <a className="button -tertiary rotate" onClick={this.handleClick}></a>
                 }
               </div>
             : null}

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -20,37 +20,21 @@ class Post extends React.Component {
 
     this.state = {
       loading: false,
-      post: this.props.post,
     };
 
     this.api = new RestApiClient;
+    this.handleClick = this.handleClick.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.post !== this.state.post) {
-      this.setState({ post: nextProps.post });
-    }
-  }
-
-  rotate(event) {
+  handleClick(event) {
     event.preventDefault();
-    this.setState({loading: true});
 
-    const post = this.props.post;
+    this.setState({ loading: true });
 
-    this.api.post(`images/${post.id}?rotate=90`)
-    .then((json) => {
-      this.setState((prevState) => {
-        const newState = {...prevState};
-
-        newState.loading = false;
-        // Add a cache-busting string to the end of the image url
-        // so that it changes and triggers a re-render.
-        newState.post.media.url = `${json.url}?time=${new Date()}`;
-
-        return newState;
+    this.props.rotate(this.props.post.id)
+      .then(() => {
+        this.setState({ 'loading' : false });
       });
-    });
   }
 
   getOtherPosts(post) {
@@ -72,7 +56,7 @@ class Post extends React.Component {
   }
 
   render() {
-    const post = this.state.post;
+    const post = this.props.post;
     const caption = displayCaption(post);
     const user = this.props.user ? this.props.user : null;
     const signup = this.props.signup;
@@ -96,7 +80,7 @@ class Post extends React.Component {
               <a href={getEditedImageUrl(post)} target="_blank">Edited Photo</a>
             </div>
             <div className="admin-tools__rotate">
-              <a className="button -tertiary rotate" onClick={(event) => this.rotate(event) }></a>
+              <a className="button -tertiary rotate" onClick={(event) => this.handleClick(event)}></a>
             </div>
           </div>
           {this.props.showSiblings ?

--- a/resources/assets/components/Post/post.scss
+++ b/resources/assets/components/Post/post.scss
@@ -20,24 +20,46 @@
 
     .admin-tools__rotate {
       float: right;
+
+      .spinner {
+        background-size: 20px;
+      }
     }
   }
 
   .post__image {
-    width: 300px;
-    height: 300px;
+    // .spinner {
+    //   width: 15px;
+    //   height: 15px;
+    // }
+    // // width: 250px;
+    // // height: 250px;
+    // background-color: grey;
+    // display: table;
+
+    // // img, .is-loading {
+    // //   display: table-cell;
+    // //   vertical-align: middle;
+    // // }
+
+    // // .is-loading {
+    // //   // display: table;
+    // //   width: 300px;
+    // //   height: 300px;
+    // //   // height: 300px;
+
+    // //   // .spinner {
+    // //   //   display: table-cell;
+    // //   //   vertical-align: middle;
+    // //   // }
+    // // }
+
+    // // img {
+    // //   width: 300px;
+    // //   height: auto;
+    // // }
   }
 
-  .images .is-loading {
-    display: table;
-    width: 300px;
-    height: 300px;
-
-    .spinner {
-      display: table-cell;
-      vertical-align: middle;
-    }
-  }
 
   .button.-tertiary {
     padding: 0px;

--- a/resources/assets/components/Post/post.scss
+++ b/resources/assets/components/Post/post.scss
@@ -27,40 +27,6 @@
     }
   }
 
-  .post__image {
-    // .spinner {
-    //   width: 15px;
-    //   height: 15px;
-    // }
-    // // width: 250px;
-    // // height: 250px;
-    // background-color: grey;
-    // display: table;
-
-    // // img, .is-loading {
-    // //   display: table-cell;
-    // //   vertical-align: middle;
-    // // }
-
-    // // .is-loading {
-    // //   // display: table;
-    // //   width: 300px;
-    // //   height: 300px;
-    // //   // height: 300px;
-
-    // //   // .spinner {
-    // //   //   display: table-cell;
-    // //   //   vertical-align: middle;
-    // //   // }
-    // // }
-
-    // // img {
-    // //   width: 300px;
-    // //   height: auto;
-    // // }
-  }
-
-
   .button.-tertiary {
     padding: 0px;
     &.rotate {

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -203,7 +203,7 @@ const reviewComponent = (Component, data) => {
 
           // Add a cache-busting string to the end of the image url
           // so that it changes and triggers a re-render.
-          newState.posts[postId].media.url = `${json.url}?time=${new Date()}`;
+          newState.posts[postId].media.url = json.url;
 
           return newState;
         });

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -20,6 +20,7 @@ const reviewComponent = (Component, data) => {
       this.hideHistory = this.hideHistory.bind(this);
       this.deletePost = this.deletePost.bind(this);
       this.setNewPosts = this.setNewPosts.bind(this);
+      this.rotate = this.rotate.bind(this);
     }
 
     // Loads initial posts into state.
@@ -190,6 +191,26 @@ const reviewComponent = (Component, data) => {
       }
     }
 
+    // Rotate a Post Image.
+    rotate(postId) {
+      const post = this.state.posts[postId];
+
+      let response = this.api.post(`images/${postId}?rotate=90`);
+
+      return response.then((json) => {
+        this.setState((prevState) => {
+          const newState = {...prevState};
+
+          // Add a cache-busting string to the end of the image url
+          // so that it changes and triggers a re-render.
+          newState.posts[postId].media.url = `${json.url}?time=${new Date()}`;
+
+          return newState;
+        });
+      });
+    }
+
+
     render() {
       const methods = {
         updatePost: this.updatePost,
@@ -199,6 +220,7 @@ const reviewComponent = (Component, data) => {
         hideHistory: this.hideHistory,
         deletePost: this.deletePost,
         setNewPosts: this.setNewPosts,
+        rotate: this.rotate,
       };
 
       // Pass in the state from this HoC to trigger rendering down the DOM

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -257,7 +257,7 @@ function stripExifData(image, dv = null) {
   return new Blob([dataView], { type: 'image/jpeg' });
 }
 
-// DEPRECIATED: Uses getImageUrlFromPost() instead.
+// DEPRECATED: Uses getImageUrlFromPost() instead.
 export function getImageUrlFromProp(photoProp) {
   let photo_url;
 
@@ -280,7 +280,7 @@ export function getImageUrlFromProp(photoProp) {
   }
 };
 
-// DEPRECIATED: Uses getImageUrlFromPost() instead.
+// DEPRECATED: Uses getImageUrlFromPost() instead.
 export function getEditedImageUrl(photoProp) {
   const edited_file_name = `edited_${photoProp.id}.jpeg`;
   var url_parts;

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -25,28 +25,6 @@ export function calculateAge(date) {
   return formattedAge;
 };
 
-export function getImageUrlFromProp(photoProp) {
-	let photo_url;
-
-  // Sometimes we get the url right on the post and sometimes it is nested under
-  // media (in cases where it goes through the PostTransformer), so handle both cases
-  // @TODO: make sure everything goes through a transformer so we don't need this
-  if ('url' in photoProp) {
-    photo_url = photoProp['url'];
-  }
-  else if ('media' in photoProp) {
-    photo_url = photoProp['media']['original_image_url'];
-  }
-
-
-  if (photo_url == "default") {
-    return "https://www.dosomething.org/sites/default/files/JenBugError.png";
-  }
-	else {
-	  return photo_url;
-	}
-};
-
 export function extractPostsFromSignups(signups) {
   const posts = keyBy(flatMap(signups, signup => {
     return signup.posts;
@@ -62,26 +40,6 @@ export function extractSignupsFromPosts(posts) {
 
   return signups;
 }
-
-export function getEditedImageUrl(photoProp) {
-  const edited_file_name = `edited_${photoProp.id}.jpeg`;
-  var url_parts;
-
-  // Sometimes we get the url right on the post and sometimes it is nested under
-  // media (in cases where it goes through the PostTransformer), so handle both cases
-  if ('url' in photoProp) {
-    url_parts = photoProp['url'].split("/");
-    url_parts.pop();
-    url_parts.push(edited_file_name);
-
-    return url_parts.join('/');
-  }
-  else if ('media' in photoProp) {
-    return photoProp['media']['url'];
-  }
-
-  return null;
-};
 
 /**
  * Returns a readable display name and age (if provided).
@@ -298,3 +256,77 @@ function stripExifData(image, dv = null) {
   // We can just create a blob with the original data.
   return new Blob([dataView], { type: 'image/jpeg' });
 }
+
+// DEPRECIATED: Uses getImageUrlFromPost() instead.
+export function getImageUrlFromProp(photoProp) {
+  let photo_url;
+
+  // Sometimes we get the url right on the post and sometimes it is nested under
+  // media (in cases where it goes through the PostTransformer), so handle both cases
+  // @TODO: make sure everything goes through a transformer so we don't need this
+  if ('url' in photoProp) {
+    photo_url = photoProp['url'];
+  }
+  else if ('media' in photoProp) {
+    photo_url = photoProp['media']['original_image_url'];
+  }
+
+
+  if (photo_url == "default") {
+    return "https://www.dosomething.org/sites/default/files/JenBugError.png";
+  }
+  else {
+    return photo_url;
+  }
+};
+
+// DEPRECIATED: Uses getImageUrlFromPost() instead.
+export function getEditedImageUrl(photoProp) {
+  const edited_file_name = `edited_${photoProp.id}.jpeg`;
+  var url_parts;
+
+  // Sometimes we get the url right on the post and sometimes it is nested under
+  // media (in cases where it goes through the PostTransformer), so handle both cases
+  if ('url' in photoProp) {
+    url_parts = photoProp['url'].split("/");
+    url_parts.pop();
+    url_parts.push(edited_file_name);
+
+    return url_parts.join('/');
+  }
+  else if ('media' in photoProp) {
+    return photoProp['media']['url'];
+  }
+
+  return null;
+};
+
+/*
+ * Given a transformed post object, return the url based on type.
+ *
+ * @param  {Object} post
+ * @return {String|null}
+ * @todo Eventually deal with other file types.
+ */
+export function getImageUrlFromPost(post, type) {
+  let url = null;
+  const defaultPhotoUrl = "https://www.dosomething.org/sites/default/files/JenBugError.png";
+
+  // Make sure media property is included in the Post.
+  if (! ('media' in post)) {
+    return url;
+  }
+
+  switch(type) {
+    case 'original':
+      url = post['media']['original_image_url'];
+      break;
+    case 'edited':
+      url = post['media']['url'];
+      break;
+    default:
+      break;
+  }
+
+  return url === "default" ?  defaultPhotoUrl : url;
+};


### PR DESCRIPTION
#### What's this PR do?
This PR does two things: 

1) [Adds a cache-busting timestamp](https://github.com/DoSomething/rogue/commit/bf2b0196054cfe6390a34566f35922e6461e64b4)
 to image urls in the response we return in the Post transformer so that we always get the new image on page reloads. 
    * I'm not sure if this is the best approach since we do really want the cached image for better performance. 
      - One option could be to only return the image with the query string if it is updated. This would require us to actually update the post record to know if it has been updated or not. We currently don't do that. Also that brings up another issue where any updates we make to Post records will cause an event log in the `events` table. So we can talk through what we really want. 

2) A little refactoring of the `Post` component. We define the `rotate` function on the parent component and pass it in as a prop so that it doesn't have to maintain it's own state and can get updated images. 

3) Refactoring of some of the image URL helpers. We had two function to grab the original image url and the edited image url. And both of these functions had to take into account that on some pages we were grabbing posts via the API and getting one response structure, and on other pages we were getting posts directly from the DB and using another response structure. 

Things have normalized a bit and we are always grabbing images via posts return in the API. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/150746155

There was an issue where after you rotated and image, if you reloaded the page, you couldn't see your updated image because of caching issues. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.