### PR TITLE
Updates to Trusted Proxy settings.

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -21,9 +21,9 @@ class TrustProxies extends Middleware
      * @var array
      */
     protected $headers = [
-        Request::HEADER_FORWARDED => 'FORWARDED',
+        Request::HEADER_FORWARDED => null, // Not set on AWS or Heroku.
         Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
-        Request::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
+        Request::HEADER_X_FORWARDED_HOST => null, // Not set on AWS or Heroku.
         Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
         Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
     ];

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,5 +1,11 @@
 <?php
 
+// Pre-process any comma-separated values into an array.
+$trustedProxies = env('TRUSTED_PROXY_IP_ADDRESSES');
+if (str_contains($trustedProxies, ',')) {
+    $trustedProxies = explode(',', $trustedProxies);
+}
+
 return [
     /*
      * Set trusted proxy IP addresses.
@@ -17,5 +23,5 @@ return [
      * It will mean that $request->getClientIp() always gets the originating client IP,
      * no matter how many proxies that client's request has subsequently passed through.
      */
-    'proxies' => explode(',', env('TRUSTED_PROXY_IP_ADDRESSES')),
+    'proxies' => $trustedProxies,
 ];


### PR DESCRIPTION
#### What's this PR do?
Whoops – two updates to our trusted proxy settings:

🗃 Only parse the `TRUSTED_PROXY_IP_ADDRESSES` environment variable into an array if it has commas, otherwise use as a string. This is required for the `*` option [that Heroku requires](https://devcenter.heroku.com/articles/getting-started-with-laravel#trusting-the-load-balancer).

🔥 Discards the `Forwarded` and `X-Forwarded-Host` headers, as instructed in [Heroku's documentation](https://devcenter.heroku.com/articles/getting-started-with-laravel#trusting-the-load-balancer) because they are not sent by (or sanitized) by Heroku or AWS.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I tested #492 after deploying it and it didn't work, turns out this is why!

#### Relevant tickets
DoSomething/devops#341

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.