### PR TITLE
Artisan command to load in pre-Gambit (or any!) signups from CSV

### DIFF
--- a/app/Console/Commands/ImportPreGambitSignupsCommand.php
+++ b/app/Console/Commands/ImportPreGambitSignupsCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Illuminate\Console\Command;
+use League\Csv\Reader;
+use Rogue\Services\Registrar;
+
+class ImportPreGambitSignupsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:pregambit';
+
+    protected $registrar;
+
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(Registrar $registrar)
+    {
+        parent::__construct();
+
+        $this->registrar = $registrar;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Create array of campaign_ids keyed by campaign_run_id
+        $campaigns_csv = Reader::createFromPath('campaign_ids_with_run_ids.csv', 'r');
+        $campaigns_csv->setHeaderOffset(0);
+        $campaign_ids = $campaigns_csv->getRecords();
+
+        $run_then_campaign = [];
+
+        foreach ($campaign_ids as $record) {
+            $run_then_campaign[$record['campaign_run_id']] = $record['campaign_id'];
+        }
+
+        // Load the missing signups
+        $signups_csv = Reader::createFromPath('all_pre_gambit_sms_signups.csv', 'r');
+        $signups_csv->setHeaderOffset(0);
+        $missing_signups = $signups_csv->getRecords();
+
+        // Create each missing signup
+        foreach ($missing_signups as $missing_signup) {
+            // dd($missing_signup);
+            // We are given uid, grab Northstar ID from Northstar
+            dd($this->registrar->find($missing_signup['uid']));
+
+            $signup = new Signup([
+                // 'northstar_id' => ,
+                // 'campaign_id' => ,
+                'campaign_run_id' => $missing_signup['campaign_run_id'],
+                'created_at' => $missing_signup['signup_created_at'],
+                // 'updated_at' => NOW
+            ]);
+            //->with(['timstamps' => false]);
+        }
+    }
+}

--- a/app/Console/Commands/ImportPreGambitSignupsCommand.php
+++ b/app/Console/Commands/ImportPreGambitSignupsCommand.php
@@ -5,7 +5,6 @@ namespace Rogue\Console\Commands;
 use Carbon\Carbon;
 use League\Csv\Reader;
 use Rogue\Models\Signup;
-
 use Rogue\Services\Registrar;
 use Illuminate\Console\Command;
 
@@ -19,7 +18,6 @@ class ImportPreGambitSignupsCommand extends Command
     protected $signature = 'rogue:pregambit';
 
     protected $registrar;
-
 
     /**
      * Create a new command instance.

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -17,6 +17,13 @@ class ImportSignupsCommand extends Command
     protected $signature = 'rogue:signupimport {path}';
 
     /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create signups based on the data in the given CSV file.';
+
+    /**
      * Create a new command instance.
      *
      * @return void

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Console\Commands;
 
-use Carbon\Carbon;
 use League\Csv\Reader;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -8,14 +8,14 @@ use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Illuminate\Console\Command;
 
-class ImportPreGambitSignupsCommand extends Command
+class ImportSignupsCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'rogue:pregambit';
+    protected $signature = 'rogue:signupimport {path}';
 
     protected $registrar;
 
@@ -39,7 +39,7 @@ class ImportPreGambitSignupsCommand extends Command
     public function handle()
     {
         // Load the missing signups
-        $signups_csv = Reader::createFromPath('all_pre_gambit_sms_signups.csv', 'r');
+        $signups_csv = Reader::createFromPath($this->argument('path'), 'r');
         $signups_csv->setHeaderOffset(0);
         $missing_signups = $signups_csv->getRecords();
 

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -17,8 +17,6 @@ class ImportSignupsCommand extends Command
      */
     protected $signature = 'rogue:signupimport {path}';
 
