### PR TITLE
Artisan command to move quantity from Signup to Post

### DIFF
--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -66,21 +66,21 @@ class PostQuantity extends Command
                 if ($acceptedPosts->isNotEmpty()) {
                     $mostRecentAcceptedPost = $acceptedPosts->first();
                     $mostRecentAcceptedPost->quantity = $quantity;
-                    $mostRecentAcceptedPost->save(['touches' => FALSE]);
+                    $mostRecentAcceptedPost->save(['touches' => false]);
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentAcceptedPost->id);
                 }
                 // If no accepted posts, put quantity on most recent post (based on creation)
                 else {
                     $mostRecentPost = $posts->sortByDesc('created_at')->first();
                     $mostRecentPost->quantity = $quantity;
-                    $mostRecentPost->save(['touches' => FALSE]);
+                    $mostRecentPost->save(['touches' => false]);
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentPost->id);
                 }
                 // Put quantity of 0 on all other posts under this signup
                 foreach ($posts as $post) {
                     if (is_null($post->quantity)) {
                         $post->quantity = 0;
-                        $post->save(['touches' => FALSE]);
+                        $post->save(['touches' => false]);
                         info('rogue:postquantity: Put quantity 0 on post ' . $post->id);
                     }
                 }

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Signup;
+use Illuminate\Console\Command;
+
+class PostQuantity extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:postquantity {start=1}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add the quantity from the corresponding signup onto the corresponding post.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Signup that we should start with
+        $start = $this->argument('start');
+
+        // Create the progress bar
+        $bar = $this->output->createProgressBar(Signup::where('id', '>=', $start)->count());
+
+        // Get all signups starting from $start in order of ID
+        Signup::where('id', '>=', $start)->orderBy('id')->with('posts')->chunk(100, function ($signups) use ($bar) {
+            foreach ($signups as $signup) {
+                // Get the posts for the signup
+                $posts = $signup->posts;
+
+                // If no posts, move on
+                if ($posts->isEmpty()) {
+                    info('rogue:postquantity: No posts for signup ' . $signup->id);
+                    $bar->advance();
+                    continue;
+                }
+                info('rogue:postquantity: Updating posts for signup ' . $signup->id);
+
+                // Get the quantity
+                $quantity = $signup->quantity ? $signup->quantity : $signup->quantity_pending;
+
+                // Put all the quantity on the most recent accepted post (based on creation)
+                $acceptedPosts = $posts->where('status', 'accepted')->sortByDesc('created_at');
+                if ($acceptedPosts->isNotEmpty()) {
+                    $mostRecentAcceptedPost = $acceptedPosts->first();
+                    $mostRecentAcceptedPost->quantity = $quantity;
+                    $mostRecentAcceptedPost->save();
+                    info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentAcceptedPost->id);
+
+                }
+                // If no accepted posts, put quantity on most recent post (based on creation)
+                else {
+                    $mostRecentPost = $posts->sortByDesc('created_at')->first();
+                    $mostRecentPost->quantity = $quantity;
+                    $mostRecentPost->save(); // do we want to save without timestamps?
+                    info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentPost->id);
+                }
+
+                // Put quantity of 0 on all other posts under this signup
+                foreach ($posts as $post) {
+                    if (is_null($post->quantity)) {
+                        $post->quantity = 0;
+                        $post->save();
+                        info('rogue:postquantity: Put quantity 0 on post ' . $post->id);
+                    }
+                }
+
+                // Advance the progress bar
+                $bar->advance();
+            }
+        });
+        // We did it!
+        $bar->finish();
+        info('rogue:postquantity: ALL DONE');
+    }
+}

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -77,7 +77,6 @@ class PostQuantity extends Command
                     $mostRecentPost->save(); // do we want to save without timestamps?
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentPost->id);
                 }
-
                 // Put quantity of 0 on all other posts under this signup
                 foreach ($posts as $post) {
                     if (is_null($post->quantity)) {

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -66,21 +66,21 @@ class PostQuantity extends Command
                 if ($acceptedPosts->isNotEmpty()) {
                     $mostRecentAcceptedPost = $acceptedPosts->first();
                     $mostRecentAcceptedPost->quantity = $quantity;
-                    $mostRecentAcceptedPost->save();
+                    $mostRecentAcceptedPost->save(['touches' => FALSE]);
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentAcceptedPost->id);
                 }
                 // If no accepted posts, put quantity on most recent post (based on creation)
                 else {
                     $mostRecentPost = $posts->sortByDesc('created_at')->first();
                     $mostRecentPost->quantity = $quantity;
-                    $mostRecentPost->save(); // do we want to save without timestamps?
+                    $mostRecentPost->save(['touches' => FALSE]);
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentPost->id);
                 }
                 // Put quantity of 0 on all other posts under this signup
                 foreach ($posts as $post) {
                     if (is_null($post->quantity)) {
                         $post->quantity = 0;
-                        $post->save();
+                        $post->save(['touches' => FALSE]);
                         info('rogue:postquantity: Put quantity 0 on post ' . $post->id);
                     }
                 }

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -58,6 +58,16 @@ class PostQuantity extends Command
                 }
                 info('rogue:postquantity: Updating posts for signup ' . $signup->id);
 
