### PR TITLE
fixes history modal close bug

### DIFF
--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -53,7 +53,7 @@ class CampaignInbox extends React.Component {
               <HistoryModal
                 id={this.props.historyModalId}
                 onUpdate={this.props.updateQuantity}
-                onClose={e => this.hideHistory(e)}
+                onClose={e => this.props.hideHistory(e)}
                 campaign={campaign}
                 signup={signups[posts[this.props.historyModalId]['signup_id']]}
               />

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -170,7 +170,7 @@ class CampaignSingle extends React.Component {
             <HistoryModal
               id={this.props.historyModalId}
               onUpdate={this.props.updateQuantity}
-              onClose={e => this.hideHistory(e)}
+              onClose={e => this.props.hideHistory(e)}
               campaign={campaign}
               signup={signups[posts[this.props.historyModalId]['signup_id']]}
             />


### PR DESCRIPTION
#### What's this PR do?
When you click on the "X" in the History Modal, the modal wouldn't close. This PR fixes that bug. 

#### How should this be reviewed?
Go to campaign inbox and single page. Make sure you can close the History Modals when opened for a post. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/151529616

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.