### PR TITLE
Refresh Bug on Uploader Modal 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.36.32",
+            "version": "3.36.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "7ba49dbd24366647a41cd4a13eab972b2264b8db"
+                "reference": "a98d00916b65c89cdbae94cf53f7905a27ff88ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7ba49dbd24366647a41cd4a13eab972b2264b8db",
-                "reference": "7ba49dbd24366647a41cd4a13eab972b2264b8db",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a98d00916b65c89cdbae94cf53f7905a27ff88ca",
+                "reference": "a98d00916b65c89cdbae94cf53f7905a27ff88ca",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-10-23T20:40:28+00:00"
+            "time": "2017-10-24T18:41:59+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -55,12 +55,16 @@ class ReportbackUploader extends React.Component {
       status: 'accepted',
     };
 
+    var signup = this.props.signup;
+
     if (this.quantity.value) {
       reportback.impact = this.quantity.value;
+      signup.quantity = reportback.impact;
     }
 
     if (this.why_participated.value) {
       reportback.whyParticipated = this.why_participated.value;
+      signup.why_participated = reportback.whyParticipated;
     }
 
     const fileType = reportback.media.file ? reportback.media.file.type : null;
@@ -75,7 +79,7 @@ class ReportbackUploader extends React.Component {
       media: this.defaultMediaState,
     });
 
