### PR TITLE
Fix inconsistencies between up & down migrations.

### DIFF
--- a/database/migrations/2016_07_27_172344_create_kudos_table.php
+++ b/database/migrations/2016_07_27_172344_create_kudos_table.php
@@ -20,7 +20,7 @@ class CreateKudosTable extends Migration
             $table->integer('taxonomy_id')->index()->comment('The taxonomy_term.tid that this kudos belongs to.');
             $table->timestamps();
 
-            $table->unique(['file_id', 'drupal_id', 'northstar_id', 'taxonomy_id']);
+            $table->unique(['file_id', 'drupal_id', 'northstar_id', 'taxonomy_id'], 'file_drupal_ns_taxonomy_unique');
         });
     }
 

--- a/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
+++ b/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
@@ -14,6 +14,8 @@ class DropFileIdFromReactions extends Migration
     {
         Schema::table('reactions', function (Blueprint $table) {
             $table->dropColumn('file_id');
+
+            $table->dropUnique('file_drupal_ns_taxonomy_unique');
         });
     }
 
@@ -25,6 +27,8 @@ class DropFileIdFromReactions extends Migration
     public function down()
     {
         Schema::table('reactions', function (Blueprint $table) {
+            $table->unique(['file_id', 'drupal_id', 'northstar_id', 'taxonomy_id'], 'file_drupal_ns_taxonomy_unique');
+
             $table->integer('file_id')->index()->comment('The reportback_file.fid that this kudos applies to.');
         });
     }

--- a/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
+++ b/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
@@ -27,9 +27,9 @@ class DropFileIdFromReactions extends Migration
     public function down()
     {
         Schema::table('reactions', function (Blueprint $table) {
-            $table->unique(['file_id', 'drupal_id', 'northstar_id', 'taxonomy_id'], 'file_drupal_ns_taxonomy_unique');
-
             $table->integer('file_id')->index()->comment('The reportback_file.fid that this kudos applies to.');
+
+            $table->unique(['file_id', 'drupal_id', 'northstar_id', 'taxonomy_id'], 'file_drupal_ns_taxonomy_unique');
         });
     }
 }

--- a/database/migrations/2017_04_06_174417_drop_reportbacks_items.php
+++ b/database/migrations/2017_04_06_174417_drop_reportbacks_items.php
@@ -40,27 +40,29 @@ class DropReportbacksItems extends Migration
             $table->integer('promoted')->nullable()->comment('Whether the Reportback has been promoted.');
             $table->string('promoted_reason')->nullable()->comment('Reason why reportback was promoted.');
             $table->timestamps();
+            $table->unique(['northstar_id', 'campaign_id', 'campaign_run_id'], 'northstar_id_campaign_run');
+            $table->unique(['drupal_id', 'campaign_id', 'campaign_run_id'], 'drupal_id_campaign_run');
         });
 
         Schema::create('reportback_items', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('reportback_id')->unsigned();
-            $table->foreign('reportback_id')->references('id')->on('reportbacks')->onDelete('cascade');
-            $table->integer('file_id')->index()->unsigned();
+            $table->integer('reportback_id')->unsigned()->index('reportback_items_reportback_id_foreign');
+            $table->string('file_url');
+            $table->string('edited_file_url')->nullable();
             $table->string('caption')->nullable();
             $table->string('status')->index()->nullable()->default('pending');
             $table->integer('reviewed')->unsigned()->nullable();
-            $table->integer('reviewer')->unsigned()->nullable();
-            $table->string('review_source')->nullable()->comment('Source URL which review was submitted from.');
+            $table->string('reviewer')->nullable();
             $table->string('source')->nullable()->comment('Source which reportback file was submitted from.');
             $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
             $table->timestamps();
+
+            $table->foreign('reportback_id')->references('id')->on('reportbacks')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
 
         Schema::create('reportback_logs', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('reportback_id')->unsigned();
-            $table->foreign('reportback_id')->references('id')->on('reportbacks')->onDelete('cascade');
+            $table->integer('reportback_id')->unsigned()->index('reportback_logs_reportback_id_foreign');
             $table->string('northstar_id')->comment('The rogue users.id that updated.');
             $table->integer('drupal_id')->comment('The phoenix users.uid that updated.');
             $table->string('op')->nullable()->comment('Operation performed on the reportback.');
@@ -71,6 +73,8 @@ class DropReportbacksItems extends Migration
             $table->ipAddress('remote_addr')->nullable()->comment('The IP address of the user that submitted the file.');
             $table->text('reason')->nullable()->comment('The reason the reoportback item was flagged/promoted');
             $table->timestamps();
+
+            $table->foreign('reportback_id')->references('id')->on('reportbacks')->onUpdate('RESTRICT')->onDelete('CASCADE');
         });
     }
 }

--- a/database/migrations/2017_04_27_183942_drop_unique_northstar_id_index_reactions_table.php
+++ b/database/migrations/2017_04_27_183942_drop_unique_northstar_id_index_reactions_table.php
@@ -13,7 +13,7 @@ class DropUniqueNorthstarIdIndexReactionsTable extends Migration
     public function up()
     {
         Schema::table('reactions', function (Blueprint $table) {
-            $table->dropUnique('kudos_file_id_drupal_id_northstar_id_taxonomy_id_unique');
+            //
         });
     }
 
@@ -25,7 +25,7 @@ class DropUniqueNorthstarIdIndexReactionsTable extends Migration
     public function down()
     {
         Schema::table('reactions', function (Blueprint $table) {
-            $table->unique('kudos_file_id_drupal_id_northstar_id_taxonomy_id_unique');
+            //
         });
     }
 }

--- a/database/migrations/2017_06_29_194312_add_user_column_to_events_table.php
+++ b/database/migrations/2017_06_29_194312_add_user_column_to_events_table.php
@@ -25,7 +25,7 @@ class AddUserColumnToEventsTable extends Migration
     public function down()
     {
         Schema::table('events', function (Blueprint $table) {
-            $table->dropColumn('northstar_id');
+            $table->dropColumn('user');
         });
     }
 }

--- a/database/migrations/2017_11_09_193724_drop_tagging_tags_table.php
+++ b/database/migrations/2017_11_09_193724_drop_tagging_tags_table.php
@@ -35,7 +35,7 @@ class DropTaggingTagsTable extends Migration
             $table->boolean('suggest')->default(false);
             $table->integer('count')->unsigned()->default(0); // count of how many times this tag was used
 
-            $table->integer('tag_group_id')->unsigned()->nullable()->after('id');
+            $table->integer('tag_group_id')->unsigned()->nullable();
             $table->foreign('tag_group_id')->references('id')->on('tagging_tag_groups');
         });
     }


### PR DESCRIPTION
#### What's this PR do?
I forgot I'd done this! This was from sorting through a bunch of fatal errors that'd occur when running `php artisan migrate:refresh` (back when I thought that was causing issues with the Laravel 5.4+ test runner). It turns out that wasn't the issue, but it's also nice to be able to rollback migrations again. 😅 

#### How should this be reviewed?
If you pull down this branch, you should be able to safely run `php artisan migrate` and then `php artisan rollback` without getting errors!

#### Any background context you want to provide?
🥞 🤷‍♂️ 

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.