### PR TITLE
Don't assume we are passed a quantity or why_participated when a new post is added

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -122,8 +122,8 @@ class PostRepository
         if (array_key_exists('updated_at', $data)) {
             // Should only update quantity, why_participated, and timestamps on the signup
             $signupFields = [
-                'quantity' => $data['quantity'],
-                'why_participated' => $data['why_participated'],
+                'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
+                'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
                 'updated_at' => $data['updated_at'],
                 'created_at' => array_key_exists('created_at', $data) ? $data['created_at'] : null,
             ];
@@ -142,8 +142,8 @@ class PostRepository
         } else {
             // Should only update quantity and why_participated on the signup
             $signupFields = [
-                'quantity' => $data['quantity'],
-                'why_participated' => $data['why_participated'],
+                'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
+                'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
             ];
 
             // Only update if the key is set (is not null).


### PR DESCRIPTION
#### What's this PR do?
In the first pass at this I assumed that each new post comes with a `quantity` and `why_participated`, but that is not the case! This fix makes no assumptions about receiving either of those fields, and maintains the signup source not getting overwritten.

#### How should this be reviewed?
Does this work with reportbacks from ALL sources? Gambit?

#### Any background context you want to provide?
We are not guaranteed a `why_participated` with a new post from Gambit.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/152979109)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love. 

cc: @ngjo this would benefit from some additional testing love