### PR TITLE
Creates POST /api/v3/posts

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -51,6 +51,42 @@ class PostsController extends ApiController
     }
 
     /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(PostRequest $request)
+    {
+        $transactionId = incrementTransactionId($request);
+
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+
+        $updating = ! is_null($signup);
+
+        // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
+        if (! $updating) {
+            $signup = $this->signups->create($request->all());
+
+            $post = $this->posts->create($request->all(), $signup->id, $transactionId);
+
+            $code = 200;
+
+            return $this->item($post);
+        } else {
+            $post = $this->posts->update($signup, $request->all(), $transactionId);
+
+            $code = 201;
+
+            if (isset($request['file'])) {
+                return $this->item($post);
+            } else {
+                return $signup;
+            }
+        }
+    }
+
+    /**
      * Returns a specific post.
      * GET /posts/:id
      *

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -102,8 +102,9 @@ Route::group(['prefix' => 'api/v3', 'middleware' => ['api']], function () {
     Route::delete('signups/{signup}', 'Three\SignupsController@destroy');
 
     // posts
+    Route::post('posts', 'Three\PostsController@store');
     Route::get('posts', 'Three\PostsController@index');
     Route::get('posts/{post}', 'Three\PostsController@show');
-    Route::delete('posts/{post}', 'Three\PostsController@destroy');
     Route::patch('posts/{post}', 'Three\PostsController@update');
+    Route::delete('posts/{post}', 'Three\PostsController@destroy');
 });

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -66,6 +66,7 @@ Endpoint                                       | Functionality
 #### Posts
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
+`POST /api/v3/posts`                           | [Create a post](endpoints/posts.md#create-a-post-and/or-create/Update-a-signup)
 `GET /api/v3/posts`                            | [Get posts](endpoints/posts.md#retrieve-all-posts)
 `GET /api/v3/posts/:post_id`                   | [Get a post](endpoints/signups.md#retrieve-a-specific-post)
 `DELETE /api/v3/posts/:post_id`                | [Delete a post](endpoints/signups.md#delete-a-post)

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -133,7 +133,7 @@ Example Response:
 ## Create a Post and/or Create/Update a Signup
 
 ```
-POST /api/v2/posts 
+POST /api/v2/posts or POST /api/v3/posts
 ```
 
   - **northstar_id**: (string) required.

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -127,6 +127,42 @@ class PostTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that non-authenticated user's/apps can't create a post.
+     *
+     * @return void
+     */
+    public function testUnauthenticatedUserCreatingAPost()
+    {
+        $signup = factory(Signup::class)->create();
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $caption = $this->faker->sentence;
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->json('POST', 'api/v3/posts', [
+            'northstar_id'     => $signup->northstar_id,
+            'campaign_id'      => $signup->campaign_id,
+            'campaign_run_id'  => $signup->campaign_run_id,
+            'quantity'         => $quantity,
+            'why_participated' => $this->faker->paragraph,
+            'num_participants' => null,
+            'caption'          => $caption,
+            'source'           => 'phpunit',
+            'remote_addr'      => $this->faker->ipv4,
+            'file'             => UploadedFile::fake()->image('photo.jpg'),
+            'crop_x'           => 0,
+            'crop_y'           => 0,
+            'crop_width'       => 100,
+            'crop_height'      => 100,
+            'crop_rotate'      => 90,
+        ]);
+
+        $response->assertResponseStatus(401);
+    }
+
+    /**
      * Test for retrieving all posts.
      *
      * GET /api/v3/posts

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -3,10 +3,129 @@
 namespace Tests\Http\Three;
 
 use Rogue\Models\Post;
+use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
+use Illuminate\Http\UploadedFile;
+use DoSomething\Gateway\Blink;
+use Tests\TestCase;
 
 class PostTest extends BrowserKitTestCase
 {
+    /**
+     * Test that a POST request to /posts creates a new
+     * post and signup, if it doesn't already exist.
+     *
+     * @return void
+     */
+    public function testCreatingAPostAndSignup()
+    {
+        $northstar_id = $this->faker->uuid;
+        $campaign_id = $this->faker->randomNumber(4);
+        $campaign_run_id = $this->faker->randomNumber(4);
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $caption = $this->faker->sentence;
+
+        // Mock the Blink API calls.
+        $this->mock(Blink::class)
+            ->shouldReceive('userSignup')
+            ->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->withRogueApiKey()->json('POST', 'api/v3/posts', [
+            'northstar_id'     => $northstar_id,
+            'campaign_id'      => $campaign_id,
+            'campaign_run_id'  => $campaign_run_id,
+            'quantity'         => $quantity,
+            'why_participated' => $this->faker->paragraph,
+            'num_participants' => null,
+            'caption'          => $caption,
+            'source'           => 'phpunit',
+            'remote_addr'      => $this->faker->ipv4,
+            'file'             => UploadedFile::fake()->image('photo.jpg'),
+            'crop_x'           => 0,
+            'crop_y'           => 0,
+            'crop_width'       => 100,
+            'crop_height'      => 100,
+            'crop_rotate'      => 90,
+        ]);
+
+        $response->assertResponseStatus(200);
+        $response->seeJson([
+            'data' => [
+                'northstar_id' => $northstar_id,
+                'status' => 'pending',
+                'media' => [
+                    'caption' => $caption,
+                ],
+            ],
+        ]);
+
+        // Make sure the signup & post are persisted to the database.
+        $this->assertDatabaseHas('signups', [
+            'campaign_id' => $campaign_id,
+            'northstar_id' => $northstar_id,
+            'quantity' => $quantity,
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'northstar_id' => $northstar_id,
+            'campaign_id' => $campaign_id,
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * Test that a POST request to /posts creates a new post.
+     *
+     * @return void
+     */
+    public function testCreatingAPost()
+    {
+        $signup = factory(Signup::class)->create();
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $caption = $this->faker->sentence;
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->withRogueApiKey()->json('POST', 'api/v3/posts', [
+            'northstar_id'     => $signup->northstar_id,
+            'campaign_id'      => $signup->campaign_id,
+            'campaign_run_id'  => $signup->campaign_run_id,
+            'quantity'         => $quantity,
+            'why_participated' => $this->faker->paragraph,
+            'num_participants' => null,
+            'caption'          => $caption,
+            'source'           => 'phpunit',
+            'remote_addr'      => $this->faker->ipv4,
+            'file'             => UploadedFile::fake()->image('photo.jpg'),
+            'crop_x'           => 0,
+            'crop_y'           => 0,
+            'crop_width'       => 100,
+            'crop_height'      => 100,
+            'crop_rotate'      => 90,
+        ]);
+
+        $response->assertResponseStatus(200);
+        $response->seeJson([
+            'data' => [
+                'northstar_id' => $signup->northstar_id,
+                'status' => 'pending',
+                'media' => [
+                    'caption' => $caption,
+                ],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'signup_id' => $signup->id,
+            'northstar_id' => $signup->northstar_id,
+            'campaign_id' => $signup->campaign_id,
+            'status' => 'pending',
+        ]);
+    }
+
     /**
      * Test for retrieving all posts.
      *

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -258,6 +258,23 @@ class PostTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that non-authenticated user's/apps can't update posts.
+     *
+     * @return void
+     */
+    public function testUnauthenticatedUserUpdatingAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->json('PATCH', 'api/v3/posts/' . $post->id, [
+            'status' => 'accepted',
+            'caption' => 'new caption',
+        ]);
+
+        $response->assertResponseStatus(401);
+    }
+
+    /**
      * Test that a post gets deleted when hitting the DELETE endpoint.
      *
      * @return void

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -7,7 +7,6 @@ use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
 use Illuminate\Http\UploadedFile;
 use DoSomething\Gateway\Blink;
-use Tests\TestCase;
 
 class PostTest extends BrowserKitTestCase
 {
@@ -50,24 +49,37 @@ class PostTest extends BrowserKitTestCase
         ]);
 
         $response->assertResponseStatus(200);
-        $response->seeJson([
+        $response->seeJsonStructure([
             'data' => [
-                'northstar_id' => $northstar_id,
-                'status' => 'pending',
+                'id',
+                'signup_id',
+                'northstar_id',
                 'media' => [
-                    'caption' => $caption,
+                    'url',
+                    'original_image_url',
+                    'caption',
                 ],
+                'tags' => [],
+                'reactions' => [
+                    'reacted',
+                    'total',
+                ],
+                'status',
+                'source',
+                'remote_addr',
+                'created_at',
+                'updated_at',
             ],
         ]);
 
         // Make sure the signup & post are persisted to the database.
-        $this->assertDatabaseHas('signups', [
+        $this->seeInDatabase('signups', [
             'campaign_id' => $campaign_id,
             'northstar_id' => $northstar_id,
             'quantity' => $quantity,
         ]);
 
-        $this->assertDatabaseHas('posts', [
+        $this->seeInDatabase('posts', [
             'northstar_id' => $northstar_id,
             'campaign_id' => $campaign_id,
             'status' => 'pending',
@@ -108,17 +120,31 @@ class PostTest extends BrowserKitTestCase
         ]);
 
         $response->assertResponseStatus(200);
-        $response->seeJson([
+
+        $response->seeJsonStructure([
             'data' => [
-                'northstar_id' => $signup->northstar_id,
-                'status' => 'pending',
+                'id',
+                'signup_id',
+                'northstar_id',
                 'media' => [
-                    'caption' => $caption,
+                    'url',
+                    'original_image_url',
+                    'caption',
                 ],
+                'tags' => [],
+                'reactions' => [
+                    'reacted',
+                    'total',
+                ],
+                'status',
+                'source',
+                'remote_addr',
+                'created_at',
+                'updated_at',
             ],
         ]);
 
-        $this->assertDatabaseHas('posts', [
+        $this->seeInDatabase('posts', [
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -5,8 +5,8 @@ namespace Tests\Http\Three;
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
-use Illuminate\Http\UploadedFile;
 use DoSomething\Gateway\Blink;
+use Illuminate\Http\UploadedFile;
 
 class PostTest extends BrowserKitTestCase
 {

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -5,6 +5,7 @@ namespace Tests\Http\Three;
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
+use DoSomething\Gateway\Blink;
 
 class SignupTest extends BrowserKitTestCase
 {

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -5,7 +5,6 @@ namespace Tests\Http\Three;
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
 use Tests\BrowserKitTestCase;
-use DoSomething\Gateway\Blink;
 
 class SignupTest extends BrowserKitTestCase
 {


### PR DESCRIPTION
#### What's this PR do?
- Creates the `POST /api/v3/posts` endpoint
- Creates tests for this endpoint
- Adds tests to make sure an unauthenticated user/app can't update posts

#### How should this be reviewed?
- Hit the `POST /api/v3/posts` endpoint and make sure a signup and post are created if a signup didn't exist yet or a post is created if the signup already exists
- Make sure all tests pass! 

#### Relevant tickets
Fixes this [Pivotal Ticket](https://www.pivotaltracker.com/n/projects/2019429/stories/152482999)

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.