### PR TITLE
Remove taggable & password reset tables.

### DIFF
--- a/database/migrations/2017_11_09_193724_drop_tagging_tags_table.php
+++ b/database/migrations/2017_11_09_193724_drop_tagging_tags_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropTaggingTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tagging_tags', function ($table) {
+            $table->dropForeign('tagging_tags_tag_group_id_foreign');
+            $table->dropColumn('tag_group_id');
+        });
+
+        Schema::drop('tagging_tags');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('tagging_tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('slug', 255)->index();
+            $table->string('name', 255);
+            $table->boolean('suggest')->default(false);
+            $table->integer('count')->unsigned()->default(0); // count of how many times this tag was used
+
+            $table->integer('tag_group_id')->unsigned()->nullable()->after('id');
+            $table->foreign('tag_group_id')->references('id')->on('tagging_tag_groups');
+        });
+    }
+}

--- a/database/migrations/2017_11_09_193847_drop_tagging_tagged_table.php
+++ b/database/migrations/2017_11_09_193847_drop_tagging_tagged_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropTaggingTaggedTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::drop('tagging_tagged');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('tagging_tagged', function (Blueprint $table) {
+            $table->increments('id');
+
+            if (config('tagging.primary_keys_type') == 'string') {
+                $table->string('taggable_id', 36)->index();
+            } else {
+                $table->integer('taggable_id')->unsigned()->index();
+            }
+
+            $table->string('taggable_type', 255)->index();
+            $table->string('tag_name', 255);
+            $table->string('tag_slug', 255)->index();
+        });
+    }
+}

--- a/database/migrations/2017_11_09_193937_drop_tagging_tag_groups_table.php
+++ b/database/migrations/2017_11_09_193937_drop_tagging_tag_groups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropTaggingTagGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::drop('tagging_tag_groups');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('tagging_tag_groups', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('slug', 255)->index();
+            $table->string('name', 255);
+        });
+    }
+}

--- a/database/migrations/2017_11_09_194027_drop_password_resets_table.php
+++ b/database/migrations/2017_11_09_194027_drop_password_resets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropPasswordResetsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::drop('password_resets');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('password_resets', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token')->index();
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
I've been sussing out some strange issues with migrations and Laravel's new `migrate:fresh` command, and happened to notice we have a few tables that we don't need!

This pull request removes `tagging_tag_groups`, `tagging_tagged`, `tagging_tags` from the old tagging package we used, and `password_resets` from Laravel's default migrations.

#### How should this be reviewed?
🥞

#### Any background context you want to provide?
🍴

#### Relevant tickets
[#152601905](https://www.pivotaltracker.com/story/show/152601905)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.