### PR TITLE
DELETE /api/v3/posts/:post_id

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -71,7 +71,9 @@ class PostsController extends ApiController
      */
     public function update(PostRequest $request, Post $post)
     {
+        // @TODO: Remove `array_filter` with 'only' changes in Laravel 5.5.
         $fields = array_filter($request->only('status', 'caption'));
+
         $post->update($fields);
 
         return $this->item($post);

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -8,6 +8,7 @@ use Rogue\Services\PostService;
 use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
 use Rogue\Http\Controllers\Api\ApiController;
+use Rogue\Http\Requests\Three\PostRequest;
 use Rogue\Http\Controllers\Traits\PostRequests;
 
 class PostsController extends ApiController
@@ -68,7 +69,7 @@ class PostsController extends ApiController
      * @param \Rogue\Models\Post $post
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Post $post)
+    public function update(PostRequest $request, Post $post)
     {
         $fields = array_filter($request->only('status', 'caption'));
         $post->update($fields);

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -6,9 +6,9 @@ use Rogue\Models\Post;
 use Illuminate\Http\Request;
 use Rogue\Services\PostService;
 use Rogue\Repositories\SignupRepository;
+use Rogue\Http\Requests\Three\PostRequest;
 use Rogue\Http\Transformers\PostTransformer;
 use Rogue\Http\Controllers\Api\ApiController;
-use Rogue\Http\Requests\Three\PostRequest;
 use Rogue\Http\Controllers\Traits\PostRequests;
 
 class PostsController extends ApiController

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -46,6 +46,8 @@ class PostsController extends ApiController
         $this->signups = $signups;
 
         $this->transformer = $transformer;
+
+        $this->middleware('auth.api');
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -64,11 +64,11 @@ class PostsController extends ApiController
      * Updates a specific post.
      * PATCH /posts/:id
      *
-     * @param PostRequest $request
+     * @param Request $request
      * @param \Rogue\Models\Post $post
      * @return \Illuminate\Http\Response
      */
-    public function update(PostRequest $request, Post $post)
+    public function update(Request $request, Post $post)
     {
         $fields = array_filter($request->only('status', 'caption'));
         $post->update($fields);

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -59,4 +59,20 @@ class PostsController extends ApiController
     {
         return $this->item($post, 200, [], $this->transformer);
     }
+
+    /**
+     * Updates a specific post.
+     * PATCH /posts/:id
+     *
+     * @param PostRequest $request
+     * @param \Rogue\Models\Post $post
+     * @return \Illuminate\Http\Response
+     */
+    public function update(PostRequest $request, Post $post)
+    {
+        $fields = array_filter($request->only('status', 'caption'));
+        $post->update($fields);
+
+        return $this->item($post);
+    }
 }

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -78,4 +78,18 @@ class PostsController extends ApiController
 
         return $this->item($post);
     }
