### PR TITLE
Support Contentful Campaign Ids

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -23,7 +23,7 @@ class PostRequest extends Request
     {
         return [
             'northstar_id' => 'required|string',
-            'campaign_id' => 'required|int',
+            'campaign_id' => 'required',
             'campaign_run_id' => 'required|int',
             'caption' => 'string',
             'status' => 'in:pending,accepted,rejected',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,7 +24,7 @@ class PostRequest extends Request
         return [
             'northstar_id' => 'required|string',
             'campaign_id' => 'required',
-            'campaign_run_id' => 'required|int',
+            'campaign_run_id' => 'int',
             'caption' => 'string',
             'status' => 'in:pending,accepted,rejected',
             'source' => 'string',

--- a/app/Http/Requests/SignupRequest.php
+++ b/app/Http/Requests/SignupRequest.php
@@ -24,7 +24,7 @@ class SignupRequest extends Request
         return [
             'northstar_id' => 'required|string',
             'campaign_id' => 'required',
-            'campaign_run_id' => 'required|int',
+            'campaign_run_id' => 'int',
             'quantity' => 'int',
             'why_participated' => 'string',
             'source' => 'string|nullable',

--- a/app/Http/Requests/SignupRequest.php
+++ b/app/Http/Requests/SignupRequest.php
@@ -23,7 +23,7 @@ class SignupRequest extends Request
     {
         return [
             'northstar_id' => 'required|string',
-            'campaign_id' => 'required|int',
+            'campaign_id' => 'required',
             'campaign_run_id' => 'required|int',
             'quantity' => 'int',
             'why_participated' => 'string',

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -19,7 +19,7 @@ class SignupRepository
 
         $signup->northstar_id = $data['northstar_id'];
         $signup->campaign_id = $data['campaign_id'];
-        $signup->campaign_run_id = $data['campaign_run_id'];
+        $signup->campaign_run_id = isset($data['campaign_run_id']) ? $data['campaign_run_id'] : null;
         $signup->quantity = isset($data['quantity']) ? $data['quantity'] : null;
         $signup->quantity_pending = isset($data['quantity_pending']) ? $data['quantity_pending'] : null;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.36.26",
+            "version": "3.36.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "96f2c1525d3fd17a0802329c309c76c01a78aa51"
+                "reference": "6a4c2643cd0883987da815f292f07d00ee098622"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/96f2c1525d3fd17a0802329c309c76c01a78aa51",
-                "reference": "96f2c1525d3fd17a0802329c309c76c01a78aa51",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6a4c2643cd0883987da815f292f07d00ee098622",
+                "reference": "6a4c2643cd0883987da815f292f07d00ee098622",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-10-12T19:45:50+00:00"
+            "time": "2017-10-16T18:49:51+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -696,20 +696,21 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "4c008848d528131016052c2b513ff6756501cda7"
+                "reference": "c9790b51ecccbf0586d9562e0a1d4810d62f3000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/4c008848d528131016052c2b513ff6756501cda7",
-                "reference": "4c008848d528131016052c2b513ff6756501cda7",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/c9790b51ecccbf0586d9562e0a1d4810d62f3000",
+                "reference": "c9790b51ecccbf0586d9562e0a1d4810d62f3000",
                 "shasum": ""
             },
             "require": {
                 "giggsey/libphonenumber-for-php": "~7.0",
+                "gree/jose": "^2.2",
                 "guzzlehttp/guzzle": "^6.2.1",
                 "lcobucci/jwt": "^3.1",
                 "league/oauth2-client": "~2.2",
@@ -743,7 +744,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2017-09-18T21:37:06+00:00"
+            "time": "2017-10-16T17:30:08+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -897,6 +898,62 @@
             ],
             "description": "Locale functions required by libphonenumber-for-php",
             "time": "2017-04-07T18:45:42+00:00"
+        },
+        {
+            "name": "gree/jose",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nov/jose-php.git",
+                "reference": "445d702ffc8b17abd22d664b334a4046a0ed0b8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nov/jose-php/zipball/445d702ffc8b17abd22d664b334a4046a0ed0b8e",
+                "reference": "445d702ffc8b17abd22d664b334a4046a0ed0b8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpseclib/phpseclib": ">=2.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JOSE": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "src/"
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nov Matake",
+                    "email": "nov@matake.jp",
+                    "homepage": "http://matake.jp"
+                }
+            ],
+            "description": "JWT, JWS and JWS implementation in PHP",
+            "homepage": "https://github.com/nov/jose",
+            "keywords": [
+                "ID Token",
+                "JOSE",
+                "JSON Web Encryption",
+                "JSON Web Signature",
+                "JSON Web Token",
+                "JWE",
+                "JWS",
+                "OpenID Connect",
+                "jwt"
+            ],
+            "time": "2016-09-14T07:47:41+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2398,6 +2455,98 @@
             "time": "2017-09-27T21:40:39+00:00"
         },
         {
+            "name": "phpseclib/phpseclib",
+            "version": "2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "34a7699e6f31b1ef4035ee36444407cecf9f56aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/34a7699e6f31b1ef4035ee36444407cecf9f56aa",
+                "reference": "34a7699e6f31b1ef4035ee36444407cecf9f56aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "~4.0",
+                "sami/sami": "~2.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "time": "2017-06-05T06:31:10+00:00"
+        },
+        {
             "name": "predis/predis",
             "version": "v1.1.1",
             "source": {
@@ -2546,16 +2695,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.8.11",
+            "version": "v0.8.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "b193cd020e8c6b66cea6457826ae005e94e6d2c0"
+                "reference": "1502354ebc70d59d8e3a87c325b0eb78a79da25b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/b193cd020e8c6b66cea6457826ae005e94e6d2c0",
-                "reference": "b193cd020e8c6b66cea6457826ae005e94e6d2c0",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1502354ebc70d59d8e3a87c325b0eb78a79da25b",
+                "reference": "1502354ebc70d59d8e3a87c325b0eb78a79da25b",
                 "shasum": ""
             },
             "require": {
@@ -2615,7 +2764,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2017-07-29T19:30:02+00:00"
+            "time": "2017-10-14T17:14:13+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -3352,16 +3501,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -3373,7 +3522,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -3407,7 +3556,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14T15:44:48+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/process",
@@ -4643,16 +4792,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.22",
+            "version": "5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "10df877596c9906d4110b5b905313829043f2ada"
+                "reference": "78532d5269d984660080d8e0f4c99c5c2ea65ffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/10df877596c9906d4110b5b905313829043f2ada",
-                "reference": "10df877596c9906d4110b5b905313829043f2ada",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/78532d5269d984660080d8e0f4c99c5c2ea65ffe",
+                "reference": "78532d5269d984660080d8e0f4c99c5c2ea65ffe",
                 "shasum": ""
             },
             "require": {
@@ -4721,7 +4870,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-09-24T07:23:38+00:00"
+            "time": "2017-10-15T06:13:55+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -58,6 +58,15 @@ $factory->define(Signup::class, function (Generator $faker) {
     ];
 });
 
+$factory->state(Signup::class, 'contentful', function (Generator $faker) {
+    $faker->addProvider(new FakerContentfulCampaignId($faker));
+
+    return [
+        'campaign_id' => $faker->contentful_id,
+        'campaign_run_id' => null,
+    ];
+});
+
 // Reaction Factory
 $factory->define(Reaction::class, function (Generator $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));

--- a/database/faker/FakerContentfulCampaignId.php
+++ b/database/faker/FakerContentfulCampaignId.php
@@ -1,0 +1,27 @@
+<?php
+
+use Faker\Provider\Base;
+
+class FakerContentfulCampaignId extends Base
+{
+    /**
+     * A selection of test campaign IDs from Contentful.
+     *
+     * @var array
+     */
+    protected static $ids = [
+        '6LQzMvDNQcYQYwso8qSkQ8', // [Test] Teens for Jeans 2017
+        '4w1fBp7W5WAowuu0wKwAac', // [Legacy Test] Mirror Messages 2017-10
+        '5bUfbCp98sicAKSoscqUUO', // [LegacyTest] Thumb Wars 2017
+    ];
+
+    /**
+     * Return a random contentful campaign ID.
+     *
+     * @return mixed
+     */
+    public function contentful_id()
+    {
+        return static::randomElement(static::$ids);
+    }
+}

--- a/database/migrations/2017_10_17_143249_store_campaign_id_as_string.php
+++ b/database/migrations/2017_10_17_143249_store_campaign_id_as_string.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class StoreCampaignIdAsString extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->string('campaign_id')->change();
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('campaign_id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->integer('campaign_id')->change();
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->integer('campaign_id')->change();
+        });
+    }
+}

