### PR TITLE
Do not update signup source with post source

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -125,7 +125,7 @@ class PostRepository
                 'quantity' => $data['quantity'],
                 'why_participated' => $data['why_participated'],
                 'updated_at' => $data['updated_at'],
-                'created_at' => array_key_exists('created_at', $data) ? $data['created_at'] : NULL,
+                'created_at' => array_key_exists('created_at', $data) ? $data['created_at'] : null,
             ];
 
             // Only update if the key is set (is not null).

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -92,7 +92,7 @@ class PostRepository
         if (isset($data['created_at'])) {
             $post->created_at = $data['created_at'];
             $post->updated_at = isset($data['updated_at']) ? $data['updated_at'] : $data['created_at'];
-            $post->save(['timestamps' => false]);
+            $post->save(['timestamps' => false, 'touch' => false]);
 
             $post->events->first()->created_at = $data['created_at'];
             $post->events->first()->updated_at = $data['created_at'];
@@ -120,12 +120,19 @@ class PostRepository
     public function update($signup, $data)
     {
         if (array_key_exists('updated_at', $data)) {
+            // Should only update quantity, why_participated, and timestamps on the signup
+            $signupFields = [
+                'quantity' => $data['quantity'],
+                'why_participated' => $data['why_participated'],
+                'updated_at' => $data['updated_at'],
+                'created_at' => array_key_exists('created_at', $data) ? $data['created_at'] : NULL,
+            ];
+
             // Only update if the key is set (is not null).
-            $nonNullArrayKeys = array_filter($data);
+            $nonNullArrayKeys = array_filter($signupFields);
             $arrayKeysToUpdate = array_keys($nonNullArrayKeys);
 
             $signup->fill(array_only($data, $arrayKeysToUpdate));
-
             $signup->save(['timestamps' => false]);
 
             $event = $signup->events->last();
@@ -133,8 +140,14 @@ class PostRepository
             $event->updated_at = $data['updated_at'];
             $event->save(['timestamps' => false]);
         } else {
+            // Should only update quantity and why_participated on the signup
+            $signupFields = [
+                'quantity' => $data['quantity'],
+                'why_participated' => $data['why_participated'],
+            ];
+
             // Only update if the key is set (is not null).
-            $nonNullArrayKeys = array_filter($data);
+            $nonNullArrayKeys = array_filter($signupFields);
             $arrayKeysToUpdate = array_keys($nonNullArrayKeys);
 
             $signup->fill(array_only($data, $arrayKeysToUpdate));

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -92,7 +92,7 @@ class PostRepository
         if (isset($data['created_at'])) {
             $post->created_at = $data['created_at'];
             $post->updated_at = isset($data['updated_at']) ? $data['updated_at'] : $data['created_at'];
-            $post->save(['timestamps' => false, 'touch' => false]);
+            $post->save(['timestamps' => false]);
 
             $post->events->first()->created_at = $data['created_at'];
             $post->events->first()->updated_at = $data['created_at'];


### PR DESCRIPTION
#### What's this PR do?

- Explicitly state which fields should be shoved into the signup when we get a request to create a new post. This prevents us from overwriting any existing fields on the signup by accident.

Questions that might be completely out of scope:
When I was working on this, the timestamps weren't behaving as I expected them to. As the code stood, the signup would be set to have the dates passed in with the post, but would then be touched by the post when the new post was created. It just didn't make sense to me to change the `updated_at` of the signup when it will end up being `now`
- If we pass timestamps with a post, do we want to apply those to the **existing** signup? 
    - I think that we don't because adding a new post doesn't change when the existing signup was created or updated.
- If we pass timestamps with a post, do we want that post to touch the signup?
    - If the signup has been backdated, this will change its `updated_at` to right now

#### How should this be reviewed?
Help me figure out the questions above! Here or in slack is fine with me!

#### Any background context you want to provide?
The point of this is to not overwrite the signup source when a new post is added. The timestamp stuff I came across when working on this and might be out of scope.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/152894138)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.