### PR TITLE
Return 422s for invalid filetypes.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -51,6 +51,12 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        // If Intervention can't parse a file (corrupted or wrong type), return 422.
+        // @TODO: Handle this with a validation rule on our v3 routes.
+        if ($e instanceof \Intervention\Image\Exception\NotReadableException) {
+            abort(422, 'Invalid image provided.');
+        }
+
         // Re-cast specific exceptions or uniquely render them:
         if ($e instanceof GlideNotFoundException) {
             $e = new NotFoundHttpException('That image could not be found.');


### PR DESCRIPTION
#### What's this PR do?
I applied this as a hotfix last night since Blink was hammering Rogue with 3,426+ retries for a single reportback with a `video/3gpp` upload attached. In order to prevent Blink from doing this, let's catch this type of exception and return a `422` error.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
- [Slack conversation](https://dosomething.slack.com/archives/C4VN7J0SE/p1511228107000049)
- [New Relic exception page](https://rpm.newrelic.com/accounts/108038/applications/24971199/filterable_errors#/show/e8c56dfc-ce5d-11e7-9600-0242ac110008_2864_12792/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart&filters=%5B%7B%22key%22%3A%22error.class%22%2C%22value%22%3A%22Intervention%5C%5CImage%5C%5CException%5C%5CNotReadableException%22%2C%22like%22%3Afalse%7D%5D&_k=4ape37)


#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.