+                // sum quant of posts
+
+                    // if non null, see if any posts have null quant
+                        // if none have null quant, continue
+                        // if some have null quant, do some math
+                            // do signup quant - post quant sum = missing quant
+                            // put missing quant on post (most recent accepted and if not most recent)
+                            // set null quants to 0
+
+                    // if null, do this:
                 // Get the quantity
                 $quantity = $signup->quantity ? $signup->quantity : $signup->quantity_pending;
 

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -66,21 +66,21 @@ class PostQuantity extends Command
                 if ($acceptedPosts->isNotEmpty()) {
                     $mostRecentAcceptedPost = $acceptedPosts->first();
                     $mostRecentAcceptedPost->quantity = $quantity;
-                    $mostRecentAcceptedPost->save(['touches' => false]);
+                    $mostRecentAcceptedPost->save();
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentAcceptedPost->id);
                 }
                 // If no accepted posts, put quantity on most recent post (based on creation)
                 else {
                     $mostRecentPost = $posts->sortByDesc('created_at')->first();
                     $mostRecentPost->quantity = $quantity;
-                    $mostRecentPost->save(['touches' => false]);
+                    $mostRecentPost->save();
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentPost->id);
                 }
                 // Put quantity of 0 on all other posts under this signup
                 foreach ($posts as $post) {
                     if (is_null($post->quantity)) {
                         $post->quantity = 0;
-                        $post->save(['touches' => false]);
+                        $post->save();
                         info('rogue:postquantity: Put quantity 0 on post ' . $post->id);
                     }
                 }

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -59,8 +59,20 @@ class PostQuantity extends Command
                 info('rogue:postquantity: Updating posts for signup ' . $signup->id);
 
                 // sum quant of posts
+                $postQuantityTotal = $posts->sum('quantity');
 
-                    // if non null, see if any posts have null quant
+                    // if >0, see if any posts have null quant
+                if ($postQuantityTotal) {
+                    $postQuantities = $posts->pluck('quantity');
+
+                    if (!in_array(null, $postQuantities)) {
+                        dd('no quants are null');
+                        continue;
+                    }
+
+                    dump($postQuantities);
+                    dd('doing math now');
+                }
                         // if none have null quant, continue
                         // if some have null quant, do some math
                             // do signup quant - post quant sum = missing quant

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -66,7 +66,7 @@ class PostQuantity extends Command
                     $postQuantities = $posts->pluck('quantity')->toArray();
 
                     // If none have null quant, continue we are done here
-                    if (!in_array(null, $postQuantities, true)) {
+                    if (! in_array(null, $postQuantities, true)) {
                         continue;
                     }
 

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -68,7 +68,6 @@ class PostQuantity extends Command
                     $mostRecentAcceptedPost->quantity = $quantity;
                     $mostRecentAcceptedPost->save();
                     info('rogue:postquantity: Put quantity ' . $quantity . ' on post ' . $mostRecentAcceptedPost->id);
-
                 }
                 // If no accepted posts, put quantity on most recent post (based on creation)
                 else {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\EditImagesCommand::class,
         Commands\SetupCommand::class,
         Commands\ImportSignupsCommand::class,
+        Commands\PostQuantity::class
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\EditImagesCommand::class,
         Commands\SetupCommand::class,
         Commands\ImportSignupsCommand::class,
-        Commands\PostQuantity::class
+        Commands\PostQuantity::class,
     ];
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -28,7 +28,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'quantity', 'url', 'caption', 'status', 'source', 'remote_addr'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -155,13 +155,7 @@ class Signup extends Model
             return $this->quantity;
         }
 
-        // Loop through all the posts and sum their quantities.
-        $quantity = 0;
-
-        foreach ($posts as $post) {
-            $quantity += $post->quantity;
-        }
-
-        return $quantity;
+        // Sum the post quantities
+        return $posts->sum('quantity');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Here it is!
What it does:
1. Takes in an argument of the Signup ID to start with. If none given, starts at the very beginning (ID=1).
2. Grabs all the signups (with their posts their posts) in chunks of 100.
3. Check if the signup has posts. If not, move on to the next signup.
4. See if any of the posts have quantity. If they do, see if it's ALL of them. If it's all of them, move on to the next signup. If it's only some of them, subtract the quantity on the posts from the quantity on the signup. If some of the posts are `accepted`, grab the most recently submitted `accepted` one and give it the difference in quantity. If there are no accepted posts, grab the most recently submitted post and give it the quantity from the signup. Give all other posts with no quantity `0`.
5. If none of the posts have a quantity, do the same thing except just using the raw quantity from the signup.
6. Move on to the next signup.

Important notes:
- as it stands now, WILL update `updated_at` on Signups
- can be re-run, re-started at any point without duplicating or otherwise mucking anything up (except re-running will again update `updated_at` on posts and signups)
- includes a progress bar
- all output goes straight to the logs prefixed with `rogue:postquantity:`
- does NOT send messages to Blink because it does everything directly to the models and does not hit the `PostService` or `SignupService` which hold the Blink sending logic

#### How should this be reviewed?
Question: Do we want to save the Posts without timestamps? Or do we want running this to update their `updated_at`? Do we want to touch the signup?

Does this do what it should based on [this doc](https://docs.google.com/document/d/1ZhwLH7LxzWfWuX5RMfFlLwJYdR2UOArBFXIePtL3tlQ/edit)?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/152900315)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.