### PR TITLE
Return sum of post quantities or signup quantity

### DIFF
--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -32,7 +32,7 @@ class ReportbackTransformer extends TransformerAbstract
                 'id' => (string) $signup->id,
                 'created_at' => $signup->created_at->toIso8601String(),
                 'updated_at' => $signup->updated_at->toIso8601String(),
-                'quantity' => $signup->quantity,
+                'quantity' => $post->getTotalQuantity(),
                 'why_participated' => $signup->why_participated,
                 'flagged' => 'false',
             ],

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -233,4 +233,29 @@ class Post extends Model
     {
         return Reaction::where('post_id', $postId)->count();
     }
+
+    /**
+     * Get the total quantity for all posts under the signup that this post is associated with.
+     *
+     * @return int
+     */
+    public function getTotalQuantity()
+    {
+        $signup = $this->signup;
+
+        // If the post has NULL quantity, it means that the quantity is still on the signup
+        if (is_null($this->quantity)) {
+            return $signup->quantity;
+        }
+
+        // Loop through all the posts and sum their quantities
+        $posts = $signup->posts;
+        $quantity = 0;
+
+        foreach ($posts as $post) {
+            $quantity += $post->quantity;
+        }
+
+        return $quantity;
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -245,7 +245,7 @@ class Post extends Model
 
         // If the post has NULL quantity, it means that the quantity is still on the signup
         if (is_null($this->quantity)) {
-            return $signup->quantity;
+            return $signup->getQuantity();
         }
 
         // Loop through all the posts and sum their quantities


### PR DESCRIPTION
#### What's this PR do?
When hitting `v1/reportbacks`, if the particular post we are returning has a quantity of `null` (indicating that we have not yet added the quantity values into the posts table), we return the `quantity` from the signup that the post is associated with. Otherwise, if the post _does_ have a quantity (including `0`), sum up the quantities of that post and all the other posts under the same signup and return that.

#### How should this be reviewed?
Does any documentation need to be updated with this?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/153073306)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.