-    this.props.updateQuantityOrWhyState(reportback.impact ? reportback.impact : null, reportback.whyParticipated ? reportback.whyParticipated : null);
+    this.props.updateSignup(signup);
   }
 
   render() {

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -57,6 +57,7 @@ class ReportbackUploader extends React.Component {
 
     if (this.quantity.value) {
       reportback.impact = this.quantity.value;
+      this.props.updateQuantity(this.props.signup, reportback.impact);
     }
 
     if (this.why_participated.value) {
@@ -68,6 +69,7 @@ class ReportbackUploader extends React.Component {
     reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
     this.props.submitReportback(reportback);
+
 
     // @TODO: only reset form AFTER successful RB submission.
     this.form.reset();

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -57,7 +57,6 @@ class ReportbackUploader extends React.Component {
 
     if (this.quantity.value) {
       reportback.impact = this.quantity.value;
-      this.props.updateQuantity(this.props.signup, reportback.impact);
     }
 
     if (this.why_participated.value) {
@@ -70,12 +69,13 @@ class ReportbackUploader extends React.Component {
 
     this.props.submitReportback(reportback);
 
-
     // @TODO: only reset form AFTER successful RB submission.
     this.form.reset();
     this.setState({
       media: this.defaultMediaState,
     });
+
+    this.props.updateQuantityOrWhyState(reportback.impact ? reportback.impact : null, reportback.whyParticipated ? reportback.whyParticipated : null);
   }
 
   render() {

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -338,6 +338,7 @@ class Signup extends React.Component {
                     signup={signup}
                     campaign={campaign}
                     submitReportback={this.submitReportback}
+                    updateQuantity={this.updateQuantity}
                     success={this.state.successfulSubmission}
                   />
                 : null}

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -74,6 +74,7 @@ class Signup extends React.Component {
     this.showUploader = this.showUploader.bind(this);
     this.hideUploader = this.hideUploader.bind(this);
     this.submitReportback = this.submitReportback.bind(this);
+    this.updateQuantityOrWhyState = this.updateQuantityOrWhyState.bind(this);
   }
 
   componentDidMount() {
@@ -206,7 +207,7 @@ class Signup extends React.Component {
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
-
+        console.log(newState);
         newState.signup.quantity = result.quantity;
 
         return newState;
@@ -215,6 +216,18 @@ class Signup extends React.Component {
 
     // Close the modal
     this.hideHistory();
+  }
+
+  // Set newstate with updated quantity and why_participated.
+  updateQuantityOrWhyState(quantity, why) {
+    this.setState((previousState) => {
+      const newState = {...previousState};
+
+      newState.signup.quantity = quantity === null ? previousState.quantity : quantity;
+      newState.signup.why_participated = why === null ? previousState.why_participated : why;
+
+      return newState;
+    });
   }
 
   // Delete a post.
@@ -338,7 +351,7 @@ class Signup extends React.Component {
                     signup={signup}
                     campaign={campaign}
                     submitReportback={this.submitReportback}
-                    updateQuantity={this.updateQuantity}
+                    updateQuantityOrWhyState={this.updateQuantityOrWhyState}
                     success={this.state.successfulSubmission}
                   />
                 : null}

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -223,8 +223,8 @@ class Signup extends React.Component {
     this.setState((previousState) => {
       const newState = {...previousState};
 
-      newState.signup.quantity = quantity === null ? previousState.quantity : quantity;
-      newState.signup.why_participated = why === null ? previousState.why_participated : why;
+      newState.signup.quantity = quantity === null ? newState.signup.quantity : quantity;
+      newState.signup.why_participated = why === null ? newState.signup.why_participated : why;
 
       return newState;
     });

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -207,7 +207,6 @@ class Signup extends React.Component {
       // Update the state
       this.setState((previousState) => {
         const newState = {...previousState};
-        console.log(newState);
         newState.signup.quantity = result.quantity;
 
         return newState;

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -74,7 +74,7 @@ class Signup extends React.Component {
     this.showUploader = this.showUploader.bind(this);
     this.hideUploader = this.hideUploader.bind(this);
     this.submitReportback = this.submitReportback.bind(this);
-    this.updateQuantityOrWhyState = this.updateQuantityOrWhyState.bind(this);
+    this.updateSignup = this.updateSignup.bind(this);
   }
 
   componentDidMount() {
@@ -218,12 +218,12 @@ class Signup extends React.Component {
   }
 
   // Set newstate with updated quantity and why_participated.
-  updateQuantityOrWhyState(quantity, why) {
+  updateSignup(signup) {
     this.setState((previousState) => {
       const newState = {...previousState};
 
-      newState.signup.quantity = quantity === null ? newState.signup.quantity : quantity;
-      newState.signup.why_participated = why === null ? newState.signup.why_participated : why;
+      newState.signup.quantity = signup.quantity;
+      newState.signup.why_participated = signup.why_participated;
 
       return newState;
     });
@@ -350,7 +350,7 @@ class Signup extends React.Component {
                     signup={signup}
                     campaign={campaign}
                     submitReportback={this.submitReportback}
-                    updateQuantityOrWhyState={this.updateQuantityOrWhyState}
+                    updateSignup={this.updateSignup}
                     success={this.state.successfulSubmission}
                   />
                 : null}

--- a/resources/assets/components/UploaderModal/index.js
+++ b/resources/assets/components/UploaderModal/index.js
@@ -25,6 +25,8 @@ class UploaderModal extends React.Component {
       reportback: {},
       submitReportback: this.props.submitReportback,
       uploads: {},
+      updateQuantity: this.props.updateQuantity,
+      signup: signup,
     }
 
     return (

--- a/resources/assets/components/UploaderModal/index.js
+++ b/resources/assets/components/UploaderModal/index.js
@@ -25,7 +25,7 @@ class UploaderModal extends React.Component {
       reportback: {},
       submitReportback: this.props.submitReportback,
       uploads: {},
-      updateQuantity: this.props.updateQuantity,
+      updateQuantityOrWhyState: this.props.updateQuantityOrWhyState,
       signup: signup,
     }
 

--- a/resources/assets/components/UploaderModal/index.js
+++ b/resources/assets/components/UploaderModal/index.js
@@ -25,7 +25,7 @@ class UploaderModal extends React.Component {
       reportback: {},
       submitReportback: this.props.submitReportback,
       uploads: {},
-      updateQuantityOrWhyState: this.props.updateQuantityOrWhyState,
+      updateSignup: this.props.updateSignup,
       signup: signup,
     }
 


### PR DESCRIPTION
#### What's this PR do?
- Adds `updateQuantityOrWhyState` function so when we update the quantity or why participated when uploading a post on behalf of the user, the state on the signup page also updates.
  - This function is needed because we only need to update the state, not make a new call since the submit button in the modal already makes that API call. 
- This fixes the bug that we have right now of when you upload a post with a quantity and/or why, the signup page doesn't reflect this information until the page is refreshed. 

#### How should this be reviewed?
- Go to a user's signup page `/signups/:signup_id`
- Upload a photo with a quantity and/or why participated
- You should see these reflected at the top of the signup page when you close the modal without refreshing the page
- No additional events should be created in the events table

#### Relevant tickets
Fixes this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/152292775).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.