+
+    /**
+     * Delete a post.
+     * DELETE /posts/:id
+     *
+     * @param \Rogue\Models\Post $post
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Post $post)
+    {
+        $post->delete();
+
+        return $this->respond('Post deleted.', 200);
+    }
 }

--- a/app/Http/Requests/Three/PostRequest.php
+++ b/app/Http/Requests/Three/PostRequest.php
@@ -25,6 +25,7 @@ class PostRequest extends Request
     {
         return [
             'status' => 'in:pending,accepted,rejected',
+            'caption' => 'string|max:140',
         ];
     }
 }

--- a/app/Http/Requests/Three/PostRequest.php
+++ b/app/Http/Requests/Three/PostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rogue\Http\Requests\Three;
+
+use Rogue\Http\Requests\Request;
+
+class PostRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'status' => 'in:pending,accepted,rejected',
+        ];
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -103,4 +103,5 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['api']], function () {
     // posts
     Route::get('posts', 'Three\PostsController@index');
     Route::get('posts/{post}', 'Three\PostsController@show');
+    Route::patch('posts/{post', 'Three\PostsController@update');
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -101,7 +101,7 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['api']], function () {
     Route::patch('signups/{signup}', 'Three\SignupsController@update');
 
     // posts
-    Route::get('posts', 'Three\{PostsController}@index');
+    Route::get('posts', 'Three\PostsController@index');
     Route::get('posts/{post}', 'Three\PostsController@show');
     Route::patch('posts/{post}', 'Three\PostsController@update');
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -103,5 +103,5 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['api']], function () {
     // posts
     Route::get('posts', 'Three\PostsController@index');
     Route::get('posts/{post}', 'Three\PostsController@show');
-    Route::patch('posts/{post', 'Three\PostsController@update');
+    Route::patch('posts/{post}', 'Three\PostsController@update');
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -101,7 +101,7 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['api']], function () {
     Route::patch('signups/{signup}', 'Three\SignupsController@update');
 
     // posts
-    Route::get('posts', 'Three\PostsController@index');
+    Route::get('posts', 'Three\{PostsController}@index');
     Route::get('posts/{post}', 'Three\PostsController@show');
     Route::patch('posts/{post}', 'Three\PostsController@update');
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -103,5 +103,6 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['api']], function () {
     // posts
     Route::get('posts', 'Three\PostsController@index');
     Route::get('posts/{post}', 'Three\PostsController@show');
+    Route::delete('posts/{post}', 'Three\PostsController@destroy');
     Route::patch('posts/{post}', 'Three\PostsController@update');
 });

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -67,3 +67,5 @@ Endpoint                                       | Functionality
 ---------------------------------------------- | --------------------------------------------------------
 `GET /api/v3/posts`                            | [Get posts](endpoints/posts.md#retrieve-all-posts)
 `GET /api/v3/posts/:post_id`                   | [Get a post](endpoints/signups.md#retrieve-a-specific-post)
+`DELETE /api/v3/posts/:post_id`                | [Delete a post](endpoints/signups.md#delete-a-post)
+`PATCH /api/v3/posts/:post_id`                 | [Update a post](endpoints/signups.md#update-a-post)   

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -212,6 +212,19 @@ Example Response:
 }
 ```
 
+## Delete a Post
+
+```
+DELETE /api/v3/posts/:post_id
+```
+Example Response: 
+
+```
+{
+    "code": 200,
+    "message": "Post deleted."
+}
+
 ```
 
 ## Update a Post

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -211,3 +211,50 @@ Example Response:
   "message": "Post deleted."
 }
 ```
+
+```
+
+## Update a Post
+
+```
+PATCH /api/v3/posts/:post_id
+```
+
+  - **status**: (string) 
+    The status of a post. Must be either pending, accepted, or rejected.
+  - **caption**: (string) 
+    The caption of the post.
+  
+Example request body:
+```
+[
+  "status" => "accepted"
+  "why_participated" => "i love this cause"
+]
+```
+
+Example response:
+```
+{
+  "data": {
+      "id": 332,
+      "signup_id": 289,
+      "northstar_id": "5589c991a59dbfa93d8b45ae",
+      "media": {
+          "url": "http://localhost/storage/uploads/reportback-items/edited_332.jpeg?time=1509379493",
+          "original_image_url": "http://localhost/storage/uploads/reportback-items/289-923df5957838355206574f72d5520f0f-1509115822.jpeg?time=1509379493",
+          "caption": "i love this cause"
+      },
+      "tags": [],
+      "reactions": {
+          "reacted": false,
+          "total": null
+      },
+      "status": "accepted",
+      "source": "rogue-admin",
+      "remote_addr": "",
+      "created_at": "2017-10-27T14:50:22+00:00",
+      "updated_at": "2017-10-30T16:04:53+00:00"
+  }
+}
+```

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -268,6 +268,7 @@ Example request body:
 [
   "quantity" => "200"
   "why_participated" => "bcuz I luv endpointz"
+]
 ```
 
 Example response:

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -116,4 +116,21 @@ class PostTest extends BrowserKitTestCase
         $this->assertEquals($post->fresh()->caption, 'new caption');
     }
 
+    /**
+     * Test validation for updating a post.
+     *
+     * PATCH /api/v3/posts/195
+     * @return void
+     */
+    public function testValidationUpdatingAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->withRogueApiKey()->json('PATCH', 'api/v3/posts/' . $post->id, [
+            'status' => 'approved',
+        ]);
+
+        $this->assertResponseStatus(422);
+        $this->assertEquals('The selected status is invalid.', $this->response->getOriginalContent()['status'][0]);
+    }
 }

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -137,4 +137,38 @@ class PostTest extends BrowserKitTestCase
 
         $this->assertEquals('The caption may not be greater than 140 characters.', $this->response->getOriginalContent()['caption'][0]);
     }
