### PR TITLE
Rogue JS API Client

### DIFF
--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { keyBy, map } from 'lodash';
-import { RestApiClient } from '@dosomething/gateway';
+import RogueClient from '../../utilities/RogueClient';
 import { extractPostsFromSignups, extractSignupsFromPosts } from '../../helpers';
 
 const reviewComponent = (Component, data) => {
@@ -14,7 +14,7 @@ const reviewComponent = (Component, data) => {
         loading: true,
       };
 
-      this.api = new RestApiClient;
+      this.api = new RogueClient();
       this.updatePost = this.updatePost.bind(this);
       this.updateTag = this.updateTag.bind(this);
       this.updateQuantity = this.updateQuantity.bind(this);

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -38,14 +38,13 @@ const reviewComponent = (Component, data) => {
 
     // Make API call to GET /posts to get posts by filtered status.
     getPostsByStatus(status, campaignId) {
-      this.api.get('posts', {
+      this.api.getPosts({
         filter: {
           status: status,
           campaign_id: campaignId,
         },
         include: ['signup','siblings'],
-      })
-      .then(json => this.setState({
+      }).then(json => this.setState({
         campaign: data.campaign,
         posts: keyBy(json.data, 'id'),
         postIds: map(json.data, 'id'),

--- a/resources/assets/utilities/RogueClient.js
+++ b/resources/assets/utilities/RogueClient.js
@@ -1,5 +1,9 @@
 import { RestApiClient } from '@dosomething/gateway';
 
-class RogueClient extends RestApiClient {}
+class RogueClient extends RestApiClient {
+  getPosts(options) {
+    return this.get('posts', options);
+  }
+}
 
 export default RogueClient;

--- a/resources/assets/utilities/RogueClient.js
+++ b/resources/assets/utilities/RogueClient.js
@@ -1,0 +1,5 @@
+import { RestApiClient } from '@dosomething/gateway';
+
+class RogueClient extends RestApiClient {}
+
+export default RogueClient;


### PR DESCRIPTION
#### What's this PR do?

Adds a new class `RogueClient` that extends the Gateway-JS `RestApiClient`. 

Right now the class doesn't do much but I did add a method that is a bit of a higher-level method for getting posts. So when you need to get posts via the api, you can call `getPosts(options)` where the `options` param is the filter configuration and query params you would like to use. 

Only using this in the `WithReviewing` component for now to keep changes contained. See background context for why. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

It is proven to be pretty hard to mock dependency classes in Jest.

When testing the `WithReviewing` component we need to mock calls to the api via the `RestApiClient`. 

Jest does not run test code through webpack so we can't easily mock the `RestApiClient`. By adding a new class, `RogueClient`, we can just extend the `RestApiClient` and then when we are testing and need mocks, we just mock the `RogueClient` instead, which Jest can find just fine. 

Additionally, we can add wrapper methods to this class so we can have an easier time working with the API (no need to hard code endpoint path, easier param pass, etc) 

#### Relevant tickets
Addresses https://www.pivotaltracker.com/story/show/151647077

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.