### PR TITLE
Adds GET /events endpoint

### DIFF
--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -26,13 +26,13 @@ class EventController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Event::class);
-
         $filters = $request->query('filter');
 
         if ($filters['signup_id']) {
             $events = $query->where('eventable_id', $filters['signup_id'])->orderBy('created_at', 'desc')->get();
 
             $signupEvents = [];
+
             foreach ($events as $event) {
                 if ($event->eventable_type === "Rogue\Models\Signup") {
                     array_push($signupEvents, $event);
@@ -41,6 +41,7 @@ class EventController extends ApiController
 
             return $this->collection($signupEvents);
         }
+
         return $this->paginatedCollection($query, $request);
     }
 }

--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -26,12 +26,13 @@ class EventController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Event::class);
+
         $filters = $request->query('filter');
 
-        if ($filters['signup_id']) {
-            $events = $query->forSignup($filters['signup_id'])->orderBy('created_at', 'desc')->get();
+        $query = $this->filter($query, $filters, Event::$indexes);
 
-            return $this->collection($events);
+        if ($filters['signup_id']) {
+            $query = $query->forSignup($filters['signup_id'])->orderBy('created_at', 'desc');
         }
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -29,17 +29,9 @@ class EventController extends ApiController
         $filters = $request->query('filter');
 
         if ($filters['signup_id']) {
-            $events = $query->where('eventable_id', $filters['signup_id'])->orderBy('created_at', 'desc')->get();
+            $events = $query->forSignup($filters['signup_id'])->orderBy('created_at', 'desc')->get();
 
-            $signupEvents = [];
-
-            foreach ($events as $event) {
-                if ($event->eventable_type === "Rogue\Models\Signup") {
-                    array_push($signupEvents, $event);
-                }
-            }
-
-            return $this->collection($signupEvents);
+            return $this->collection($events);
         }
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rogue\Http\Controllers\Api;
+
+use Rogue\Models\Event;
+use Illuminate\Http\Request;
+use Rogue\Http\transformers\EventTransformer;
+
+class EventController extends ApiController
+{
+    /**
+     * Create a controller instance.
+     */
+    public function __construct()
+    {
+        $this->transformer = new EventTransformer();
+    }
+
+    /**
+     * Returns events.
+     * GET /events
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $query = $this->newQuery(Event::class);
+
+        $filters = $request->query('filter');
+
+        return $this->paginatedCollection($query, $request);
+    }
+}

--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -29,6 +29,18 @@ class EventController extends ApiController
 
         $filters = $request->query('filter');
 
+        if ($filters['signup_id']) {
+            $events = $query->where('eventable_id', $filters['signup_id'])->orderBy('created_at', 'desc')->get();
+
+            $signupEvents = [];
+            foreach ($events as $event) {
+                if ($event->eventable_type === "Rogue\Models\Signup") {
+                    array_push($signupEvents, $event);
+                }
+            }
+
+            return $this->collection($signupEvents);
+        }
         return $this->paginatedCollection($query, $request);
     }
 }

--- a/app/Http/Transformers/EventTransformer.php
+++ b/app/Http/Transformers/EventTransformer.php
@@ -15,21 +15,11 @@ class EventTransformer extends TransformerAbstract
      */
     public function transform(Event $event)
     {
-        $content = [];
-        $contentString = substr($event->content, 1, -1);
-        $contentStringWithNoQuotations = str_replace('"', '', $contentString);
-        $contentArray = explode(',', $contentStringWithNoQuotations);
-
-        foreach ($contentArray as $attribute) {
-            $attributeParts = explode(':', $attribute);
-            $content[$attributeParts[0]] = $attributeParts[1];
-        }
-
         return [
             'event_id' => $event->id,
             'eventable_id' => $event->eventable_id,
             'event_type' => $event->eventable_type,
-            'content' => $content,
+            'content' => $event->content,
             'user' => $event->user,
             'created_at' => $event->created_at->toIso8601String(),
             'updated_at' => $event->updated_at->toIso8601String(),

--- a/app/Http/Transformers/EventTransformer.php
+++ b/app/Http/Transformers/EventTransformer.php
@@ -15,18 +15,22 @@ class EventTransformer extends TransformerAbstract
      */
     public function transform(Event $event)
     {
+        $content = [];
+        $contentString = substr($event->content,1,-1);
+        $contentStringWithNoQuotations = str_replace('"', '', $contentString);
+        $contentArray = explode(",", $contentStringWithNoQuotations);
+
+        foreach ($contentArray as $attribute) {
+            $attributeParts = explode(':', $attribute);
+            $content[$attributeParts[0]] = $attributeParts[1];
+        }
+
         return [
             'event_id' => $event->id,
-            'event_type' => $event->event_type,
-            'submission_type' => $event->submission_type,
-            'quantity' => $event->quantity,
-            'quantity_pending' => $event->quantity_pending,
-            'why_participated' => $event->why_participated,
-            'caption' => $event->caption,
-            'status' => $event->status,
-            'source' => $event->source,
-            'remote_addr' => $event->remote_addr,
-            'reason' => $event->reason,
+            'eventable_id' => $event->eventable_id,
+            'event_type' => $event->eventable_type,
+            'content' => $content,
+            'user' => $event->user,
             'created_at' => $event->created_at->toIso8601String(),
             'updated_at' => $event->updated_at->toIso8601String(),
         ];

--- a/app/Http/Transformers/EventTransformer.php
+++ b/app/Http/Transformers/EventTransformer.php
@@ -16,9 +16,9 @@ class EventTransformer extends TransformerAbstract
     public function transform(Event $event)
     {
         $content = [];
-        $contentString = substr($event->content,1,-1);
+        $contentString = substr($event->content, 1, -1);
         $contentStringWithNoQuotations = str_replace('"', '', $contentString);
-        $contentArray = explode(",", $contentStringWithNoQuotations);
+        $contentArray = explode(',', $contentStringWithNoQuotations);
 
         foreach ($contentArray as $attribute) {
             $attributeParts = explode(':', $attribute);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -65,6 +65,9 @@ Route::group(['prefix' => 'api/v2', 'middleware' => ['auth.api', 'log.received.r
     // activity
     Route::get('activity', 'Api\ActivityController@index');
 
+    // events
+    Route::get('events', 'Api\EventController@index');
+
     // posts
     Route::post('posts', 'Api\PostsController@store');
     Route::get('posts', 'Api\PostsController@index');

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -13,6 +13,15 @@ class Event extends Model
      */
     protected $fillable = ['eventable_id', 'eventable_type', 'content', 'user'];
 
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'content' => 'array',
+    ];
+
     public function eventable()
     {
         return $this->morphTo();

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -26,4 +26,10 @@ class Event extends Model
     {
         return $this->morphTo();
     }
+
+    public function scopeForSignup($query, $id)
+    {
+        return $query->where('eventable_type', 'Rogue\Models\Signup')
+                     ->where('eventable_id', $id);
+    }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -14,6 +14,18 @@ class Event extends Model
     protected $fillable = ['eventable_id', 'eventable_type', 'content', 'user'];
 
     /**
+     * Attributes that can be queried when filtering.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $indexes = [
+        'eventable_id',
+    ];
+
+    /**
      * The attributes that should be cast to native types.
      *
      * @var array

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -31,6 +31,11 @@ Endpoint                                       | Functionality
 ---------------------------------------------- | --------------------------------------------------------
 `GET /api/v2/activity`                         | [Get all user activity](endpoints/activity.md#activity)
 
+#### Events
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`GET /api/v2/events`                         | [Get all events](endpoints/events.md#events)
+
 #### Posts
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------

--- a/documentation/endpoints/events.md
+++ b/documentation/endpoints/events.md
@@ -1,0 +1,57 @@
+## Events
+
+Retrieve all event data.
+
+```
+GET /api/v2/events
+```
+### Optional Query Parameters
+- **filter[signup_id]** _(integer)_
+  - Filter results by the given `signup_id`
+  
+Example Response:
+{
+  "data": [
+    {
+      "event_id": 1117,
+      "eventable_id": 18,
+      "event_type": "Rogue\\Models\\Signup",
+      "content": {
+        "id": "18",
+        "northstar_id": "574dace47f43c21f1e0d674c",
+        "campaign_id": "1173",
+        "campaign_run_id": "1771",
+        "quantity": "1",
+        "quantity_pending": "5371",
+        "why_participated": "Ut quidem aut et ex est beatae facilis.",
+        "source": "phoenix-web",
+        "created_at": "2017-08-14 21",
+        "updated_at": "2017-09-28 18"
+      },
+      "user": "5589c991a59dbfa93d8b45ae",
+      "created_at": "2017-09-28T18:21:27+00:00",
+      "updated_at": "2017-09-28T18:21:27+00:00"
+    },
+    {
+      "event_id": 747,
+      "eventable_id": 18,
+      "event_type": "Rogue\\Models\\Signup",
+      "content": {
+        "id": "18",
+        "northstar_id": "574dace47f43c21f1e0d674c",
+        "campaign_id": "1173",
+        "campaign_run_id": "1771",
+        "quantity": "4",
+        "quantity_pending": "5371",
+        "why_participated": "Ut quidem aut et ex est beatae facilis.",
+        "source": "phoenix-web",
+        "created_at": "2017-08-14 21",
+        "updated_at": "2017-08-24 15"
+      },
+      "user": "5589c991a59dbfa93d8b45ae",
+      "created_at": "2017-08-24T15:08:14+00:00",
+      "updated_at": "2017-08-24T15:08:14+00:00"
+      },
+    }
+  ]
+}


### PR DESCRIPTION
#### What's this PR do?
- Adds `GET /events` endpoint 
- Returns either paginated results of all events or all events per signup (`/events?filter[signup_id]=:sid`
- Updates documentation

#### How should this be reviewed?
- Hit `/api/v2/events` and you should get paginated list of all events 
- hit `/api/v2/events?filter[signup_id]=18`and you should get non-paginated results of all events that are signup events for signup 18 (or any :sid)

#### Any background context you want to provide?
Not sure if this is the best way to do this or not for the future (when we want to grab all events associated by a post or a different type of post in the future) but figured we can start with this? 

#### Relevant tickets
First part in this [Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/150986550). Wanted to break this up so it didn't turn into a monster PR! 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.