### PR TITLE
GET /api/v3/signups/:signup_id endpoint

### DIFF
--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -44,16 +44,12 @@ class SignupsController extends ApiController
      * GET /signups/:id
      *
      * @param Request $request
-     * @return ]Illuminate\Http\Response
+     * @return Illuminate\Http\Response
      */
     public function show($id)
     {
-        $signup = Signup::find($id);
+        $signup = Signup::findOrFail($id);
 
-        if ($signup) {
-            return $this->item($signup);
-        } else {
-            throw (new ModelNotFoundException)->setModel('Signup');
-        }
+        return $this->item($signup);
     }
 }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -40,7 +40,7 @@ class SignupsController extends ApiController
     }
 
     /**
-     * Returns a specific signup(s).
+     * Returns a specific signup.
      * GET /signups/:id
      *
      * @param Request $request

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -44,12 +44,13 @@ class SignupsController extends ApiController
      * GET /signups/:id
      *
      * @param Request $request
+     * @param int $id
      * @return Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(Request $request, $id)
     {
         $signup = Signup::findOrFail($id);
 
-        return $this->item($signup);
+        return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
     }
 }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -38,4 +38,22 @@ class SignupsController extends ApiController
 
         return $this->paginatedCollection($query, $request);
     }
+
+    /**
+     * Returns a specific signup(s).
+     * GET /signups/:id
+     *
+     * @param Request $request
+     * @return ]Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $signup = Signup::find($id);
+
+        if ($signup) {
+            return $this->item($signup);
+        } else {
+            throw (new ModelNotFoundException)->setModel('Signup');
+        }
+    }
 }

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -44,13 +44,14 @@ trait TransformsRequests
      * @param  int  $code
      * @param  array  $meta
      * @param  null|object  $transformer
+     * @param  null|string $include
      * @return \Illuminate\Http\JsonResponse
      */
-    public function item($data, $code = 200, $meta = [], $transformer = null)
+    public function item($data, $code = 200, $meta = [], $transformer = null, $include = null)
     {
         $item = new Item($data, $this->setTransformer($transformer));
 
-        return $this->transform($item, $code, $meta);
+        return $this->transform($item, $code, $meta, $include);
     }
 
     /**
@@ -59,6 +60,7 @@ trait TransformsRequests
      * @param  \League\Fractal\Resource\Item|\League\Fractal\Resource\Collection  $data
      * @param  int  $code
      * @param  array  $meta
+     * @param  null|string $include
      * @return \Illuminate\Http\JsonResponse
      */
     public function transform($data, $code = 200, $meta = [], $include = null)

--- a/app/Http/Transformers/Three/SignupTransformer.php
+++ b/app/Http/Transformers/Three/SignupTransformer.php
@@ -4,6 +4,7 @@ namespace Rogue\Http\Transformers\Three;
 
 use Rogue\Models\Signup;
 use League\Fractal\TransformerAbstract;
