### PR TITLE
Add quantity column to posts table

### DIFF
--- a/database/migrations/2017_11_20_202525_add_quantity_column_to_posts_table.php
+++ b/database/migrations/2017_11_20_202525_add_quantity_column_to_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddQuantityColumnToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->integer('quantity')->after('northstar_id')->default(null)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('quantity');
+        });
+    }
+}

--- a/database/migrations/2017_11_20_202525_add_quantity_column_to_posts_table.php
+++ b/database/migrations/2017_11_20_202525_add_quantity_column_to_posts_table.php
@@ -14,7 +14,7 @@ class AddQuantityColumnToPostsTable extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->integer('quantity')->after('northstar_id')->default(null)->nullable();
+            $table->integer('quantity')->after('northstar_id')->nullable();
         });
     }
 


### PR DESCRIPTION
#### What's this PR do?
Added a `quantity` column to the `posts` table.
- column is after `northstar_id`
- defaults to `null`
- is nullable
- is an integer

#### How should this be reviewed?
Is that where we want the column to be? Are there different qualities we want it to have?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/152900013)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.