### PR TITLE
Refactors Event Logic 

### DIFF
--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -19,7 +19,7 @@ class ModelServiceProvider extends ServiceProvider
     {
         // When a Signup's why_participated, quantity, quantity_pending, or deleted_at are changed, create an event.
         // @TODO: when we move quantity on the post, we'll want to remove this check below.
-        Signup::saved(function ($signup) {
+        Signup::saving(function ($signup) {
             if ($signup->isDirty('why_participated') || $signup->isDirty('quantity') || $signup->isDirty('quantity_pending') || $signup->isDirty('deleted_at')) {
                 $signup->events()->create([
                     'content' => $signup->toJson(),

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -18,6 +18,7 @@ class ModelServiceProvider extends ServiceProvider
     public function boot()
     {
         // When a Signup's why_participated, quantity, quantity_pending, or deleted_at are changed, create an event.
+        // @TODO: when we move quantity on the post, we'll want to remove this check below.
         Signup::saved(function ($signup) {
             if ($signup->isDirty('why_participated') || $signup->isDirty('quantity') || $signup->isDirty('quantity_pending') || $signup->isDirty('deleted_at')) {
                 $signup->events()->create([

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -19,7 +19,7 @@ class ModelServiceProvider extends ServiceProvider
     {
         // When a Signup's why_participated, quantity, quantity_pending, or deleted_at are changed, create an event.
         // @TODO: when we move quantity on the post, we'll want to remove this check below.
-        Signup::saving(function ($signup) {
+        Signup::saved(function ($signup) {
             if ($signup->isDirty('why_participated') || $signup->isDirty('quantity') || $signup->isDirty('quantity_pending') || $signup->isDirty('deleted_at')) {
                 $signup->events()->create([
                     'content' => $signup->toJson(),

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -17,14 +17,16 @@ class ModelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // When Signups are saved create an event for them.
+        // When a Signup's why_participated, quantity, quantity_pending, or deleted_at are changed, create an event.
         Signup::saved(function ($signup) {
-            $signup->events()->create([
-                'content' => $signup->toJson(),
-                // Use the authenticated user if coming from the web,
-                // otherwise use the id of the user in the request.
-                'user' => auth()->user() ? auth()->user()->northstar_id : $signup->northstar_id,
-            ]);
+            if ($signup->isDirty('why_participated') || $signup->isDirty('quantity') || $signup->isDirty('quantity_pending') || $signup->isDirty('deleted_at')) {
+                $signup->events()->create([
+                    'content' => $signup->toJson(),
+                    // Use the authenticated user if coming from the web,
+                    // otherwise use the id of the user in the request.
+                    'user' => auth()->user() ? auth()->user()->northstar_id : $signup->northstar_id,
+                ]);
+            }
         });
 
         // When Posts are saved create an event for them.

--- a/tests/Http/EventTest.php
+++ b/tests/Http/EventTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Http;
+
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+use Tests\BrowserKitTestCase;
+
+class EventTest extends BrowserKitTestCase
+{
+    /**
+     * Test that an event gets created when a signup is created.
+     *
+     * @return void
+     */
+    public function testCreatingSignupEvent()
+    {
+        // Create a signup
+        $this->mockTime('8/3/2017 17:02:00');
+        factory(Signup::class)->create();
+
+        // Make sure we created an event for the signup creation.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Signup',
+            'created_at' => '2017-08-03 17:02:00',
+        ]);
+    }
+
+    /**
+     * Test that an event gets created when a signup is updated.
+     *
+     * @return void
+     */
+    public function testUpdatingSignupEvent()
+    {
+        // Create a signup
+        $this->mockTime('8/3/2017 17:02:00');
+        $signup = factory(Signup::class)->create();
+
+        // And then later on, we'll update this signup...
+        $this->mockTime('8/4/2017 18:02:00');
+        $signup->quantity = $signup->quantity + 1;
+        $signup->save();
+
+        // Make sure we created an event for the signup creation.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Signup',
+            'created_at' => '2017-08-03 17:02:00',
+        ]);
+
+        // Make sure we also created an event for the signup update.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Signup',
+            'created_at' => '2017-08-04 18:02:00',
+        ]);
+    }
+
+    /**
+     * Test that an event get created when a post is created.
+     *
+     * @return void
+     */
+    public function testCreatingPostEvent()
+    {
+        // Create a post
+        $this->mockTime('8/3/2017 17:02:00');
+        factory(Post::class)->create();
+
+        // Make sure we created an event for the post creation.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Post',
+            'created_at' => '2017-08-03 17:02:00',
+        ]);
+    }
+
+    /**
+     * Test that an event gets created when a post is updated (and that a signup event doesn't get updated).
+     *
+     * @return void
+     */
+    public function testUpdatingPostEvent()
+    {
+        // Create a signup
+        $signup = factory(Signup::class)->create();
+
+        // Create a post and associate it to the signup.
+        $this->mockTime('8/3/2017 17:02:00');
+        $post = factory(Post::class)->create();
+        $post->signup()->associate($signup);
+
+        // And then later on, we'll update this post...
+        $this->mockTime('8/4/2017 18:02:00');
+        $post->status = 'rejected';
+        $post->save();
+
+        // Make sure we created an event for the post creation.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Post',
+            'created_at' => '2017-08-03 17:02:00',
+        ]);
+
+        // Make sure we also created an event for the post update.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Post',
+            'created_at' => '2017-08-04 18:02:00',
+        ]);
+
+        // Make sure a signup event wasn't created when the post was updated.
+        $this->notSeeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Signup',
+            'created_at' => '2017-08-04 18:02:00',
+        ]);
+    }
+}

--- a/tests/Http/EventTest.php
+++ b/tests/Http/EventTest.php
@@ -111,4 +111,25 @@ class EventTest extends BrowserKitTestCase
             'created_at' => '2017-08-04 18:02:00',
         ]);
     }
+
+    /**
+     * Test deleting a post via the API (DELETE 'posts/{id}') creates an event.
+     *
+     * @return void
+     */
+    public function testDeletingPostViaApiEvent()
+    {
+        // Create a post.
+        $post = factory(Post::class)->create();
+
+        // Delete the post via the API.
+        $this->mockTime('8/4/2017 18:02:00');
+        $this->actingAsAdmin()->delete('posts/' . $post->id);
+
+        // Make sure an event is created when the post is deleted.
+        $this->seeInDatabase('events', [
+            'eventable_type' => 'Rogue\Models\Post',
+            'created_at' => '2017-08-04 18:02:00',
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
- Only creates a signup event if `why_participated`, `quantity`, `quantity_pending`, or `deleted_at` has changed. 
- This prevents creating unnecessary/redundant signup events in the events table when a post is updated but nothing about the actual signup is updated.
- Adds tests to make sure:
  - An event gets created when a signup is created
  - An event gets created when a signup is updated
  - An event gets created when a post is created
  - An event gets created when a post is updated, but a signup event does not get created when this happens.

#### How should this be reviewed?
- Go to a user's signup page. 
- Upload a new post for the user. 
- You should only see one event added in the events table for the new post. 
- Update the quantity of the signup. 
- You should then see a new signup event in the events table. 
- If you reject or approve of a post for this signup, you should only see a review and post event. 

I based this logic off of the fact that we want to create an event for the following: 
- When a signup is created.
- When a signup's `quantity`/`quantity_pending`, `why_participated`, and `deleted_at` are updated/changed. 
- When a post is created. 
- When a post is updated.
- When a review is made.
Is there anything else I'm missing? 

#### Any background context you want to provide?
- Adds a `@TODO` in the code for when we move `quantity` to a post instead of signup, we'll want to remove the check in this file. Should I add this on a card somewhere so it doesn't get lost? 
- I think we still want [this code](https://github.com/DoSomething/rogue/blob/master/resources/assets/components/HistoryModal/index.js#L23) to partse the events table data until the data in the `content` column is all standardized. 

#### Relevant tickets
Fixes this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/151720823).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.