+
+    /**
+     * Test that a post gets deleted when hitting the DELETE endpoint.
+     *
+     * @return void
+     */
+    public function testDeletingAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        // Mock time of when the post is soft deleted.
+        $this->mockTime('8/3/2017 14:00:00');
+
+        $response = $this->withRogueApiKey()->delete('api/v3/posts/' . $post->id);
+
+        $this->assertResponseStatus(200);
+
+        // Make sure that the post's deleted_at gets persisted in the database.
+        $this->assertEquals($post->fresh()->deleted_at->toTimeString(), '14:00:00');
+    }
+
+    /**
+     * Test that non-authenticated user's/apps can't delete posts.
+     *
+     * @return void
+     */
+    public function testUnauthenticatedUserDeletingAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->deleteJson('api/v3/posts/' . $post->id);
+
+        $response->assertResponseStatus(401);
+    }
 }

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -128,9 +128,13 @@ class PostTest extends BrowserKitTestCase
 
         $response = $this->withRogueApiKey()->json('PATCH', 'api/v3/posts/' . $post->id, [
             'status' => 'approved',
+            'caption' => 'This must be longer than 140 characters to break the validation rules so here I will create a caption that is longer than 140 characters to test.',
         ]);
 
         $this->assertResponseStatus(422);
+
         $this->assertEquals('The selected status is invalid.', $this->response->getOriginalContent()['status'][0]);
+
+        $this->assertEquals('The caption may not be greater than 140 characters.', $this->response->getOriginalContent()['caption'][0]);
     }
 }

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -93,4 +93,27 @@ class PostTest extends BrowserKitTestCase
 
         $this->assertEquals($post->id, $this->response->getOriginalContent()['data']['id']);
     }
+
+    /**
+     * Test for updating a post successfully.
+     *
+     * PATCH /api/v3/posts/186
+     * @return void
+     */
+    public function testUpdatingAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->withRogueApiKey()->json('PATCH', 'api/v3/posts/' . $post->id, [
+            'status' => 'accepted',
+            'caption' => 'new caption',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // Make sure that the posts's new status and caption gets persisted in the database.
+        $this->assertEquals($post->fresh()->status, 'accepted');
+        $this->assertEquals($post->fresh()->caption, 'new caption');
+    }
+
 }


### PR DESCRIPTION
#### What's this PR do?
- Creates the `DELETE /api/v3/posts/:post_id` endpoint
- Creates tests for this endpoint

#### How should this be reviewed?
- Hit the `DELETE /api/v3/posts/:post_id` endpoint. 
- Make sure the post was soft deleted.
- Hit that same endpoint without the `X-DS-Rogue-API-Key` and you shouldn't be able to delete the post. 
- Make sure all tests pass!

#### Any background context you want to provide?
@katiecrane @DFurnes I just realized that when you hit this endpoint (and also the `DELETE /api/v3/signups/:signup_id` endpoint), it doesn't create an event. Do we want it to create an event for these?

#### Relevant tickets
Fixes the last task in this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/151852968).

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.