### PR TITLE
Signup details file exports

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -79,13 +79,11 @@ class CampaignsController extends Controller
     {
         $campaign = $this->campaignService->find($id);
         $totals = $this->campaignService->getPostTotals($campaign);
-        $export = Signup::whereNotNull('details')->where('campaign_id', $id)->get();
 
         return view('pages.campaign_single')
             ->with('state', [
                 'campaign' => $campaign,
                 'initial_posts' => 'accepted',
-                'export' => ! $export->isEmpty(),
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,
                     'pending_count' => $totals->pending_count,

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -85,7 +85,7 @@ class CampaignsController extends Controller
             ->with('state', [
                 'campaign' => $campaign,
                 'initial_posts' => 'accepted',
-                'export' => !$export->isEmpty(),
+                'export' => ! $export->isEmpty(),
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,
                     'pending_count' => $totals->pending_count,

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Http\Controllers;
 
-use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Rogue\Services\CampaignService;
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Controllers;
 
+use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Rogue\Services\CampaignService;
 
@@ -78,11 +79,13 @@ class CampaignsController extends Controller
     {
         $campaign = $this->campaignService->find($id);
         $totals = $this->campaignService->getPostTotals($campaign);
+        $export = Signup::whereNotNull('details')->where('campaign_id', $id)->get();
 
         return view('pages.campaign_single')
             ->with('state', [
                 'campaign' => $campaign,
                 'initial_posts' => 'accepted',
+                'export' => !$export->isEmpty(),
                 'post_totals' => [
                     'accepted_count' => $totals->accepted_count,
                     'pending_count' => $totals->pending_count,

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -35,9 +35,7 @@ class ExportController extends Controller
         // Run the query
         $signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
 
-        // Compile the data
-        $results = $this->export->exportSignups($signups, $campaignId);
-
-        return response($results['output'], 200, $results['headers']);
+        // Compile the data and trigger the CSV download
+        return $this->export->exportSignups($signups, $campaignId);
     }
 }

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -36,21 +36,8 @@ class ExportController extends Controller
         $signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
 
         // Compile the data
-        $final_results = $this->export->exportSignups($signups);
+        $results = $this->export->exportSignups($signups, $campaignId);
 
-        // Format as csv
-        $output = '';
-        foreach ($final_results as $row) {
-            $output .= implode(',', array_values($row)) . "\n";
-        }
-
-        // Build and return the file
-        $filename = 'export_' . $campaignId . '.csv';
-        $headers = [
-          'Content-Type'        => 'text/csv',
-          'Content-Disposition' => 'attachment; filename="'.$filename.'"',
-        ];
-
-        return response($output, 200, $headers);
+        return response($results['output'], 200, $results['headers']);
     }
 }

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -3,25 +3,26 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Signup;
-use Rogue\Services\Registrar;
+use Rogue\Services\ExportService;
 
 class ExportController extends Controller
 {
     /**
-     * Registrar instance
+     * ExportService instance
      *
-     * @var Rogue\Services\Registrar
+     * @var Rogue\Services\ExportService
      */
-    protected $registrar;
+    protected $export;
 
     /**
      * Instantiate a new ExportController instance.
      *
      * @param Rogue\Services\Registrar $registrar
      */
-    public function __construct(Registrar $registrar)
+    public function __construct(ExportService $export)
     {
-        $this->registrar = $registrar;
+        $this->middleware('auth');
+        $this->export = $export;
     }
 
     /**
@@ -35,23 +36,7 @@ class ExportController extends Controller
         $signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
 
         // Compile the data
-        $final_results = [];
-
-        foreach ($signups as $signup) {
-            $northstar_user = $this->registrar->find($signup->northstar_id);
-
-            $next_row = [
-                'campaign_id' => $signup->campaign_id,
-                'campaign_run_id' => $signup->campaign_run_id,
-                'northstar_id' => $signup->northstar_id,
-                'first_name' => $northstar_user->first_name,
-                'email' => $northstar_user->email,
-                'mobile' => $northstar_user->mobile,
-                'age' => getAgeFromBirthdate($northstar_user->birthdate),
-            ];
-
-            array_push($final_results, $next_row);
-        }
+        $final_results = $this->export->exportSignups($signups);
 
         // Format as csv
         $output = '';

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rogue\Http\Controllers;
+
+use Rogue\Models\Signup;
+use Illuminate\Http\Request;
+use Rogue\Services\Registrar;
+
+class ExportController extends Controller
+{
+    /**
+     * Registrar instance
+     *
+     * @var Rogue\Services\Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Instantiate a new ExportController instance.
+     *
+     * @param Rogue\Services\Registrar $registrar
+     */
+    public function __construct(Registrar $registrar)
+    {
+        $this->registrar = $registrar;
+    }
+
+	/**
+	 * Download the export of signup details for the specified campaign.
+	 * 
+	 * @param int $campaignId
+	 */
+	public function show($campaignId)
+	{
+		// Run the query
+		$signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
+
+		// Compile the data
+		$final_results = [];
+
+		foreach ($signups as $signup) {
+	        $northstar_user = $this->registrar->find($signup->northstar_id);
+
+			$next_row = [
+				'campaign_id' => $signup->campaign_id,
+				'campaign_run_id' => $signup->campaign_run_id,
+				'northstar_id' => $signup->northstar_id,
+				'first_name' => $northstar_user->first_name,
+				'email' => $northstar_user->email,
+				'mobile' => $northstar_user->mobile,
+				'age' => getAgeFromBirthdate($northstar_user->birthdate),
+			];
+
+			array_push($final_results, $next_row);
+		}
+
+		// Format as csv
+		$output = '';
+		foreach ($final_results as $row) {
+			$output .= implode(',', array_values($row)) . "\n";
+		}
+
+		// Build and return the file
+		$filename = 'export_' . $campaignId . '.csv';
+        $headers = [
+          'Content-Type'        => 'text/csv',
+          'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+        ];
+
+        return response($output, 200, $headers);
+
+	}
+}

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -3,7 +3,6 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Signup;
-use Illuminate\Http\Request;
 use Rogue\Services\Registrar;
 
 class ExportController extends Controller
@@ -25,49 +24,48 @@ class ExportController extends Controller
         $this->registrar = $registrar;
     }
 
-	/**
-	 * Download the export of signup details for the specified campaign.
-	 * 
-	 * @param int $campaignId
-	 */
-	public function show($campaignId)
-	{
-		// Run the query
-		$signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
+    /**
+     * Download the export of signup details for the specified campaign.
+     *
+     * @param int $campaignId
+     */
+    public function show($campaignId)
+    {
+        // Run the query
+        $signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
 
-		// Compile the data
-		$final_results = [];
+        // Compile the data
+        $final_results = [];
 
-		foreach ($signups as $signup) {
-	        $northstar_user = $this->registrar->find($signup->northstar_id);
+        foreach ($signups as $signup) {
+            $northstar_user = $this->registrar->find($signup->northstar_id);
 
-			$next_row = [
-				'campaign_id' => $signup->campaign_id,
-				'campaign_run_id' => $signup->campaign_run_id,
-				'northstar_id' => $signup->northstar_id,
-				'first_name' => $northstar_user->first_name,
-				'email' => $northstar_user->email,
-				'mobile' => $northstar_user->mobile,
-				'age' => getAgeFromBirthdate($northstar_user->birthdate),
-			];
+            $next_row = [
+                'campaign_id' => $signup->campaign_id,
+                'campaign_run_id' => $signup->campaign_run_id,
+                'northstar_id' => $signup->northstar_id,
+                'first_name' => $northstar_user->first_name,
+                'email' => $northstar_user->email,
+                'mobile' => $northstar_user->mobile,
+                'age' => getAgeFromBirthdate($northstar_user->birthdate),
+            ];
 
-			array_push($final_results, $next_row);
-		}
+            array_push($final_results, $next_row);
+        }
 
-		// Format as csv
-		$output = '';
-		foreach ($final_results as $row) {
-			$output .= implode(',', array_values($row)) . "\n";
-		}
+        // Format as csv
+        $output = '';
+        foreach ($final_results as $row) {
+            $output .= implode(',', array_values($row)) . "\n";
+        }
 
-		// Build and return the file
-		$filename = 'export_' . $campaignId . '.csv';
+        // Build and return the file
+        $filename = 'export_' . $campaignId . '.csv';
         $headers = [
           'Content-Type'        => 'text/csv',
           'Content-Disposition' => 'attachment; filename="'.$filename.'"',
         ];
 
         return response($output, 200, $headers);
-
-	}
+    }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -25,6 +25,9 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('campaigns/{id}/inbox', 'CampaignsController@showInbox');
     Route::get('campaigns/{id}', 'CampaignsController@showCampaign');
 
+    // Exports
+    Route::get('exports/{id}', 'ExportController@show');
+
     // Posts
     Route::post('posts', 'PostController@store');
     Route::get('posts', 'PostController@index');

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -3,7 +3,6 @@
 namespace Rogue\Services;
 
 use League\Csv\Writer;
-use Rogue\Services\Registrar;
 
 class ExportService
 {
@@ -32,7 +31,7 @@ class ExportService
      */
     public function exportSignups($signups, $campaignId)
     {
-    	$final_results = [];
+        $final_results = [];
 
         foreach ($signups as $signup) {
             $northstar_user = $this->registrar->find($signup->northstar_id);
@@ -68,8 +67,8 @@ class ExportService
         }
 
         // Create and return CSV file
-		$writer = Writer::createFromString($output);
+        $writer = Writer::createFromString($output);
 
-		return $writer->output('export_' . $campaignId . '.csv');
+        return $writer->output('export_' . $campaignId . '.csv');
     }
 }

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -2,8 +2,8 @@
 
 namespace Rogue\Services;
 
-use SplTempFileObject;
 use League\Csv\Writer;
+use SplTempFileObject;
 
 class ExportService
 {

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rogue\Services;
+
+use Rogue\Services\Registrar;
+
+class ExportService
+{
+    /**
+     * Registrar instance
+     *
+     * @var Rogue\Services\Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Instantiate a new ExportController instance.
+     *
+     * @param Rogue\Services\Registrar $registrar
+     */
+    public function __construct(Registrar $registrar)
+    {
+        $this->registrar = $registrar;
+    }
+
+    public function exportSignups($signups)
+    {
+    	$final_results = [];
+
+        foreach ($signups as $signup) {
+            $northstar_user = $this->registrar->find($signup->northstar_id);
+
+            $next_row = [
+                'campaign_id' => $signup->campaign_id,
+                'campaign_run_id' => $signup->campaign_run_id,
+                'northstar_id' => $signup->northstar_id,
+                'first_name' => $northstar_user->first_name,
+                'email' => $northstar_user->email,
+                'mobile' => $northstar_user->mobile,
+                'age' => getAgeFromBirthdate($northstar_user->birthdate),
+            ];
+
+            array_push($final_results, $next_row);
+        }
+
+        return $final_results;
+    }
+}

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -2,7 +2,7 @@
 
 namespace Rogue\Services;
 
-use SplFileObject;
+use SplTempFileObject;
 use League\Csv\Writer;
 
 class ExportService
@@ -61,21 +61,9 @@ class ExportService
      */
     public function makeCSV($data, $campaignId)
     {
-        // Format as CSV
-        // $output = '';
-        // foreach ($data as $row) {
-        //     $output .= implode(',', array_values($row)) . "\n";
-        // }
-
-        // // Create and return CSV file
-        // $writer = Writer::createFromString($output);
-
-        // return $writer->output('export_' . $campaignId . '.csv');
-
-        $writer = Writer::createFromFileObject(new SplFileObject('export_' . $campaignId . '.csv'));
-
+        // Create and return CSV file
+        $writer = Writer::createFromFileObject(new SplTempFileObject());
         $writer->insertAll($data);
-
 
         return $writer->output('export_' . $campaignId . '.csv');
     }

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Services;
 
+use SplFileObject;
 use League\Csv\Writer;
 
 class ExportService
@@ -61,13 +62,20 @@ class ExportService
     public function makeCSV($data, $campaignId)
     {
         // Format as CSV
-        $output = '';
-        foreach ($data as $row) {
-            $output .= implode(',', array_values($row)) . "\n";
-        }
+        // $output = '';
+        // foreach ($data as $row) {
+        //     $output .= implode(',', array_values($row)) . "\n";
+        // }
 
-        // Create and return CSV file
-        $writer = Writer::createFromString($output);
+        // // Create and return CSV file
+        // $writer = Writer::createFromString($output);
+
+        // return $writer->output('export_' . $campaignId . '.csv');
+
+        $writer = Writer::createFromFileObject(new SplFileObject('export_' . $campaignId . '.csv'));
+
+        $writer->insertAll($data);
+
 
         return $writer->output('export_' . $campaignId . '.csv');
     }

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Services;
 
+use League\Csv\Writer;
 use Rogue\Services\Registrar;
 
 class ExportService
@@ -60,22 +61,15 @@ class ExportService
      */
     public function makeCSV($data, $campaignId)
     {
-        // Format as csv
+        // Format as CSV
         $output = '';
         foreach ($data as $row) {
             $output .= implode(',', array_values($row)) . "\n";
         }
 
-        // Build and return the file
-        $filename = 'export_' . $campaignId . '.csv';
-        $headers = [
-          'Content-Type'        => 'text/csv',
-          'Content-Disposition' => 'attachment; filename="'.$filename.'"',
-        ];
+        // Create and return CSV file
+		$writer = Writer::createFromString($output);
 
-        return $results = [
-			'output' => $output,
-			'headers' => $headers,
-        ];
+		return $writer->output('export_' . $campaignId . '.csv');
     }
 }

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -23,7 +23,13 @@ class ExportService
         $this->registrar = $registrar;
     }
 
-    public function exportSignups($signups)
+    /**
+     * Prepare the export of signup details for the specified campaign.
+     *
+     * @param object $signups
+     * @param int $campaignId
+     */
+    public function exportSignups($signups, $campaignId)
     {
     	$final_results = [];
 
@@ -43,6 +49,33 @@ class ExportService
             array_push($final_results, $next_row);
         }
 
-        return $final_results;
+        return $this->makeCSV($final_results, $campaignId);
+    }
+
+    /**
+     * Build the CSV of signup details for the specified campaign.
+     *
+     * @param array $signups
+     * @param int $campaignId
+     */
+    public function makeCSV($data, $campaignId)
+    {
+        // Format as csv
+        $output = '';
+        foreach ($data as $row) {
+            $output .= implode(',', array_values($row)) . "\n";
+        }
+
+        // Build and return the file
+        $filename = 'export_' . $campaignId . '.csv';
+        $headers = [
+          'Content-Type'        => 'text/csv',
+          'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+        ];
+
+        return $results = [
+			'output' => $output,
+			'headers' => $headers,
+        ];
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Support\HtmlString;
 
 /**
@@ -79,15 +80,14 @@ function multipleValueQuery($query, $queryString, $filter)
     }
 }
 
+/**
+ * Returns age of user with given birthdate (or number of full years since given date).
+ * @param string $birthdate
+ */
 function getAgeFromBirthdate($birthdate)
 {
-    // Make DateTime for right now
-    $now = new DateTime('now');
+    $birthdate = new Carbon($birthdate);
+    $now = new Carbon();
 
-    // Make DateTime for birthday
-    $birthday = new DateTime();
-    $birthday->setTimestamp(strtotime($birthdate));
-
-    // Calculate the difference and return the years
-    return $now->diff($birthday)->y;
+    return $birthdate->diffInYears($now);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -78,3 +78,16 @@ function multipleValueQuery($query, $queryString, $filter)
         $query->where($filter, $values[0], 'and');
     }
 }
+
+function getAgeFromBirthdate($birthdate)
+{
+    // Make DateTime for right now
+    $now = new DateTime('now');
+
+    // Make DateTime for birthday
+    $birthday = new DateTime();
+    $birthday->setTimestamp(strtotime($birthdate));
+
+    // Calculate the difference and return the years
+    return $now->diff($birthday)->y;
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "league/fractal": "^0.13.0",
     "league/glide-laravel": "^1.0",
     "predis/predis": "~1.0",
-    "spatie/laravel-backup": "^4.19"
+    "spatie/laravel-backup": "^4.19",
+    "league/csv": "^9.0"
   },
   "require-dev": {
     "fzaninotto/faker": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a6357af789effb5a79e35745599b503",
+    "content-hash": "dc73c088d1f471d864937d50a7267319",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1484,6 +1484,70 @@
                 "jwt"
             ],
             "time": "2017-09-01T08:23:26+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "5dc305e7958190bcab0cc2778888a4f658d29aa1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/5dc305e7958190bcab0cc2778888a4f658d29aa1",
+                "reference": "5dc305e7958190bcab0cc2778888a4f658d29aa1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.0.10"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Csv data manipulation made easy in PHP",
+            "homepage": "http://csv.thephpleague.com",
+            "keywords": [
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "write"
+            ],
+            "time": "2017-08-21T13:42:10+00:00"
         },
         {
             "name": "league/flysystem",

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -12,6 +12,7 @@ import StatusCounter from '../StatusCounter';
 import DropdownFilter from '../DropdownFilter';
 import ModalContainer from '../ModalContainer';
 import MultiValueFilter from '../MultiValueFilter';
+import UserExport from '../UserExport';
 
 class CampaignSingle extends React.Component {
   constructor(props) {
@@ -136,8 +137,16 @@ class CampaignSingle extends React.Component {
 
     return (
       <div className="container">
-        <StatusCounter postTotals={this.props.post_totals} campaign={campaign} download={downloads}/>
-
+        <div className="container__block">
+          <div className="container__row">
+            <div className="container__block -half">
+              <StatusCounter postTotals={this.props.post_totals} campaign={campaign}/>
+            </div>
+            <div className="container__block -half">
+              <UserExport campaign={campaign} download={downloads}/>
+            </div>
+          </div>
+        </div>
         <FilterBar onSubmit={this.filterPosts}>
           <DropdownFilter options={statusFilters} header={'Post Status'}/>
           <MultiValueFilter options={tagFilters} header={'Tags'}/>

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -123,7 +123,6 @@ class CampaignSingle extends React.Component {
       values: tags,
       type: 'tags',
     };
-    const downloads = this.props.export ? true : false;
 
     const statusFilters = {
       values: {
@@ -143,7 +142,7 @@ class CampaignSingle extends React.Component {
               <StatusCounter postTotals={this.props.post_totals} campaign={campaign}/>
             </div>
             <div className="container__block -half">
-              <UserExport campaign={campaign} download={downloads}/>
+              <UserExport campaign={campaign}/>
             </div>
           </div>
         </div>

--- a/resources/assets/components/CampaignSingle/index.js
+++ b/resources/assets/components/CampaignSingle/index.js
@@ -122,6 +122,7 @@ class CampaignSingle extends React.Component {
       values: tags,
       type: 'tags',
     };
+    const downloads = this.props.export ? true : false;
 
     const statusFilters = {
       values: {
@@ -135,7 +136,7 @@ class CampaignSingle extends React.Component {
 
     return (
       <div className="container">
-        <StatusCounter postTotals={this.props.post_totals} campaign={campaign} />
+        <StatusCounter postTotals={this.props.post_totals} campaign={campaign} download={downloads}/>
 
         <FilterBar onSubmit={this.filterPosts}>
           <DropdownFilter options={statusFilters} header={'Post Status'}/>

--- a/resources/assets/components/StatusCounter/index.js
+++ b/resources/assets/components/StatusCounter/index.js
@@ -7,7 +7,15 @@ export default (props) => (
           <li>
               <span className="count">{props.postTotals.pending_count}</span>
               <span className="status">Pending</span>
-              <a className="button -secondary" href={`/campaigns/${props.campaign.id}/inbox`}>Review</a>
+              <div>
+                <a className="button -secondary" href={`/campaigns/${props.campaign.id}/inbox`}>Review</a>
+              </div>
+              {props.download ?
+                <div>
+                  <a className="button -secondary" href={`/exports/${props.campaign.id}`}>📩 Export</a>
+                </div>
+                : null
+              }
           </li>
           {/* @TODO - add back in when we deal with pagination on the single campaign view
           <li>

--- a/resources/assets/components/StatusCounter/index.js
+++ b/resources/assets/components/StatusCounter/index.js
@@ -10,12 +10,6 @@ export default (props) => (
               <div>
                 <a className="button -secondary" href={`/campaigns/${props.campaign.id}/inbox`}>Review</a>
               </div>
-              {props.download ?
-                <div>
-                  <a className="button -secondary" href={`/exports/${props.campaign.id}`}>📩 Export</a>
-                </div>
-                : null
-              }
           </li>
           {/* @TODO - add back in when we deal with pagination on the single campaign view
           <li>

--- a/resources/assets/components/UserExport/index.js
+++ b/resources/assets/components/UserExport/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import './user-export.scss';
+
+class UserExport extends React.Component {
+
+	render () {
+		return (
+			<div className="user-export">
+				<h1 className="heading -delta">User Export</h1>
+				<p>Download a .csv of all users who have opted to receive additional messaging.</p>
+				<div>
+				  <a className="button -secondary" href={`/exports/${this.props.campaign.id}`}>📩 Export</a>
+				</div>
+			</div>
+		)
+	}
+}
+export default UserExport;

--- a/resources/assets/components/UserExport/user-export.scss
+++ b/resources/assets/components/UserExport/user-export.scss
@@ -1,0 +1,14 @@
+/**
+ * User Export
+ */
+@import '~@dosomething/forge/scss/toolkit';
+
+.user-export {
+	margin-bottom: $base-spacing * 2;
+    padding: $base-spacing;
+
+	.button {
+		margin-top: $base-spacing;
+		background-color: $blue;
+	}
+}

--- a/resources/assets/components/UserExport/user-export.scss
+++ b/resources/assets/components/UserExport/user-export.scss
@@ -1,11 +1,11 @@
+@import '~@dosomething/forge/scss/toolkit';
+
 /**
  * User Export
  */
-@import '~@dosomething/forge/scss/toolkit';
-
 .user-export {
-	margin-bottom: $base-spacing * 2;
-    padding: $base-spacing;
+  margin-bottom: $base-spacing * 2;
+  padding: $base-spacing;
 
 	.button {
 		margin-top: $base-spacing;


### PR DESCRIPTION
#### What's this PR do?
- Added new `ExportController` with a `show` function to trigger a download of the signup details csv for the given Campaign. Also includes corresponding route.
- New helper on the backend `getAgeFromBirthdate` to calculate ages based on birthdays.
- In `CampaignsController.php`, check to see if any signups on the given campaign have `details`. This has to be on the backend because we need to check ALL signups, not just ones on the current page. Then, conditionally display the export button (only show if there is something to export).

The button:

![image](https://user-images.githubusercontent.com/4240292/31099563-70ab2d8c-a794-11e7-80a4-0cd5d59fb57c.png)


#### How should this be reviewed?
The part that I'm least sure about is how the front-end decides how to display the button each time. Seems a little wild to run the 
```
$export = Signup::whereNotNull('details')->where('campaign_id', $id)->get();
``` 
query every time a single view page gets hit, and then re-run it if the admin decides to download. Does it make sense to cache that?

#### Any background context you want to provide?
For now there are no plans to have multiple types of details per campaign, so we assume any signups under a campaign with details all have the same details.

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/151225385)

#### Checklist
- [ ] Tested on staging.