--- a/database/migrations/2017_10_17_144601_make_campaign_run_nullable.php
+++ b/database/migrations/2017_10_17_144601_make_campaign_run_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeCampaignRunNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->integer('campaign_run_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->integer('campaign_run_id')->nullable(false)->change();
+        });
+    }
+}

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -8,9 +8,9 @@ POST /api/v2/posts
 
   - **northstar_id**: (string) required.
     The northstar id of the user creating the post.
-  - **campaign_id**: (int) required.
+  - **campaign_id**: (int|string) required.
     The drupal node id of the campaign that the user's post is associated with. 
-  - **campaign_run_id**: (int) required.
+  - **campaign_run_id**: (int) optional.
     The drupal campaign run node id of the campaign that the user's post is associated with.
   - **quantity**: (int).
     The number of reportback nouns verbed. 

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -87,9 +87,9 @@ POST /api/v2/signups
 
   - **northstar_id**: (string) required.
     The northstar id of the user signing up.
-  - **campaign_id**: (int) required.
+  - **campaign_id**: (int|string) required.
     The drupal node id of the campaign the user is signing up for.
-  - **campaign_run_id**: (int) required.
+  - **campaign_run_id**: (int) optional.
     The drupal campaign run node id of the campaign run the user is signing up for.
   - **quantity**: (int) optional.
     The approved number of reportback nouns verbed.

