### PR TITLE
Fixes History Modal & Update Quantity Bug

### DIFF
--- a/app/Http/Transformers/EventTransformer.php
+++ b/app/Http/Transformers/EventTransformer.php
@@ -29,8 +29,8 @@ class EventTransformer extends TransformerAbstract
             foreach ($array as $key => $value) {
                 $keyValues = explode(':', $value);
 
-                $key = trim($keyValues[0], '"');
-                $value = trim($keyValues[1], '"');
+                $key = isset($keyValues[0]) ? trim($keyValues[0], '"') : '';
+                $value = isset($keyValues[1]) ? trim($keyValues[1], '"') : '';
                 $content[$key] = $value;
             }
 

--- a/app/Http/Transformers/EventTransformer.php
+++ b/app/Http/Transformers/EventTransformer.php
@@ -29,7 +29,7 @@ class EventTransformer extends TransformerAbstract
             foreach ($array as $key => $value) {
                 $keyValues = explode(':', $value);
 
-                $key = isset($keyValues[0]) ? trim($keyValues[0], '"') : '';
+                $key = trim($keyValues[0], '"');
                 $value = isset($keyValues[1]) ? trim($keyValues[1], '"') : '';
                 $content[$key] = $value;
             }


### PR DESCRIPTION
#### What's this PR do?
While parsing through content column of Events tables, checks if value is set first before trimming to fix 🐛 

#### How should this be reviewed?
Make sure you can open and update history modal (usually with more recent entries). 

#### Any background context you want to provide?
For some reason, the content column of the Events table is not getting stored in the same manner as older events (some have spaces of `\` in the response). I'll make another card for this to check out to make sure all of our data is being stored in a normalized manner. 

#### Relevant tickets
Fixes this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/152039043).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.