### PR TITLE
Export signups with null details

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -33,7 +33,7 @@ class ExportController extends Controller
     public function show($campaignId)
     {
         // Run the query
-        $signups = Signup::whereNotNull('details')->where('campaign_id', $campaignId)->get();
+        $signups = Signup::whereNull('details')->where('campaign_id', $campaignId)->get();
 
         // Compile the data and trigger the CSV download
         return $this->export->exportSignups($signups, $campaignId);


### PR DESCRIPTION
#### What's this PR do?

For this first pass, We only want to export signups that have no details. PN only sends over details if the user _opts out_ of third party messaging. Otherwise we assume they are opted-in. For the pass at thisexport, we only want to see opt-INs not opt-OUTs.

#### How should this be reviewed?
👁 

#### Any background context you want to provide?

If we do use this export functionality for more things, we should really think about refactoring this so that we can pass in options about what to actually export. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/151767351

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.