+use Rogue\Http\Transformers\PostTransformer;
 
 class SignupTransformer extends TransformerAbstract
 {

--- a/app/Http/Transformers/Three/SignupTransformer.php
+++ b/app/Http/Transformers/Three/SignupTransformer.php
@@ -8,6 +8,15 @@ use League\Fractal\TransformerAbstract;
 class SignupTransformer extends TransformerAbstract
 {
     /**
+     * List of resources possible to include
+     *
+     * @var array
+     */
+    protected $availableIncludes = [
+        'posts',
+    ];
+
+    /**
      * Transform resource data.
      *
      * @param \Rogue\Models\Signup $signup
@@ -27,5 +36,18 @@ class SignupTransformer extends TransformerAbstract
             'created_at' => $signup->created_at->toIso8601String(),
             'updated_at' => $signup->updated_at->toIso8601String(),
         ];
+    }
+
+    /**
+     * Include posts
+     *
+     * @param \Rogue\Models\Signup $signup
+     * @return \League\Fractal\Resource\Collection
+     */
+    public function includePosts(Signup $signup)
+    {
+        $post = $signup->posts;
+
+        return $this->collection($post, new PostTransformer);
     }
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -96,4 +96,5 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['auth.api', 'log.received.r
 
     // signups
     Route::get('signups', 'Three\SignupsController@index');
+    Route::get('signups/{id}', 'Three\SignupsController@show');
 });

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -58,4 +58,4 @@ Endpoint                                       | Functionality
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `GET /api/v3/signups`                          | [Get signups](endpoints/signups.md#retrieve-all-signups)
-`GET /api/v3/signups/signup_id`                | [Get s signup](endpoints/signups.md#retrieve-a-specific-signup)          
+`GET /api/v3/signups/signup_id`                | [Get a signup](endpoints/signups.md#retrieve-a-specific-signup)          

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -58,3 +58,4 @@ Endpoint                                       | Functionality
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `GET /api/v3/signups`                          | [Get signups](endpoints/signups.md#retrieve-all-signups)
+`GET /api/v3/signups/signup_id`                | [Get s signup](endpoints/signups.md#retrieve-a-specific-signup)          

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -17,7 +17,7 @@ GET /api/v2/activity
 - **page** _(integer)_
   - For pagination, specify page of activity to return in the response.
   - e.g. `/activity?page=2`
-- **include** _(integer)_
+- **include** _(string)_
   - Include additional related records in the response: `user`
   - e.g. `/activity?include=user`
 - **orderBy** _(string)_

--- a/documentation/endpoints/events.md
+++ b/documentation/endpoints/events.md
@@ -10,6 +10,7 @@ GET /api/v2/events
   - Filter results by the given `signup_id`
   
 Example Response:
+```
 {
   "data": [
     {
@@ -55,3 +56,4 @@ Example Response:
     }
   ]
 }
+```

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -12,7 +12,7 @@ Example Response:
   "data": [
     {
       "id": 1,
-      "northstar_id": "12334",
+      "northstar_id": "5589c991a59dbfa93d8b45ae",
       "campaign_id": 1173,
       "campaign_run_id": 6519,
       "quantity": 8570,
@@ -24,7 +24,7 @@ Example Response:
     },
     {
       "id": 2,
-      "northstar_id": "345367",
+      "northstar_id": "5589c991a59dbfa93d8b45ae",
       "campaign_id": 1631,
       "campaign_run_id": 1626,
       "quantity": 1338,
@@ -61,7 +61,7 @@ Example Response:
 {
   "data": {
     "id": 1,
-    "northstar_id": "1234",
+    "northstar_id": "5589c991a59dbfa93d8b45ae",
     "campaign_id": 1173,
     "campaign_run_id": 6519,
     "quantity": 8570,

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -55,6 +55,11 @@ Example Response:
 ```
 GET /api/v3/signups/:signup_id
 ```
+### Optional Query Parameters
+- **include** _(string)_
+  - Include additional related records in the response: `posts`
+  - e.g. `/api/v3/signups/1?include=posts`
+  
 Example Response: 
 
 ```

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -12,7 +12,7 @@ Example Response:
   "data": [
     {
       "id": 1,
-      "northstar_id": "5589c991a59dbfa93d8b45ae",
+      "northstar_id": "12334",
       "campaign_id": 1173,
       "campaign_run_id": 6519,
       "quantity": 8570,
@@ -24,7 +24,7 @@ Example Response:
     },
     {
       "id": 2,
-      "northstar_id": "5589c991a59dbfa93d8b45ae",
+      "northstar_id": "345367",
       "campaign_id": 1631,
       "campaign_run_id": 1626,
       "quantity": 1338,
@@ -50,6 +50,30 @@ Example Response:
 }
 
 ```
+## Retrieve a specific signup
+
+```
+GET /api/v3/signups/:signup_id
+```
+Example Response: 
+
+```
+{
+  "data": {
+    "id": 1,
+    "northstar_id": "1234",
+    "campaign_id": 1173,
+    "campaign_run_id": 6519,
+    "quantity": 8570,
+    "why_participated": "Eos architecto et quibusdam quasi.",
+    "source": "phoenix-web",
+    "details": null,
+    "created_at": "2017-08-14T21:20:51+00:00",
+    "updated_at": "2017-08-15T16:03:25+00:00"
+  }
+}
+```
+
 ## Create a Signup
 
 ```

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http\Three;
 
-use Rogue\Models\Signup;
 use Rogue\Models\Post;
+use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
 
 class SignupTest extends BrowserKitTestCase
@@ -77,7 +77,6 @@ class SignupTest extends BrowserKitTestCase
         ]);
     }
 
-
     /**
      * Test for retrieving a signup with included post info.
      *
@@ -89,10 +88,7 @@ class SignupTest extends BrowserKitTestCase
         $signup = factory(Signup::class)->create();
         $post = factory(Post::class)->create();
         $post->signup()->associate($signup);
-        $post->campaign_id = $signup->campaign_id;
-        $post->northstar_id = $signup->northstar_id;
         $post->save();
-
 
         $this->get('api/v3/signups/' . $signup->id . '?include=posts');
         $this->assertResponseStatus(200);

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Http\Three;
+
+use Rogue\Models\Signup;
+use Tests\BrowserKitTestCase;
+
+class SignupTest extends BrowserKitTestCase
+{
+    /**
+     * Test for retrieving all signups.
+     *
+     * GET /api/v3/signups
+     * @return void
+     */
+    public function testSignupsIndex()
+    {
+        factory(Signup::class, 10)->create();
+
+        $this->get('api/v3/signups');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'northstar_id',
+                    'campaign_id',
+                    'campaign_run_id',
+                    'quantity',
+                    'why_participated',
+                    'source',
+                    'details',
+                    'created_at',
+                    'updated_at',
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total',
+                    'count',
+                    'per_page',
+                    'current_page',
+                    'total_pages',
+                    'links',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Test for retrieving a specific signup.
+     *
+     * GET /api/v3/signups
+     * @return void
+     */
+    public function testSignupShow()
+    {
+        $signup = factory(Signup::class)->create();
+        $this->get('api/v3/signups/' . $signup->id);
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'data' => [
+                'id',
+                'northstar_id',
+                'campaign_id',
+                'campaign_run_id',
+                'quantity',
+                'why_participated',
+                'source',
+                'details',
+                'created_at',
+                'updated_at',
+            ],
+        ]);
+    }
+}

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Http\Three;
 
 use Rogue\Models\Signup;
+use Rogue\Models\Post;
 use Tests\BrowserKitTestCase;
 
 class SignupTest extends BrowserKitTestCase
@@ -51,7 +52,7 @@ class SignupTest extends BrowserKitTestCase
     /**
      * Test for retrieving a specific signup.
      *
-     * GET /api/v3/signups
+     * GET /api/v3/signups/:signup_id
      * @return void
      */
     public function testSignupShow()
@@ -72,6 +73,39 @@ class SignupTest extends BrowserKitTestCase
                 'details',
                 'created_at',
                 'updated_at',
+            ],
+        ]);
+    }
+
+
+    /**
+     * Test for retrieving a signup with included post info.
+     *
+     * GET /api/v3/signups/186?include=posts
+     * @return void
+     */
+    public function testSignupWithIncludedPosts()
+    {
+        $signup = factory(Signup::class)->create();
+        $post = factory(Post::class)->create();
+        $post->signup()->associate($signup);
+        $post->campaign_id = $signup->campaign_id;
+        $post->northstar_id = $signup->northstar_id;
+        $post->save();
+
+
+        $this->get('api/v3/signups/' . $signup->id . '?include=posts');
+        $this->assertResponseStatus(200);
+
+        $this->seeJsonStructure([
+            'data' => [
+                'posts' => [
+                    'data' => [
+                        '*' => [
+                            'id',
+                        ],
+                    ],
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
#### What's this PR do?
- Adds functionality for the `GET /api/v3/signups/:signup_id` endpoint
  - Adds functionality to optionally include posts e.g. `GET /api/v3/signups/:signup_id?include=posts`
- Adds tests for `GET /api/v3/signups`, `GET /api/v3/signups/:signup_id`, and `GET /api/v3/signups/:signup_id?include=posts`

#### How should this be reviewed?
- Hit the `GET /api/v3/signups/:signup_id` and you should see all the correct information for the signup you specified! 
- If you do something like `GET /api/v3/signups/z`, you should get this error message: 
`{"error":{"code":500,"message":"Class 'Rogue\\Http\\Controllers\\Three\\ModelNotFoundException' not found"},"debug":{"file":"\/home\/vagrant\/DoSomething.org\/rogue\/app\/Http\/Controllers\/Three\/SignupsController.php","line":58}}`
- In your vagrant box, run `vendor/bin/phpunit` and make sure all tests pass! 

#### Relevant tickets
Fixes 2nd task in this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/151852986)

#### Checklist
- [ X ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.