### PR TITLE
Individual signup page order change and added information 

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -27,7 +27,7 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
-        if ($request->query('orderByPost') === 'desc') {
+        if ($request->query('orderBy') === 'desc') {
             $query = $this->newQuery(Signup::class)->with('posts')->orderBy('created_at', 'desc');
         } else {
             $query = $this->newQuery(Signup::class)->with('posts');
@@ -37,12 +37,13 @@ class ActivityController extends ApiController
 
         $query = $this->filter($query, $filters, Signup::$indexes);
 
-        // if ($request->query('limit') === 'all') {
+        if (($request->query('limit') === 'all')) {
+            $signups = Signup::where([
+                'northstar_id' => $filters['northstar_id'],
+            ])->with('posts')->orderBy('created_at', 'desc')->get();
 
-        //     dd($request->query['parameters']);
-        //     // unset($request->query('limit'));
-        //     return $this->collection($query, $request);
-        // }
+            return $this->collection($signups);
+        }
 
         return $this->paginatedCollection($query, $request);
     }

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -39,6 +39,7 @@ class ActivityController extends ApiController
 
         if (($request->query('limit') === 'all')) {
             $signups = $query->get();
+
             return $this->collection($signups);
         }
 

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -38,10 +38,7 @@ class ActivityController extends ApiController
         $query = $this->filter($query, $filters, Signup::$indexes);
 
         if (($request->query('limit') === 'all')) {
-            $signups = Signup::where([
-                'northstar_id' => $filters['northstar_id'],
-            ])->with('posts')->orderBy('created_at', 'desc')->get();
-
+            $signups = $query->get();
             return $this->collection($signups);
         }
 

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -28,7 +28,10 @@ class ActivityController extends ApiController
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
         if ($request->query('orderBy') === 'desc') {
-            $query = $this->newQuery(Signup::class)->with('posts')->orderBy('created_at', 'desc');
+            // $query = $this->newQuery(Signup::class)->with('posts')->orderBy('posts.created_at', 'desc');
+            $query = Signup::with(['posts' => function ($q) {
+                $q->orderBy('created_at', 'desc');
+            }]);
         } else {
             $query = $this->newQuery(Signup::class)->with('posts');
         }

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -27,7 +27,7 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
-        if ($request->query('orderBy') === 'desc') {
+        if ($request->query('orderByPost') === 'desc') {
             // $query = $this->newQuery(Signup::class)->with('posts')->orderBy('posts.created_at', 'desc');
             $query = Signup::with(['posts' => function ($q) {
                 $q->orderBy('created_at', 'desc');

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -27,10 +27,10 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
+        $query = $this->newQuery(Signup::class)->with('posts');
+
         if ($request->query('orderBy') === 'desc') {
-            $query = $this->newQuery(Signup::class)->with('posts')->orderBy('created_at', 'desc');
-        } else {
-            $query = $this->newQuery(Signup::class)->with('posts');
+            $query = $query->orderBy('created_at', 'desc');
         }
 
         $filters = $request->query('filter');

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -27,9 +27,14 @@ class ActivityController extends ApiController
     {
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
-        $query = $this->newQuery(Signup::class)->with('posts');
+        if ($request->query('orderBy') === 'desc') {
+            $query = $this->newQuery(Signup::class)->with('posts')->orderBy('created_at', 'desc');
+        } else {
+            $query = $this->newQuery(Signup::class)->with('posts');
+        }
 
         $filters = $request->query('filter');
+
         $query = $this->filter($query, $filters, Signup::$indexes);
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -28,10 +28,7 @@ class ActivityController extends ApiController
         // Create an empty Signup query and eager-load posts, which we
         // can either filter or paginate to retrieve all signup records.
         if ($request->query('orderByPost') === 'desc') {
-            // $query = $this->newQuery(Signup::class)->with('posts')->orderBy('posts.created_at', 'desc');
-            $query = Signup::with(['posts' => function ($q) {
-                $q->orderBy('created_at', 'desc');
-            }]);
+            $query = $this->newQuery(Signup::class)->with('posts')->orderBy('created_at', 'desc');
         } else {
             $query = $this->newQuery(Signup::class)->with('posts');
         }
@@ -39,6 +36,13 @@ class ActivityController extends ApiController
         $filters = $request->query('filter');
 
         $query = $this->filter($query, $filters, Signup::$indexes);
+
+        // if ($request->query('limit') === 'all') {
+
+        //     dd($request->query['parameters']);
+        //     // unset($request->query('limit'));
+        //     return $this->collection($query, $request);
+        // }
 
         return $this->paginatedCollection($query, $request);
     }

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -12,6 +12,7 @@ GET /api/v2/activity
   - You can filter by more than one value for a column, e.g. `/activity?filter[id]=121,122`
 - **limit** _(default is 20)_
   - Set the number of records to return in a single response.
+  - If limit is set to 'all' (e.g. `limit='all'`), results will not be paginated.
   - e.g. `/activity?limit=35`
 - **page** _(integer)_
   - For pagination, specify page of activity to return in the response.

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -19,6 +19,11 @@ GET /api/v2/activity
 - **include** _(integer)_
   - Include additional related records in the response: `user`
   - e.g. `/activity?include=user`
+- **orderBy** _(string)_
+  - Determines order results are returned, based on created_at timestamp.
+  - If 'desc' is not passed through, defaults to ascending order. 
+  - Otherwise, results will be returned from last created first. 
+  - e.g. `/activity'?orderBy=desc`
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -19,11 +19,11 @@ GET /api/v2/activity
 - **include** _(integer)_
   - Include additional related records in the response: `user`
   - e.g. `/activity?include=user`
-- **orderBy** _(string)_
-  - Determines order results are returned, based on created_at timestamp.
-  - If 'desc' is not passed through, defaults to ascending order. 
-  - Otherwise, results will be returned from last created first. 
-  - e.g. `/activity'?orderBy=desc`
+- **orderByPosts** _(string)_
+  - Determines order the results are returned, based on the post's created_at timestamp.
+  - If 'desc' is not passed through, defaults to return results by signup's created_at by ascending order. 
+  - Otherwise, results will be returned with the last created post first. 
+  - e.g. `/activity'?orderByPost=desc`
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -19,10 +19,9 @@ GET /api/v2/activity
 - **include** _(integer)_
   - Include additional related records in the response: `user`
   - e.g. `/activity?include=user`
-- **orderByPosts** _(string)_
-  - Determines order the results are returned, based on the post's created_at timestamp.
+- **orderBy** _(string)_
+  - Determines order the results are returned, based on the signups's created_at timestamp.
   - If 'desc' is not passed through, defaults to return results by signup's created_at by ascending order. 
-  - Otherwise, results will be returned with the last created post first. 
   - e.g. `/activity'?orderByPost=desc`
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -16,7 +16,20 @@ class SignupCard extends React.Component {
     const posts = signup.posts.data.slice(0, gallerySize).map((post, index) => {
       return <PostTile key={index} details={post} />;
     });
+
     const signupUrl = `/signups/${signup.signup_id}`;
+
+    var campaign_run_start_date = null;
+
+    for (var key in campaign.campaign_runs.current) {
+      if (campaign.campaign_runs.current[key]['id'] == signup.campaign_run_id) {
+        const date = campaign.campaign_runs.current[key]['start_date'];
+
+        if (date) {
+          campaign_run_start_date = campaign.campaign_runs.current[key]['start_date'].split(" ")[0];
+        }
+      }
+    }
 
     return (
         <article className="container__row signup-card">
@@ -24,7 +37,11 @@ class SignupCard extends React.Component {
             <div className="container__block -half">
               <div className="container__row">
                 <h2 className="heading">{campaign ? campaign.title : signup.campaign_id}</h2>
+                <h4 className="heading">Campaign ID: {signup.campaign_id}</h4>
                 <h4 className="heading">Campaign Run ID: {signup.campaign_run_id}</h4>
+                { campaign_run_start_date ?
+                  <h4 className="heading">Campaign Run Start Date: {campaign_run_start_date}</h4>
+                :null }
               </div>
               <div className="container__row">
                 <h4 className="heading">Why Statement</h4>

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -6,6 +6,26 @@ import { RestApiClient } from '@dosomething/gateway';
 import { extractPostsFromSignups } from '../../helpers';
 
 class SignupCard extends React.Component {
+  /**
+   * Gets the campaign run start date.
+   *
+   * @param {Object} campaignRuns
+   * @param {String} campaignRunId
+   * @return {String}
+   */
+  getCampaignRunStartDate(campaignRuns, campaignRunId) {
+    for (let key in campaignRuns) {
+      if (campaignRuns[key]['id'] == campaignRunId) {
+        const date = campaignRuns[key]['start_date'];
+
+        if (date) {
+          return campaignRuns[key]['start_date'].split(" ")[0];
+        }
+      }
+      return null;
+    }
+  }
+
   render() {
     const signup = this.props.signup;
     const campaign = this.props.campaign;
@@ -19,17 +39,7 @@ class SignupCard extends React.Component {
 
     const signupUrl = `/signups/${signup.signup_id}`;
 
-    var campaign_run_start_date = null;
-
-    for (let key in campaign.campaign_runs.current) {
-      if (campaign.campaign_runs.current[key]['id'] == signup.campaign_run_id) {
-        const date = campaign.campaign_runs.current[key]['start_date'];
-
-        if (date) {
-          campaign_run_start_date = campaign.campaign_runs.current[key]['start_date'].split(" ")[0];
-        }
-      }
-    }
+    const campaignRunStartDate = this.getCampaignRunStartDate(campaign.campaign_runs.current, signup.campaign_run_id);
 
     return (
         <article className="container__row signup-card">
@@ -39,8 +49,8 @@ class SignupCard extends React.Component {
                 <h2 className="heading">{campaign ? campaign.title : signup.campaign_id}</h2>
                 <h4 className="heading">Campaign ID: {signup.campaign_id}</h4>
                 <h4 className="heading">Campaign Run ID: {signup.campaign_run_id}</h4>
-                { campaign_run_start_date ?
-                  <h4 className="heading">Campaign Run Start Date: {campaign_run_start_date}</h4>
+                { campaignRunStartDate ?
+                  <h4 className="heading">Campaign Run Start Date: {campaignRunStartDate}</h4>
                 :null }
               </div>
               <div className="container__row">

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -21,7 +21,7 @@ class SignupCard extends React.Component {
 
     var campaign_run_start_date = null;
 
-    for (var key in campaign.campaign_runs.current) {
+    for (let key in campaign.campaign_runs.current) {
       if (campaign.campaign_runs.current[key]['id'] == signup.campaign_run_id) {
         const date = campaign.campaign_runs.current[key]['start_date'];
 

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -16,7 +16,6 @@ class SignupCard extends React.Component {
     const posts = signup.posts.data.slice(0, gallerySize).map((post, index) => {
       return <PostTile key={index} details={post} />;
     });
-
     const signupUrl = `/signups/${signup.signup_id}`;
 
     return (
@@ -25,6 +24,7 @@ class SignupCard extends React.Component {
             <div className="container__block -half">
               <div className="container__row">
                 <h2 className="heading">{campaign ? campaign.title : signup.campaign_id}</h2>
+                <h4 className="heading">Campaign Run ID: {signup.campaign_run_id}</h4>
               </div>
               <div className="container__row">
                 <h4 className="heading">Why Statement</h4>

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -29,7 +29,7 @@ class UserOverview extends React.Component {
       filter: {
         northstar_id: id,
       },
-      orderBy: 'desc',
+      orderByPosts: 'desc',
     }).then(json => this.setState({
       signups: json.data
     }, () => {

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -28,7 +28,8 @@ class UserOverview extends React.Component {
     this.api.get('api/v2/activity', {
       filter: {
         northstar_id: id,
-      }
+      },
+      orderBy: 'desc',
     }).then(json => this.setState({
       signups: json.data
     }, () => {

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -29,8 +29,8 @@ class UserOverview extends React.Component {
       filter: {
         northstar_id: id,
       },
-      orderByPosts: 'desc',
-      limit: 100,
+      orderBy: 'desc',
+      limit: 'all',
     }).then(json => this.setState({
       signups: json.data
     }, () => {

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -30,6 +30,7 @@ class UserOverview extends React.Component {
         northstar_id: id,
       },
       orderByPosts: 'desc',
+      limit: 100,
     }).then(json => this.setState({
       signups: json.data
     }, () => {


### PR DESCRIPTION
#### What's this PR do?
- On the user page, the `campaign_id`, `campaign_run_id`, and campaign run start date (if we have it) is exposed to provide the admin with more information: 
![screen shot 2017-09-26 at 5 38 31 pm](https://user-images.githubusercontent.com/9019452/30885500-8a3e7b62-a2e1-11e7-96b1-5a83fcb05dc4.png)
- The signups are now returned by signups with the most recently created posts at the top in descending order. 
  - The card wanted to sort by more recent campaigns first, and then of the more recent campaigns, sort the ones that the member has RB on first (campaign leads said that they just want to see these first as it's most important to see what they've RB for over everything they've signed up for). However, I was unable to do this because the `/activity` endpoint returns signups (not campaigns). I started to return by most recent signups in descending order but of those results, couldn't figure out a way to then filter by signups that had posts first. I figured this would be helpful to the campaigns team to see the most recent created post first, since that should correlate to the most recent signup. @ngjo is this ok? I'm sure my explanation here is very confusion so happy to chat more IRL with anyone to figure out! 

#### How should this be reviewed?
- Go to a user page (`/users/:northstar_id`)
- The signups should be returned in the order of the most recently created post. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/150849332

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.