### PR TITLE
Signupless reportback updates (let some fields be nullable, timestamps)

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -25,10 +25,10 @@ class PostRequest extends Request
             'northstar_id' => 'required|string',
             'campaign_id' => 'required',
             'campaign_run_id' => 'int',
-            'caption' => 'string',
+            'caption' => 'nullable|string',
             'status' => 'in:pending,accepted,rejected',
-            'source' => 'string',
-            'remote_addr' => 'string',
+            'source' => 'nullable|string',
+            'remote_addr' => 'nullable|string',
             // 'file' => 'string', // @TODO - should do some better validation around files.
         ];
     }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -91,7 +91,7 @@ class PostRepository
         // Let Laravel take care of the timestamps unless they are specified in the request
         if (isset($data['created_at'])) {
             $post->created_at = $data['created_at'];
-            $post->updated_at = $data['created_at'];
+            $post->updated_at = isset($data['updated_at']) ? $data['updated_at'] : $data['created_at'];
             $post->save(['timestamps' => false]);
 
             $post->events->first()->created_at = $data['created_at'];

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -36,6 +36,10 @@ POST /api/v2/posts
     The copy height coordinates of the post image if the user cropped the image.
   - **crop_rotate** (int).
     The copy rotate coordinates of the post image if the user cropped the image.
+  - **created_at** (string in format 2015-07-23 14:02:46).
+    Time that the post was created.
+  - **updated_at** (string in format 2015-07-23 14:02:46).
+    Time that the post was updated.
 
 Example Response:
 


### PR DESCRIPTION
#### What's this PR do?
- Previously, we didn't required posts to provide `caption`, `source`, `remote_addr`, but if they WERE provided, they couldn't be `null`. Lots of old data is missing these values, so we want to allow `null` values to be submitted. 
- Update how we use timestamps for migrated posts. Previously, we set the `created_at` and `updated_at` to both be what was sent as `created_at` in the script. Now, we want to allow `updated_at` to be set if we have it.

#### How should this be reviewed?
👀 This won't mess up any non-migration related functionality, will it?

#### Relevant tickets
[Pivotal](https://www.pivotaltracker.com/story/show/151761727)

#### Checklist
- [X] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.