-    protected $registrar;
-
     /**
      * Create a new command instance.
      *
@@ -27,8 +25,6 @@ class ImportSignupsCommand extends Command
     public function __construct(Registrar $registrar)
     {
         parent::__construct();
-
-        $this->registrar = $registrar;
     }
 
     /**
@@ -61,7 +57,7 @@ class ImportSignupsCommand extends Command
                 $signup->source = 'sms';
                 $signup->created_at = $missing_signup['signup_created_at_timestamp'];
                 $signup->updated_at = Carbon::now();
-                $signup->save(['timstamps' => false]);
+                $signup->save(['timestamps' => false]);
 
                 $this->line('Created signup ' . $signup->id);
             } else {

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -50,14 +50,13 @@ class ImportSignupsCommand extends Command
 
             // Create a signup if there isn't on already
             if (! $existing_signup) {
-                $signup = new Signup;
-                $signup->northstar_id = $missing_signup['northstar_id'];
-                $signup->campaign_id = $missing_signup['campaign_node_id'];
-                $signup->campaign_run_id = $missing_signup['campaign_run_id'];
-                $signup->source = 'sms';
-                $signup->created_at = $missing_signup['signup_created_at_timestamp'];
-                $signup->updated_at = Carbon::now();
-                $signup->save(['timestamps' => false]);
+                $signup = Signup::create([
+                    'northstar_id' => $missing_signup['northstar_id'],
+                    'campaign_id' => $missing_signup['campaign_node_id'],
+                    'campaign_run_id' => $missing_signup['campaign_run_id'],
+                    'source' => 'sms',
+                    'created_at' => $missing_signup['signup_created_at_timestamp'],
+                ]);
 
                 $this->line('Created signup ' . $signup->id);
             } else {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\ClearDB::class,
         Commands\EditImagesCommand::class,
         Commands\SetupCommand::class,
+        Commands\ImportPreGambitSignupsCommand::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\ClearDB::class,
         Commands\EditImagesCommand::class,
         Commands\SetupCommand::class,
-        Commands\ImportPreGambitSignupsCommand::class,
+        Commands\ImportSignupsCommand::class,
     ];
 
     /**

--- a/tests/Console/ImportSignupsCommandTest.php
+++ b/tests/Console/ImportSignupsCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Console;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use Rogue\Models\Signup;
+
+class ImportSignupsCommandTest extends TestCase
+{
+    public function testImportingSignupsWithNoDuplicates()
+    {
+        // Timestamp right before running the script
+        $start_time = Carbon::now();
+
+        // Run the signup import command
+        $this->artisan('rogue:signupimport', ['path' => 'tests/Console/example-signups.csv']);
+
+        // And see that we stored the two unique signups
+        $this->assertDatabaseHas('signups', [
+            'northstar_id' => '56e83a07469c64d8578b5ed4',
+            'campaign_id' => '362',
+            'campaign_run_id' => '2341',
+            'source' => 'sms',
+            'created_at' => '2014-03-13 21:39:01',
+        ]);
+
+        $this->assertDatabaseHas('signups', [
+            'northstar_id' => '5589c9bb469c6475138b81f0',
+            'campaign_id' => '1144',
+            'campaign_run_id' => '5066',
+            'source' => 'sms',
+            'created_at' => '2013-11-06 23:32:03',
+        ]);
+
+        // Make sure there are no duplicates
+        $all_signups = Signup::all();
+        $this->assertTrue($all_signups->count() == 2);
+
+        // Make sure the 'updated_at' timestamps are not backdated
+        foreach ($all_signups as $signup) {
+            $this->assertTrue($signup->updated_at->gte($start_time));
+        }
+    }
+}

--- a/tests/Console/example-signups.csv
+++ b/tests/Console/example-signups.csv
@@ -1,0 +1,4 @@
+"drupal_id","campaign_run_id","campaign_node_id","signup_source","signup_created_at_timestamp","northstar_id"
+10,2341,362,"sms","2014-03-13 21:39:01","56e83a07469c64d8578b5ed4"
+10,2341,362,"sms","2014-03-13 21:39:01","56e83a07469c64d8578b5ed4"
+3526,5066,1144,"sms","2013-11-06 23:32:03","5589c9bb469c6475138b81f0"


### PR DESCRIPTION
#### What's this PR do?
Includes a script to import signups from a csv! The csv will include ALL pre-Gambit signups. The script checks if a signup already exists for the given user, campaign, and campaign run before creating a new one so there are no duplicates.

#### How should this be reviewed?
Will this run right?

#### Any background context you want to provide?
This is gonna make Rogue the source of truth!!

#### Relevant tickets
[Pivotal](https://www.pivotaltracker.com/story/show/151064896)

#### Checklist
- [ ] Tested on staging.
