### PR TITLE
Use a cursor to grab signups to lessen the load on memory

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -32,10 +32,7 @@ class ExportController extends Controller
      */
     public function show($campaignId)
     {
-        // Run the query
-        $signups = Signup::whereNull('details')->where('campaign_id', $campaignId)->get();
-
         // Compile the data and trigger the CSV download
-        return $this->export->exportSignups($signups, $campaignId);
+        return $this->export->exportSignups($campaignId);
     }
 }

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -4,6 +4,7 @@ namespace Rogue\Services;
 
 use League\Csv\Writer;
 use SplTempFileObject;
+use Rogue\Models\Signup;
 
 class ExportService
 {
@@ -30,8 +31,10 @@ class ExportService
      * @param object $signups
      * @param int $campaignId
      */
-    public function exportSignups($signups, $campaignId)
+    public function exportSignups($campaignId)
     {
+        $signups = Signup::whereNull('details')->where('campaign_id', $campaignId)->cursor();
+
         // Set up column headers
         $column_headers = ['Campaign ID', 'Campaign Run ID', 'Northstar ID', 'First Name', 'Email', 'Mobile', 'Age'];
         $final_results = [$column_headers];

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -33,42 +33,30 @@ class ExportService
      */
     public function exportSignups($campaignId)
     {
-        $signups = Signup::whereNull('details')->where('campaign_id', $campaignId)->cursor();
+        $writer = Writer::createFromFileObject(new SplTempFileObject());
 
         // Set up column headers
-        $column_headers = ['Campaign ID', 'Campaign Run ID', 'Northstar ID', 'First Name', 'Email', 'Mobile', 'Age'];
-        $final_results = [$column_headers];
+        $headers = ['Campaign ID', 'Campaign Run ID', 'Northstar ID', 'First Name', 'Email', 'Mobile', 'Age'];
+
+        $writer->insertOne($headers);
+
+        $signups = Signup::whereNull('details')->where('campaign_id', $campaignId)->cursor();
 
         foreach ($signups as $signup) {
-            $northstar_user = $this->registrar->find($signup->northstar_id);
+            $northstarUser = $this->registrar->find($signup->northstar_id);
 
-            $next_row = [
+            $nextRow = [
                 'campaign_id' => $signup->campaign_id,
                 'campaign_run_id' => $signup->campaign_run_id,
                 'northstar_id' => $signup->northstar_id,
-                'first_name' => $northstar_user->first_name,
-                'email' => $northstar_user->email,
-                'mobile' => $northstar_user->mobile,
-                'age' => getAgeFromBirthdate($northstar_user->birthdate),
+                'first_name' => $northstarUser->first_name,
+                'email' => $northstarUser->email,
+                'mobile' => $northstarUser->mobile,
+                'age' => getAgeFromBirthdate($northstarUser->birthdate),
             ];
 
-            array_push($final_results, $next_row);
+            $writer->insertOne($nextRow);
         }
-
-        return $this->makeCSV($final_results, $campaignId);
-    }
-
-    /**
-     * Build the CSV of signup details for the specified campaign.
-     *
-     * @param array $signups
-     * @param int $campaignId
-     */
-    public function makeCSV($data, $campaignId)
-    {
-        // Create and return CSV file
-        $writer = Writer::createFromFileObject(new SplTempFileObject());
-        $writer->insertAll($data);
 
         return $writer->output('export_' . $campaignId . '.csv');
     }


### PR DESCRIPTION
#### What's this PR do?

Uses eloquent [`cursor`](https://laravel.com/docs/5.5/eloquent#chunking-results) method to iterate through all signups more efficiently. 

#### How should this be reviewed?

👀 


#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.