### PR TITLE
Pagination performance

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -43,6 +43,6 @@ class ActivityController extends ApiController
             return $this->collection($signups);
         }
 
-        return $this->paginatedCollection($query, $request);
+        return $this->paginatedCollection($query, $request, 200, [], null, 'cursor');
     }
 }

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -4,9 +4,10 @@ namespace Rogue\Http\Controllers\Traits;
 
 use League\Fractal\Manager;
 use League\Fractal\Resource\Item;
-use League\Fractal\Resource\Collection;
+use League\Fractal\Pagination\Cursor;
 use League\Fractal\Serializer\DataArraySerializer;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+use League\Fractal\Resource\Collection as FractalCollection;
 
 trait TransformsRequests
 {
@@ -105,16 +106,43 @@ trait TransformsRequests
         }
 
         $pages = (int) $request->query('limit', 20);
-        $paginator = $query->paginate(min($pages, 100));
+
+        $fastMode = $request->query('pagination') === 'cursor';
+
+        if ($fastMode) {
+            $paginator = $query->simplePaginate(min($pages, 100));
+        } else {
+            $paginator = $query->paginate(min($pages, 100));
+        }
 
         $queryParams = array_diff_key($request->query(), array_flip(['page']));
         $paginator->appends($queryParams);
 
-        $resource = new Collection($paginator->getCollection(), $transformer);
-
+        $resource = new FractalCollection($paginator->getCollection(), $transformer);
         $resource->setMeta($meta);
 
-        $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
+        // Attach the right paginator or cursor based on "speed".
+        if ($fastMode) {
+            $cursor = new Cursor(
+                $paginator->currentPage(),
+                $paginator->previousPageUrl(),
+                $paginator->nextPageUrl(),
+                $paginator->count()
+            );
+            $resource->setCursor($cursor);
+        } else {
+            $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
+        }
+        // $paginator = $query->paginate(min($pages, 100));
+
+        // $queryParams = array_diff_key($request->query(), array_flip(['page']));
+        // $paginator->appends($queryParams);
+
+        // $resource = new Collection($paginator->getCollection(), $transformer);
+
+        // $resource->setMeta($meta);
+
+        // $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
         $includes = $request->query('include');
 

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -99,7 +99,7 @@ trait TransformsRequests
      * @param $query - Eloquent query
      * @return \Illuminate\Http\Response
      */
-    public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null)
+    public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null, $pagination = null)
     {
         if (is_null($transformer)) {
             $transformer = $this->transformer;
@@ -107,7 +107,7 @@ trait TransformsRequests
 
         $pages = (int) $request->query('limit', 20);
 
-        $fastMode = $request->query('pagination') === 'cursor';
+        $fastMode = $request->query('pagination') === 'cursor' || $pagination === 'cursor';
 
         if ($fastMode) {
             $paginator = $query->simplePaginate(min($pages, 100));
@@ -133,16 +133,6 @@ trait TransformsRequests
         } else {
             $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
         }
-        // $paginator = $query->paginate(min($pages, 100));
-
-        // $queryParams = array_diff_key($request->query(), array_flip(['page']));
-        // $paginator->appends($queryParams);
-
-        // $resource = new Collection($paginator->getCollection(), $transformer);
-
-        // $resource->setMeta($meta);
-
-        // $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
         $includes = $request->query('include');
 

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -39,12 +39,11 @@ class ActivityApiTest extends BrowserKitTestCase
                 ],
             ],
             'meta' => [
-                'pagination' => [
-                    'total',
+                'cursor' => [
+                    'current',
+                    'prev',
+                    'next',
                     'count',
-                    'per_page',
-                    'current_page',
-                    'total_pages',
                 ],
             ],
         ]);
@@ -65,8 +64,9 @@ class ActivityApiTest extends BrowserKitTestCase
 
         $response = $this->decodeResponseJson();
         $this->assertCount(8, $response['data']);
-        $this->assertEquals(2, $response['meta']['pagination']['total_pages']);
-        $this->assertNotEmpty($response['meta']['pagination']['links']['next']);
+        $this->assertNotEmpty($response['meta']['cursor']['next']);
+        $this->assertEquals(8, $response['meta']['cursor']['count']);
+        $this->assertEquals(1, $response['meta']['cursor']['current']);
     }
 
     /**
@@ -109,7 +109,8 @@ class ActivityApiTest extends BrowserKitTestCase
                 ],
             ],
             'meta' => [
-                'pagination' => [
+                'cursor' => [
+                    'current' => 1,
                     'count' => 3,
                 ],
             ],


### PR DESCRIPTION
#### What's this PR do?

Changes the pagination method on the `GET /activity`endpoint to default to use Laravel's `simplePaginate` and Fractal's `Cursor`. 

For the most part, this just steals from how [Northstar deals with pagination](https://github.com/DoSomething/northstar/blob/1ce09c3ed300bc7166d4df5446544bbdfad2381d/app/Http/Controllers/Traits/TransformsResponses.php#L93-L118). h/t @DFurnes 

The only thing I changed a bit, was I updated the `paginateCollection` method to take in new `$pagination` param that we set to `cursor` in the `ActivityController`. I did this so that the client requesting data could set an optional `pagination` query param OR we can default to this method in code. I did it this way so that we could update this endpoint's performance without needed other teams to update how they are making the request to get this data.

#### How should this be reviewed?
:eyes:

#### Any background context you want to provide?

The hope is that this will fix a lot of the [New Relic Alerts](https://rpm.newrelic.com/accounts/108038/incidents/27182371) that have been popping up around this endpoint. The alert seems to signify that there is a performance issue with running the `select count(*) AS aggregate FROM signups` that was used to include total counts in the meta data. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/151378040

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.