### PR TITLE
Symlink persistent keys directory when deploying.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,4 +19,4 @@ set :npm_flags, ''
 set :composer_install_flags, '--no-dev --optimize-autoloader'
 
 set :linked_files, %w{.env}
-set :linked_dirs, %w{images storage/logs storage/dumps storage/system}
+set :linked_dirs, %w{images storage/logs storage/dumps storage/keys storage/system}


### PR DESCRIPTION
#### What's this PR do?
We need Northstar's [public key](https://aurora.dosomething.org/clients) for each environment to be able to accept JWTs. To do this, we want to symlink the `storage/keys` directory to a persistent version kept in `/var/www/rogue/shared` between deploys.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
References #403.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.