### PR TITLE
Allow requests to include flag to not send data to Blink

### DIFF
--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -47,7 +47,7 @@ class PostService
         $post = $this->repository->create($data, $signupId);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
-        $should_send_to_blink = !(array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+        $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
 
         // Save the new post in Customer.io, via Blink.
         if (config('features.blink') && $should_send_to_blink) {
@@ -74,7 +74,7 @@ class PostService
         $postOrSignup = $this->repository->update($signup, $data);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
-        $should_send_to_blink = !(array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+        $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
 
         // Save the new post in Customer.io, via Blink.
         if (config('features.blink') && $postOrSignup instanceof Post && isset($data['dont_send_to_blink']) && $should_send_to_blink) {

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -78,7 +78,7 @@ class PostService
         $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
 
         // Save the new post in Customer.io, via Blink.
-        if (config('features.blink') && $postOrSignup instanceof Post && isset($data['dont_send_to_blink']) && $should_send_to_blink) {
+        if (config('features.blink') && $postOrSignup instanceof Post && $should_send_to_blink) {
             $payload = $postOrSignup->toBlinkPayload();
             $this->blink->userSignupPost($payload);
             logger()->info('Post ' . $post->id . ' sent to Blink');

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -53,6 +53,7 @@ class PostService
         if (config('features.blink') && $should_send_to_blink) {
             $payload = $post->toBlinkPayload();
             $this->blink->userSignupPost($payload);
+            logger()->info('Post ' . $post->id . ' sent to Blink');
         }
 
         // Add new transaction id to header.
@@ -80,6 +81,7 @@ class PostService
         if (config('features.blink') && $postOrSignup instanceof Post && isset($data['dont_send_to_blink']) && $should_send_to_blink) {
             $payload = $postOrSignup->toBlinkPayload();
             $this->blink->userSignupPost($payload);
+            logger()->info('Post ' . $post->id . ' sent to Blink');
         }
 
         // Add new transaction id to header.

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -46,8 +46,11 @@ class PostService
     {
         $post = $this->repository->create($data, $signupId);
 
+        // Send to Blink unless 'dont_send_to_blink' is TRUE
+        $should_send_to_blink = !(array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+
         // Save the new post in Customer.io, via Blink.
-        if (config('features.blink')) {
+        if (config('features.blink') && $should_send_to_blink) {
             $payload = $post->toBlinkPayload();
             $this->blink->userSignupPost($payload);
         }
@@ -70,8 +73,11 @@ class PostService
     {
         $postOrSignup = $this->repository->update($signup, $data);
 
+        // Send to Blink unless 'dont_send_to_blink' is TRUE
+        $should_send_to_blink = !(array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+
         // Save the new post in Customer.io, via Blink.
-        if (config('features.blink') && $postOrSignup instanceof Post) {
+        if (config('features.blink') && $postOrSignup instanceof Post && isset($data['dont_send_to_blink']) && $should_send_to_blink) {
             $payload = $postOrSignup->toBlinkPayload();
             $this->blink->userSignupPost($payload);
         }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -81,7 +81,7 @@ class PostService
         if (config('features.blink') && $postOrSignup instanceof Post && $should_send_to_blink) {
             $payload = $postOrSignup->toBlinkPayload();
             $this->blink->userSignupPost($payload);
-            logger()->info('Post ' . $post->id . ' sent to Blink');
+            logger()->info('Post ' . $postOrSignup->id . ' sent to Blink');
         }
 
         // Add new transaction id to header.

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -44,8 +44,11 @@ class SignupService
     {
         $signup = $this->signup->create($data);
 
+        // Send to Blink unless 'dont_send_to_blink' is TRUE
+        $should_send_to_blink = !(array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+
         // Save the new signup in Customer.io, via Blink.
-        if (config('features.blink')) {
+        if (config('features.blink') && $should_send_to_blink) {
             $payload = $signup->toBlinkPayload();
             $this->blink->userSignup($payload);
         }

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -45,7 +45,7 @@ class SignupService
         $signup = $this->signup->create($data);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
-        $should_send_to_blink = !(array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+        $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
 
         // Save the new signup in Customer.io, via Blink.
         if (config('features.blink') && $should_send_to_blink) {

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -51,6 +51,7 @@ class SignupService
         if (config('features.blink') && $should_send_to_blink) {
             $payload = $signup->toBlinkPayload();
             $this->blink->userSignup($payload);
+            logger()->info('Signup ' . $signup->id . ' sent to Blink');
         }
 
         // Add new transaction id to header.

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -36,10 +36,12 @@ POST /api/v2/posts
     The copy height coordinates of the post image if the user cropped the image.
   - **crop_rotate** (int).
     The copy rotate coordinates of the post image if the user cropped the image.
-  - **created_at** (string in format 2015-07-23 14:02:46).
-    Time that the post was created.
-  - **updated_at** (string in format 2015-07-23 14:02:46).
-    Time that the post was updated.
+  - **dont_send_to_blink** (boolean) optional.
+    If included and true, the data for this Post will not be sent to Blink.
+  - **created_at**: (string) optional.
+    `Y-m-d H:i:s` format. When the post was created.
+  - **updated_at**: (string) optional.
+    `Y-m-d H:i:s` format. When the post was last updated.
 
 Example Response:
 

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -101,6 +101,8 @@ POST /api/v2/signups
     The source of the signup.
   - **details**: (string) optional
     Details to be added to the "details" column on the signup, such as signed up to receive affiliate messaging.
+  - **dont_send_to_blink** (boolean) optional.
+    If included and true, the data for this Signup will not be sent to Blink.
   - **created_at**: (string) optional.
     `Y-m-d H:i:s` format. When the signup was created.
   - **updated_at**: (string) optional.


### PR DESCRIPTION
#### What's this PR do?
Added the ability to send `dont_send_to_blink` flag with Post and Signup requests. If the flag is true, we do not send anything to Blink. If the flag is false or not included, the data will be set to Blink as long as the other already existing conditions are true (ex. Blink feature flag is true).

#### How should this be reviewed?
Is the logic right?

#### Any background context you want to provide?
We don't want to send a bunch of events to Blink when we run the upcoming Signupless Reportback migration.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/152320855)

#### Checklist
- [X] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
