### PR TITLE
Blank state if there are no events to show in the History Modal

### DIFF
--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -70,8 +70,10 @@ class HistoryModal extends React.Component {
           <h3>📖 History 📖</h3>
           <div className="container">
             { ! isEmpty(parsedEvents) ?
-              <p>Below shows the 20 most recent changes to the member's signup. This includes changes to the quantity or why. If you need changes beyond the 20 listed here, please reach out to Team Bleed!</p>
-              <Table headings={['Quantity', 'Why Participated', 'Updated At', 'User']} data={parsedEvents} type="events" />
+              <div>
+                <p>Below shows the 20 most recent changes to the member's signup. This includes changes to the quantity or why. If you need changes beyond the 20 listed here, please reach out to Team Bleed!</p>
+                <Table headings={['Quantity', 'Why Participated', 'Updated At', 'User']} data={parsedEvents} type="events" />
+              </div>
               :
               <Empty header="No History To Show!" copy="Sorry, but we don't have any history for this signup."/>
             }

--- a/resources/assets/components/HistoryModal/index.js
+++ b/resources/assets/components/HistoryModal/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { map } from 'lodash';
+import { map, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 
+import Empty from '../Empty';
 import Table from '../Table';
 import './history-modal.scss';
 
@@ -45,9 +46,10 @@ class HistoryModal extends React.Component {
   }
 
   render() {
+    console.log('history');
     const signup = this.props.signup;
     const campaign = this.props.campaign;
-    const parsedEvents = this.parseEventData(this.props.signupEvents);
+    const parsedEvents = ! isEmpty(this.props.signupEvents) ? this.parseEventData(this.props.signupEvents) : null;
 
     return (
       <div className="modal">
@@ -66,9 +68,13 @@ class HistoryModal extends React.Component {
           </div>
 
           <h3>📖 History 📖</h3>
-          <p>Below shows the 20 most recent changes to the member's signup. This includes changes to the quantity or why. If you need changes beyond the 20 listed here, please reach out to Team Bleed!</p>
           <div className="container">
-            <Table headings={['Quantity', 'Why Participated', 'Updated At', 'User']} data={parsedEvents} type="events" />
+            { ! isEmpty(parsedEvents) ?
+              <p>Below shows the 20 most recent changes to the member's signup. This includes changes to the quantity or why. If you need changes beyond the 20 listed here, please reach out to Team Bleed!</p>
+              <Table headings={['Quantity', 'Why Participated', 'Updated At', 'User']} data={parsedEvents} type="events" />
+              :
+              <Empty header="No History To Show!" copy="Sorry, but we don't have any history for this signup."/>
+            }
           </div>
         </div>
         <button className="button -history" disabled={! this.state.quantity} onClick={() => this.props.onUpdate(signup, this.state.quantity)}>Save</button>


### PR DESCRIPTION
#### What's this PR do?
If there are no events under a signup, instead of not opening the history modal at all (which means there would be no way to update quantity either), show a blank state!

Blank:
![image](https://user-images.githubusercontent.com/4240292/33037755-831a461e-ce00-11e7-9cb3-47444e962b08.png)

Not blank:
![image](https://user-images.githubusercontent.com/4240292/33037730-76b128c0-ce00-11e7-9d90-010e5b697694.png)

#### How should this be reviewed?
Does it look okay? Is the copy okay?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/152851215)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.