--- a/tests/Http/Api/SignupApiTest.php
+++ b/tests/Http/Api/SignupApiTest.php
@@ -49,4 +49,45 @@ class SignupApiTest extends BrowserKitTestCase
             'details' => 'affiliate-messaging',
         ]);
     }
+
+    /**
+     * Test creating signups from a Contentful campaign
+     *
+     * @group creatingAPhoto
+     * @return void
+     */
+    public function testCreatingAContentfulSignup()
+    {
+        $northstarId = '54fa272b469c64d7068b456a';
+        $campaignId = '6LQzMvDNQcYQYwso8qSkQ8';
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignup');
+
+        $this->withRogueApiKey()->json('POST', 'api/v2/signups', [
+            'northstar_id'     => $northstarId,
+            'campaign_id'      => $campaignId,
+            'source'           => 'phoenix-next',
+            'details'          => 'affiliate-messaging-optout',
+        ]);
+
+        // Make sure we get the 201 Created response
+        $this->assertResponseStatus(201);
+        $this->seeJson([
+            'northstar_id' => $northstarId,
+            'campaign_id' => $campaignId,
+            'campaign_run_id' => null,
+            'signup_source' => 'phoenix-next',
+            'quantity' => null,
+            'why_participated' => null,
+        ]);
+
+        // Make sure the signup is persisted.
+        $this->seeInDatabase('signups', [
+            'northstar_id' => $northstarId,
+            'campaign_id' => $campaignId,
+            'campaign_run_id' => null,
+            'details' => 'affiliate-messaging-optout',
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?

Allows Rogue to support Contentful Campaigns directly. Contentful Campaign IDs are strings in the vain of `6LQzMvDNQcYQYwso8qSkQ8`. So this PR updates the DB and some logic to support that. Also Contentful campaigns do not have runs, so this PR removes the requirements around `campaign_run_id`. Also adds tests for sending a request from Contentful. 

#### How should this be reviewed?

I think you can go commit-by-commit. 

@DFurnes would love for you to check out the tests to make sure I am making the correct assumptions about what the request would look like. Mainly that PN would only send over a `campaign_id` with no run. 

#### Any background context you want to provide?

This will help PN talk directly to Rogue without needing a PA proxy endpoint. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/151853719

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.