### PR TITLE
capitalizes the T

### DIFF
--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -4,7 +4,7 @@ namespace Rogue\Http\Controllers\Api;
 
 use Rogue\Models\Event;
 use Illuminate\Http\Request;
-use Rogue\Http\transformers\EventTransformer;
+use Rogue\Http\Transformers\EventTransformer;
 
 class EventController extends ApiController
 {


### PR DESCRIPTION
#### What's this PR do?
Capitalizes the "T" in "Transformer" to fix this bug I was getting on Thor when trying to hit the `/events` endpoint: 
```
[2017-10-02 15:52:18] thor.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Class 'Rogue\Http\transformers\EventTransformer' not found in /var/www/rogue/releases/20171002154015/app/Http/Controllers/Api/EventController.php:16
```

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
I _think_ this is the fix for this bug! Couldn't reproduce on my local environment and noticed that it was a lowercase t - might be causing issues? 

#### Relevant tickets
Fixes typo in this PR: #433 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.