### PR TITLE
Optin to cursor pagination instead of doing it by default

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -43,6 +43,6 @@ class ActivityController extends ApiController
             return $this->collection($signups);
         }
 
-        return $this->paginatedCollection($query, $request, 200, [], null, 'cursor');
+        return $this->paginatedCollection($query, $request, 200, [], null);
     }
 }

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -99,7 +99,7 @@ trait TransformsRequests
      * @param $query - Eloquent query
      * @return \Illuminate\Http\Response
      */
-    public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null, $pagination = null)
+    public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null)
     {
         if (is_null($transformer)) {
             $transformer = $this->transformer;
@@ -107,7 +107,7 @@ trait TransformsRequests
 
         $pages = (int) $request->query('limit', 20);
 
-        $fastMode = $request->query('pagination') === 'cursor' || $pagination === 'cursor';
+        $fastMode = $request->query('pagination') === 'cursor';
 
         if ($fastMode) {
             $paginator = $query->simplePaginate(min($pages, 100));

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -28,9 +28,8 @@ GET /api/v2/activity
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`
 - **pagination** _(string)_
-  - If set to 'cursor' we use Laravel's `simplePaginate` to paginate the results which will return less meta data on each request, if `null` will use regular pagination.
-  - Note: we default to `cursor` pagination but you could opt out of that by explicity setting this parameter to `null` in your request.
-  - e.g. `/activity'?pagination=cursor`
+  - If set to 'cursor' we use Laravel's `simplePaginate` to paginate the results which will return less meta data on each request, if it is not passed it will use regular pagination.
+  - e.g. `/activity?pagination=cursor`
 
 Example Response:
 

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -39,11 +39,12 @@ class ActivityApiTest extends BrowserKitTestCase
                 ],
             ],
             'meta' => [
-                'cursor' => [
-                    'current',
-                    'prev',
-                    'next',
+                'pagination' => [
+                    'total',
                     'count',
+                    'per_page',
+                    'total_pages',
+                    'links',
                 ],
             ],
         ]);
@@ -64,9 +65,8 @@ class ActivityApiTest extends BrowserKitTestCase
 
         $response = $this->decodeResponseJson();
         $this->assertCount(8, $response['data']);
-        $this->assertNotEmpty($response['meta']['cursor']['next']);
-        $this->assertEquals(8, $response['meta']['cursor']['count']);
-        $this->assertEquals(1, $response['meta']['cursor']['current']);
+        $this->assertNotEmpty($response['meta']['pagination']['links']['next']);
+        $this->assertEquals(1, $response['meta']['pagination']['current_page']);
     }
 
     /**
@@ -109,8 +109,8 @@ class ActivityApiTest extends BrowserKitTestCase
                 ],
             ],
             'meta' => [
-                'cursor' => [
-                    'current' => 1,
+                'pagination' => [
+                    'current_page' => 1,
                     'count' => 3,
                 ],
             ],
@@ -223,6 +223,45 @@ class ActivityApiTest extends BrowserKitTestCase
             'data' => [
                 [
                     'signup_id' => $secondSignup->id,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Test for retrieving activity using simplePagination
+     *
+     * GET /activity?pagination=cursor
+     * @return void
+     */
+    public function testActivityIndexWithFastPagination()
+    {
+        factory(Signup::class, 10)->create();
+
+        $this->get('api/v2/activity?pagination=cursor');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'data' => [
+                '*' => [
+                    'signup_id',
+                    'northstar_id',
+                    'campaign_id',
+                    'campaign_run_id',
+                    'quantity',
+                    'why_participated',
+                    'signup_source',
+                    'created_at',
+                    'updated_at',
+                    'posts' => [],
+                ],
+            ],
+            'meta' => [
+                'cursor' => [
+                    'current',
+                    'prev',
+                    'next',
+                    'count',
                 ],
             ],
         ]);


### PR DESCRIPTION
#### What's this PR do?
Fixes my previous PR that assumed we could just change the pagination by default. 

That wasn't great because it was a breaking change. 

Updates the `/activity` endpoint to allow a client to specify `cursor` pagination to make for quicker pagination queries. 

#### How should this be reviewed?
👀 


#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.