### PR TITLE
Mobile Link to Signup Page

### DIFF
--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -20,9 +20,9 @@ const UserInformation = props => (
               if (props.user.mobile) {
                 if (props.linkSignup && isEmpty(props.user.first_name)) {
                   return (<span><a href={`/signups/${props.linkSignup}`}>{props.user.mobile}</a><br /></span>);
-                } else {
-                  return (<span>{props.user.mobile}<br /></span>);
                 }
+
+                return (<span>{props.user.mobile}<br /></span>);
               }
               return (null);
             })()

--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -19,11 +19,13 @@ const UserInformation = props => (
             (() => {
               if (props.user.mobile) {
                 if (props.linkSignup && isEmpty(props.user.first_name)) {
+
                   return (<span><a href={`/signups/${props.linkSignup}`}>{props.user.mobile}</a><br /></span>);
                 }
 
                 return (<span>{props.user.mobile}<br /></span>);
               }
+
               return (null);
             })()
           }

--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -14,7 +14,16 @@ const UserInformation = props => (
         }
         <p>
           {props.user.email ? <span>{props.user.email}<br /></span> : null}
-          {props.user.mobile ? <span>{props.user.mobile}<br /></span> : null }
+
+          {props.user.mobile ?
+              {props.linkSignup && isEmpty(props.user.first_name) ?
+                <span><a href={`/signups/${props.linkSignup}`}>{props.user.mobile}</a><br /></span>;
+                :
+                <span>{props.user.mobile}<br /></span>;
+              }
+            : null
+          }
+
           {displayCityState(props.user.addr_city, props.user.addr_state) ?
             <span>{displayCityState(props.user.addr_city, props.user.addr_state) }<br /></span>
             :

--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -15,17 +15,18 @@ const UserInformation = props => (
         <p>
           {props.user.email ? <span>{props.user.email}<br /></span> : null}
 
-          {(() => {
-            if (props.user.mobile) {
-              if (props.linkSignup) {
-                <span><a href={`/signups/${props.linkSignup}`}>{props.user.mobile}</a><br /></span>;
-              } else {
-                <span>{props.user.mobile}<br /></span>;
+          {
+            (() => {
+              if (props.user.mobile) {
+                if (props.linkSignup && isEmpty(props.user.first_name)) {
+                  return (<span><a href={`/signups/${props.linkSignup}`}>{props.user.mobile}</a><br /></span>);
+                } else {
+                  return (<span>{props.user.mobile}<br /></span>);
+                }
               }
-            } else {
-              null
-            }
-          })()}
+              return (null);
+            })()
+          }
 
           {displayCityState(props.user.addr_city, props.user.addr_state) ?
             <span>{displayCityState(props.user.addr_city, props.user.addr_state) }<br /></span>

--- a/resources/assets/components/Users/UserInformation.js
+++ b/resources/assets/components/Users/UserInformation.js
@@ -15,14 +15,17 @@ const UserInformation = props => (
         <p>
           {props.user.email ? <span>{props.user.email}<br /></span> : null}
 
-          {props.user.mobile ?
-              {props.linkSignup && isEmpty(props.user.first_name) ?
+          {(() => {
+            if (props.user.mobile) {
+              if (props.linkSignup) {
                 <span><a href={`/signups/${props.linkSignup}`}>{props.user.mobile}</a><br /></span>;
-                :
+              } else {
                 <span>{props.user.mobile}<br /></span>;
               }
-            : null
-          }
+            } else {
+              null
+            }
+          })()}
 
           {displayCityState(props.user.addr_city, props.user.addr_state) ?
             <span>{displayCityState(props.user.addr_city, props.user.addr_state) }<br /></span>


### PR DESCRIPTION
#### What's this PR do?
If a user doesn't have a first name, their mobile number will link to their signup page.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
The mobile number will only link to their signup page if there is no user name. If there is a user name, the mobile number will not be a link. Do we want the first name AND the mobile number to always link to the signup page, even if the user has both for more consistency? 

#### Relevant tickets
Fixes this [Pivotal Ticket](https://www.pivotaltracker.com/n/projects/2019429/stories/151462735).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.