### PR TITLE
Use updated Wercker box.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,16 +1,12 @@
-box: dosomething/ds-docker-php
+box: dosomething/ds-docker-php:build-updates
 
 build:
     steps:
       - script:
-          name: install chromedriver
-          code: |-
-            sudo apt-get update
-            sudo apt-get -y install libxpm4 libxrender1 libgtk2.0-0 libnss3 libgconf-2-4
-            sudo apt-get -y install chromium-browser
-      - script:
           name: start mysql
-          code: sudo service mysql start
+          code: |-
+            chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
+            sudo service mysql start
       - script:
           name: configure environment
           code: |-

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: dosomething/ds-docker-php:build-updates
+box: dosomething/ds-docker-php
 
 build:
     steps:


### PR DESCRIPTION
#### What's this PR do?
This pull request uses our [updated Docker box](https://github.com/DoSomething/ds-docker-php/pull/2), which includes ChromeDriver, Node 8, and npm 5.3. This gets us deterministic npm installs using the `package.lock` file & faster builds (2 minutes 22 seconds, down from 4 minutes on the old box).

#### How should this be reviewed?
🚥 👀 

#### Any background context you want to provide?
~We can remove the `:box-updates` tag if we decide to merge this in to `latest`.~ We did!

#### Relevant tickets
References #490.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.