### PR TITLE
Quantity update to GET /api/v2/activity

### DIFF
--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -32,7 +32,7 @@ class ReportbackTransformer extends TransformerAbstract
                 'id' => (string) $signup->id,
                 'created_at' => $signup->created_at->toIso8601String(),
                 'updated_at' => $signup->updated_at->toIso8601String(),
-                'quantity' => $post->getTotalQuantity(),
+                'quantity' => $signup->getQuantity(),
                 'why_participated' => $signup->why_participated,
                 'flagged' => 'false',
             ],

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -34,14 +34,11 @@ class SignupTransformer extends TransformerAbstract
      */
     public function transform(Signup $signup)
     {
-        // $firstPost = $signup->posts()->first();
-
         return [
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
-            // 'quantity' => $firstPost ? $firstPost->getTotalQuantity() : $signup->getQuantity(),
             'quantity' => $signup->getQuantity(),
             'why_participated' => $signup->why_participated,
             'signup_source' => $signup->source,

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -34,12 +34,14 @@ class SignupTransformer extends TransformerAbstract
      */
     public function transform(Signup $signup)
     {
+        $firstPost = $signup->posts()->first();
+
         return [
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
-            'quantity' => $signup->getQuantity(),
+            'quantity' => $firstPost ? $firstPost->getTotalQuantity() : $signup->getQuantity(),
             'why_participated' => $signup->why_participated,
             'signup_source' => $signup->source,
             'details' => $signup->details,

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -34,14 +34,15 @@ class SignupTransformer extends TransformerAbstract
      */
     public function transform(Signup $signup)
     {
-        $firstPost = $signup->posts()->first();
+        // $firstPost = $signup->posts()->first();
 
         return [
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
-            'quantity' => $firstPost ? $firstPost->getTotalQuantity() : $signup->getQuantity(),
+            // 'quantity' => $firstPost ? $firstPost->getTotalQuantity() : $signup->getQuantity(),
+            'quantity' => $signup->getQuantity(),
             'why_participated' => $signup->why_participated,
             'signup_source' => $signup->source,
             'details' => $signup->details,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -233,29 +233,4 @@ class Post extends Model
     {
         return Reaction::where('post_id', $postId)->count();
     }
-
-    /**
-     * Get the total quantity for all posts under the signup that this post is associated with.
-     *
-     * @return int
-     */
-    public function getTotalQuantity()
-    {
-        $signup = $this->signup;
-
-        // If the post has NULL quantity, it means that the quantity is still on the signup
-        if (is_null($this->quantity)) {
-            return $signup->getQuantity();
-        }
-
-        // Loop through all the posts and sum their quantities
-        $posts = $signup->posts;
-        $quantity = 0;
-
-        foreach ($posts as $post) {
-            $quantity += $post->quantity;
-        }
-
-        return $quantity;
-    }
 }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -138,7 +138,7 @@ class Signup extends Model
         // it means that the quantity is still on the signup.
         $posts = $this->posts;
 
-        if ($posts->count() <= 0 || is_null($posts->first()->quantity)) {
+        if ($posts->isEmpty() || is_null($posts->first()->quantity)) {
             if (! is_null($this->quantity_pending) && is_null($this->quantity)) {
                 return $this->quantity_pending;
             }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -127,7 +127,7 @@ class Signup extends Model
      * @return int
      */
     public function getQuantity()
-{
+    {
         // @TODO - This is temporary. We have migrated data that has stored quanity in the
         // quanity_pending column on the signup. However, since then we updated the business
         // logic to store everything in the quanity column and not use the quanity_pending

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -120,21 +120,39 @@ class Signup extends Model
     }
 
     /**
-     * Get either the quantity or quantity_pending for a Signup.
+     * Get either the quantity or quantity_pending for a signup.
+     * If the quantity lives on the signup's posts,
+     * return quantity as a summed total of quantity across all posts under a signup.
      *
      * @return int
      */
     public function getQuantity()
-    {
+{
         // @TODO - This is temporary. We have migrated data that has stored quanity in the
         // quanity_pending column on the signup. However, since then we updated the business
         // logic to store everything in the quanity column and not use the quanity_pending
         // column at all. We only want to return what is in the quanity_pending column
         // if is the only place quanity is stored.
-        if (! is_null($this->quantity_pending) && is_null($this->quantity)) {
-            return $this->quantity_pending;
+
+        // If the there is at least one post and it has NULL quantity,
+        // it means that the quantity is still on the signup.
+        $posts = $this->posts;
+
+        if ($posts->count() <= 0 || is_null($posts->first()->quantity)) {
+            if (! is_null($this->quantity_pending) && is_null($this->quantity)) {
+                return $this->quantity_pending;
+            }
+
+            return $this->quantity;
         }
 
-        return $this->quantity;
+        // Loop through all the posts and sum their quantities.
+        $quantity = 0;
+
+        foreach ($posts as $post) {
+            $quantity += $post->quantity;
+        }
+
+        return $quantity;
     }
 }

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -291,7 +291,7 @@ class ActivityApiTest extends TestCase
         $thirdSignup->quantity_pending = null;
         $thirdSignup->save();
 
-        for ($i = 0 ; $i < 3; $i++) {
+        for ($i = 0; $i < 3; $i++) {
             $post = $thirdSignup->posts()->save(factory(Post::class)->make());
             $post->quantity = 3;
             $post->save();
@@ -313,7 +313,7 @@ class ActivityApiTest extends TestCase
                 [
                     'quantity' => 9,
                     // ...
-                ]
+                ],
             ],
         ]);
     }

--- a/tests/Http/Api/ActivityApiTest.php
+++ b/tests/Http/Api/ActivityApiTest.php
@@ -266,4 +266,55 @@ class ActivityApiTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * Test to make sure we are returning quantity correctly.
+     * Quantity is either summed total of quantity across all posts under a signup
+     * or quanttiy under signup if it is still on signup record.
+     *
+     * GET /activity
+     * @return void
+     */
+    public function testQuantityOnActivityIndex()
+    {
+        // Create one signup with a quantity_pending.
+        $firstSignup = factory(Signup::class)->create();
+
+        // Create another signup with a quantity.
+        $secondSignup = factory(Signup::class)->create();
+        $secondSignup->quantity_pending = null;
+        $secondSignup->quantity = 8;
+        $secondSignup->save();
+
+        // Create another signup with three posts with quantities.
+        $thirdSignup = factory(Signup::class)->create();
+        $thirdSignup->quantity_pending = null;
+        $thirdSignup->save();
+
+        for ($i = 0 ; $i < 3; $i++) {
+            $post = $thirdSignup->posts()->save(factory(Post::class)->make());
+            $post->quantity = 3;
+            $post->save();
+        }
+
+        $response = $this->getJson('api/v2/activity');
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                [
+                    'quantity' => $firstSignup->quantity_pending,
+                    // ...
+                ],
+                [
+                    'quantity' => 8,
+                    // ...
+                ],
+                [
+                    'quantity' => 9,
+                    // ...
+                ]
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
- Updates `SignupTransformer` to return quantity as a summed total of quantity across all posts under a signup, if `$signup->quantity` doesn't exists.
  - Combines `getTotalQuantity()` into `getQuantity()`
- Adds a test to make sure quantities are returned correctly. 

#### How should this be reviewed?
- Does the logic in the test and code make sense? 
- All tests should pass! 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/153032066) Pivotal card. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.