### PR TITLE
Add auth and admin middleware to UsersController

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -17,6 +17,9 @@ class UsersController extends Controller
     public function __construct(Registrar $registrar)
     {
         $this->registrar = $registrar;
+
+        $this->middleware('auth');
+        $this->middleware('role:admin,staff');
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Added `auth` and  `role:admin,staff` middlewares (middlesware?) to the `UsersController` so that only logged in admins can hit the `/users` and `/user/{id}` routes. Unauthenticated users could only hit those routes directly, and were unable to search.

#### How should this be reviewed?
1. Don't log in.
2. Go here: `/users/5589c991a59dbfa93d8b45ae`.
3. Go here: `/users`.
4. Both of those should take you to the login page.

#### Relevant tickets
[Pivotal Card](https://www.pivotaltracker.com/story/show/151605532)

#### Checklist
- [ ] Tested on staging.
