### PR TITLE
Include param as array

### DIFF
--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -116,14 +116,10 @@ trait TransformsRequests
 
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
-        $includes = null;
+        $includes = $request->query('include');
 
-        if ($request->query('include')) {
-            if (is_array($request->query('include'))) {
-                $includes = $request->query('include');
-            } else {
-                $includes = explode(',', $request->query('include'));
-            }
+        if (is_string($includes)) {
+            $includes = explode(',', $request->query('include'));
         }
 
         return $this->transform($resource, $code, [], $includes);

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -118,7 +118,15 @@ trait TransformsRequests
 
         $includes = null;
         if ($request->query('include')) {
-            $includes = explode(',', $request->query('include'));
+            // dd($request->query('include'));
+            if (is_array($request->query('include'))) {
+                // dump('array');
+                $includes = $request->query('include');
+            } else {
+                // dump('string');
+                $includes = explode(',', $request->query('include'));
+                // dump($includes);
+            }
         }
 
         return $this->transform($resource, $code, [], $includes);

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -117,15 +117,12 @@ trait TransformsRequests
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
         $includes = null;
+
         if ($request->query('include')) {
-            // dd($request->query('include'));
             if (is_array($request->query('include'))) {
-                // dump('array');
                 $includes = $request->query('include');
             } else {
-                // dump('string');
                 $includes = explode(',', $request->query('include'));
-                // dump($includes);
             }
         }
 

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -104,7 +104,7 @@ class CampaignSingle extends React.Component {
 
     this.api.get('/posts', {
       filter: filters,
-      include: 'signup,siblings',
+      include: ['signup','siblings'],
     })
     .then(json => {
       this.setState({loadingNewPosts: false });

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -41,7 +41,7 @@ const reviewComponent = (Component, data) => {
           status: status,
           campaign_id: campaignId,
         },
-        include: 'signup,siblings',
+        include: ['signup','siblings'],
       })
       .then(json => this.setState({
         campaign: data.campaign,


### PR DESCRIPTION
#### What's this PR do?

Allows the API to accept an `include` parameter in a `GET` request as an array _and_ a comma-separated set of strings. 

Gateway JS will parse the passed array and add `&include[]=signup&include[]=siblings` to the query string. 

Apparently, when grabbing query string values, laravel will parse that as an array so we end up with `['signup','siblings']` on the server. 

So all this does is check if we got an array in the query param, if so just use that, else parse the comma separated list. 

#### How should this be reviewed?
commit-by-commit?

#### Any background context you want to provide?
I feel like I am lacking a little bit of context on this one, so if there was something else that needed to be done, let me know!

Also, i decided to leave support for the comma-separated version of the parameter just in case anything was using it. 


#### Relevant tickets
https://www.pivotaltracker.com/story/show/150224221

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.