### PR TITLE
Add signup details to factory

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -55,7 +55,7 @@ $factory->define(Signup::class, function (Generator $faker) {
         'quantity_pending' => $faker->randomNumber(4),
         'why_participated' => $faker->sentence(),
         'source' => 'phoenix-web',
-        'details' => $details_options[rand(0,3)],
+        'details' => $details_options[rand(0, 3)],
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -46,7 +46,6 @@ $factory->defineAs(Post::class, 'rejected', function () use ($factory) {
 $factory->define(Signup::class, function (Generator $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
     $faker->addProvider(new FakerCampaignId($faker));
-    $details_options = [null, null, 'fun-affiliate-stuff', 'i-say-the-tails'];
 
     return [
         'northstar_id' => $faker->northstar_id,
@@ -55,7 +54,7 @@ $factory->define(Signup::class, function (Generator $faker) {
         'quantity_pending' => $faker->randomNumber(4),
         'why_participated' => $faker->sentence(),
         'source' => 'phoenix-web',
-        'details' => $details_options[rand(0, 3)],
+        'details' => $faker->randomElement([null, 'fun-affiliate-stuff', 'i-say-the-tails']),
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -46,6 +46,7 @@ $factory->defineAs(Post::class, 'rejected', function () use ($factory) {
 $factory->define(Signup::class, function (Generator $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
     $faker->addProvider(new FakerCampaignId($faker));
+    $details_options = [null, null, 'fun-affiliate-stuff', 'i-say-the-tails'];
 
     return [
         'northstar_id' => $faker->northstar_id,
@@ -54,6 +55,7 @@ $factory->define(Signup::class, function (Generator $faker) {
         'quantity_pending' => $faker->randomNumber(4),
         'why_participated' => $faker->sentence(),
         'source' => 'phoenix-web',
+        'details' => $details_options[rand(0,3)],
     ];
 });
 


### PR DESCRIPTION
#### What's this PR do?
In the Signup factory we want to add some `details` to the signups. Each signup gets `details` assigned at random from the following list:
`[null, null, 'fun-affiliate-stuff', 'i-say-the-tails']`

I put `null` twice because I figure it is closer to reality to have at least 50% `null`, but if we don't care that much about that I can remove it so it is only there once.

#### How should this be reviewed?
When you seed your database, does this fill some values (or some `null`s) into your `signups` database for `details`?

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/151225172)

#### Checklist
- [ ] Tested on staging.

![027c45e2e5e90e91da83b585348f4a21bfc9d4395c2cfc8e87754e41a06853eb](https://user-images.githubusercontent.com/4240292/30972328-39f0e1a6-a438-11e7-875f-37ba838dd84c.gif)
