### PR TITLE
remove :on_error

### DIFF
--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -20,7 +20,7 @@ namespace :laravel do
   desc 'Restart queue'
   task :restart_queue_worker do
     on roles(:all) do
-      run "ps -ef | grep 'queue:restart' | awk '{print $2}' | xargs sudo kill -9"
+      execute :php, "artisan queue:restart"
     end
   end
 end

--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -20,7 +20,7 @@ namespace :laravel do
   desc 'Restart queue'
   task :restart_queue_worker do
     on roles(:all) do
-      run "ps -ef | grep 'queue:work' | awk '{print $2}' | xargs sudo kill -9"
+      run "ps -ef | grep 'queue:restart' | awk '{print $2}' | xargs sudo kill -9"
     end
   end
 end

--- a/lib/capistrano/tasks/laravel.rake
+++ b/lib/capistrano/tasks/laravel.rake
@@ -18,7 +18,7 @@ namespace :laravel do
   end
 
   desc 'Restart queue'
-  task :restart_queue_worker, :on_error => :continue do
+  task :restart_queue_worker do
     on roles(:all) do
       run "ps -ef | grep 'queue:work' | awk '{print $2}' | xargs sudo kill -9"
     end


### PR DESCRIPTION
#### What's this PR do?
One more change to the deploy. Removes the `:on_error` param (task?) which is not supported by Cap 3. 

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.