### PR TITLE
Changes limit to 80 instead of all on user page 

### DIFF
--- a/app/Http/Controllers/Api/ActivityController.php
+++ b/app/Http/Controllers/Api/ActivityController.php
@@ -37,12 +37,6 @@ class ActivityController extends ApiController
 
         $query = $this->filter($query, $filters, Signup::$indexes);
 
-        if (($request->query('limit') === 'all')) {
-            $signups = $query->get();
-
-            return $this->collection($signups);
-        }
-
         return $this->paginatedCollection($query, $request, 200, [], null);
     }
 }

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -12,7 +12,6 @@ GET /api/v2/activity
   - You can filter by more than one value for a column, e.g. `/activity?filter[id]=121,122`
 - **limit** _(default is 20)_
   - Set the number of records to return in a single response.
-  - If limit is set to 'all' (e.g. `limit='all'`), results will not be paginated.
   - e.g. `/activity?limit=35`
 - **page** _(integer)_
   - For pagination, specify page of activity to return in the response.

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -50,7 +50,7 @@ class UserOverview extends React.Component {
         northstar_id: id,
       },
       orderBy: 'desc',
-      limit: 'all',
+      limit: 80,
     });
 
     return request.then((result) => {


### PR DESCRIPTION
#### What's this PR do?
- Removes logic for `limit=all`.
- Updates the user page to grab `80` signups instead of `all`.
- Updates documentation.

#### How should this be reviewed?
- Visit a user page. All signups should be listed and it should work! 

#### Any background context you want to provide?
We wanted to change this manually to a large number in order to see all user signups on their overview page. We don't want to have the `limit=all` logic any longer in case of a "busy" edge case or a malicious call so it doesn't kill our servers.

We'll revisit this problem once we build more RESTful API endpoints. 

#### Relevant tickets
Fixes this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/151566633).

#### Checklist
- [ x ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.