### PR TITLE
Link user name to signup, if specified

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -41,6 +41,7 @@ class CampaignInbox extends React.Component {
                 onTag={this.props.updateTag}
                 deletePost={this.props.deletePost}
                 showHistory={this.props.showHistory}
+                rotate={this.props.rotate}
                 showSiblings={true}
                 showQuantity={true}
                 allowHistory={true} />

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -96,7 +96,7 @@ class Post extends React.Component {
 
         {/* User and Post information */}
         <div className="container__block -third">
-          <UserInformation user={user}>
+          <UserInformation user={user} linkSignup={signup.signup_id}>
             {signup.quantity && this.props.showQuantity ?
               <Quantity quantity={signup.quantity} noun={campaign.reportback_info.noun} verb={campaign.reportback_info.verb} />
             : null}

--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -6,7 +6,11 @@ const UserInformation = (props) => (
   <div>
     {props.user ?
       <div className="container -padded">
-        <h2 className="heading">{displayUserInfo(props.user.first_name, props.user.last_name, props.user.birthdate)}</h2>
+        {props.linkSignup ?
+          <h2 className="heading"><a href={`/signups/${props.linkSignup}`}>{displayUserInfo(props.user.first_name, props.user.last_name, props.user.birthdate)}</a></h2>
+        :
+          <h2 className="heading">{displayUserInfo(props.user.first_name, props.user.last_name, props.user.birthdate)}</h2>
+        }
         <p>
           {props.user.email ? <span>{props.user.email}<br/></span>: null}
           {props.user.mobile ? <span>{props.user.mobile}<br/></span> : null }


### PR DESCRIPTION
#### What's this PR do?

Adds a prop to the `UserInformation` component to decide of it should link to a signup or not. The prop should pass the signup id to link to and then link to it. 

Also fixes a little bug where I didn't pass the rotation functionality to `Posts` on inbox pages.

#### How should this be reviewed?

👀 

#### Any background context you want to provide?
Cause it just makes sense.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/151141191

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.