### PR TITLE
WIP: POST api/v2/posts - store quantity on post

### DIFF
--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -24,7 +24,6 @@ trait PostRequests
 
         $updating = ! is_null($signup);
 
-        // @TODO - should we eventually throw an error if a signup doesn't exist before a post is created? I create one here because we haven't implemented sending signups to rogue yet, so it will have to create a signup record for all posts.
         if (! $updating) {
             $signup = $this->signups->create($request->all());
 

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -25,6 +25,7 @@ class PostRequest extends Request
             'northstar_id' => 'required|string',
             'campaign_id' => 'required',
             'campaign_run_id' => 'int',
+            'quantity' => 'nullable|int',
             'caption' => 'nullable|string',
             'status' => 'in:pending,accepted,rejected',
             'source' => 'nullable|string',

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -35,6 +35,7 @@ class PostTransformer extends TransformerAbstract
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
+            'quantity' => $post->quantity,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.
             // @NOTE - Remove if we get rid of rotation.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -28,7 +28,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'url', 'caption', 'status', 'source', 'remote_addr'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'quantity', 'url', 'caption', 'status', 'source', 'remote_addr'];
 
     /**
      * Attributes that can be queried when filtering.
@@ -38,7 +38,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'status'];
+    public static $indexes = ['id', 'signup_id', 'quantity', 'campaign_id', 'northstar_id', 'status'];
 
     /**
      * Each post has events.
@@ -157,7 +157,7 @@ class Post extends Model
         return [
             'id' => $this->id,
             'signup_id' => $this->signup_id,
-            'quantity' => $this->signup->quantity,
+            'quantity' => $this->signup->getQuantity(),
             'why_participated' => $this->signup->why_participated,
             'campaign_id' => (string) $this->campaign_id,
             'campaign_run_id' => (string) $this->signup->campaign_run_id,

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -82,6 +82,7 @@ class PostRepository
             'campaign_id' => $signup->campaign_id,
             'url' => $fileUrl,
             'caption' => $data['caption'],
+            'quantity' => $data['quantity'],
             'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => $data['source'],
             'remote_addr' => $data['remote_addr'],

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -121,9 +121,8 @@ class PostRepository
     public function update($signup, $data)
     {
         if (array_key_exists('updated_at', $data)) {
-            // Should only update quantity, why_participated, and timestamps on the signup
+            // Should only update why_participated, and timestamps on the signup
             $signupFields = [
-                'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
                 'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
                 'updated_at' => $data['updated_at'],
                 'created_at' => array_key_exists('created_at', $data) ? $data['created_at'] : null,
@@ -141,9 +140,8 @@ class PostRepository
             $event->updated_at = $data['updated_at'];
             $event->save(['timestamps' => false]);
         } else {
-            // Should only update quantity and why_participated on the signup
+            // Should only update why_participated on the signup
             $signupFields = [
-                'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
                 'why_participated' => isset($data['why_participated']) ? $data['why_participated'] : null,
             ];
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -82,7 +82,7 @@ class PostRepository
             'campaign_id' => $signup->campaign_id,
             'url' => $fileUrl,
             'caption' => $data['caption'],
-            'quantity' => $data['quantity'],
+            'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
             'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => $data['source'],
             'remote_addr' => $data['remote_addr'],

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -75,6 +75,10 @@ class PostRepository
 
         $signup = Signup::find($signupId);
 
+        if (isset($data['quantity'])) {
+            $quantityDiff = $data['quantity'] - $signup->quantity;
+        }
+
         // Create a post.
         $post = new Post([
             'signup_id' => $signup->id,
@@ -82,7 +86,7 @@ class PostRepository
             'campaign_id' => $signup->campaign_id,
             'url' => $fileUrl,
             'caption' => $data['caption'],
-            'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
+            'quantity' => $quantityDiff,
             'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => $data['source'],
             'remote_addr' => $data['remote_addr'],
@@ -101,6 +105,13 @@ class PostRepository
         } else {
             $post->save();
         }
+
+
+        if (isset($data['quantity'])) {
+            $signup->quantity = $signup->getQuantity();
+            $signup->save();
+        }
+
 
         // Edit the image if there is one
         if (isset($data['file'])) {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -77,6 +77,10 @@ class PostRepository
 
         if (isset($data['quantity'])) {
             $quantityDiff = $data['quantity'] - $signup->quantity;
+
+            if ($quantityDiff < 0) {
+                $quantityDiff = $data['quantity'];
+            }
         }
 
         // Create a post.
@@ -86,7 +90,7 @@ class PostRepository
             'campaign_id' => $signup->campaign_id,
             'url' => $fileUrl,
             'caption' => $data['caption'],
-            'quantity' => $quantityDiff,
+            'quantity' => isset($quantityDiff) ? quantityDiff : null,
             'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => $data['source'],
             'remote_addr' => $data['remote_addr'],
@@ -111,7 +115,6 @@ class PostRepository
             $signup->quantity = $signup->getQuantity();
             $signup->save();
         }
-
 
         // Edit the image if there is one
         if (isset($data['file'])) {

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -17,11 +17,18 @@ class SignupRepository
         // Create the signup
         $signup = new Signup;
 
+        // $quantity = $signup->quantity;
+        // $isFirstSignup = is_null($quantity);
+        // $quantityWasSubmitted = isset($data['quantity']);
+
+        // if ($isFirstSignup && $quantityWasSubmitted) {
+        //     $quantity = $data['quantity'];
+        // }
+
         $signup->northstar_id = $data['northstar_id'];
         $signup->campaign_id = $data['campaign_id'];
         $signup->campaign_run_id = isset($data['campaign_run_id']) ? $data['campaign_run_id'] : null;
         $signup->quantity = isset($data['quantity']) ? $data['quantity'] : null;
-        $signup->quantity_pending = isset($data['quantity_pending']) ? $data['quantity_pending'] : null;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : null;
         $signup->details = isset($data['details']) ? $data['details'] : null;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -17,14 +17,6 @@ class SignupRepository
         // Create the signup
         $signup = new Signup;
 
-        // $quantity = $signup->quantity;
-        // $isFirstSignup = is_null($quantity);
-        // $quantityWasSubmitted = isset($data['quantity']);
-
-        // if ($isFirstSignup && $quantityWasSubmitted) {
-        //     $quantity = $data['quantity'];
-        // }
-
         $signup->northstar_id = $data['northstar_id'];
         $signup->campaign_id = $data['campaign_id'];
         $signup->campaign_run_id = isset($data['campaign_run_id']) ? $data['campaign_run_id'] : null;

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.38.3",
+            "version": "3.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "0dfe5513b48776bc7f8d5d6ec195ed3dc714cb96"
+                "reference": "ff9d3bcdceec26067ae86eb621cb5899e7cb39af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0dfe5513b48776bc7f8d5d6ec195ed3dc714cb96",
-                "reference": "0dfe5513b48776bc7f8d5d6ec195ed3dc714cb96",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ff9d3bcdceec26067ae86eb621cb5899e7cb39af",
+                "reference": "ff9d3bcdceec26067ae86eb621cb5899e7cb39af",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-11-15T19:04:10+00:00"
+            "time": "2017-11-29T05:42:28+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -1445,16 +1445,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.5.21",
+            "version": "v5.5.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6321069a75723d88103526903d3192f0b231544a"
+                "reference": "2404af887ca8272d721628a99bbc721ac3b692e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6321069a75723d88103526903d3192f0b231544a",
-                "reference": "6321069a75723d88103526903d3192f0b231544a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/2404af887ca8272d721628a99bbc721ac3b692e7",
+                "reference": "2404af887ca8272d721628a99bbc721ac3b692e7",
                 "shasum": ""
             },
             "require": {
@@ -1574,7 +1574,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2017-11-14T15:08:13+00:00"
+            "time": "2017-11-27T15:29:55+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -1699,16 +1699,16 @@
         },
         {
             "name": "league/csv",
-            "version": "9.1.0",
+            "version": "9.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "bfa3aa8e755377cd6cc2242cfd074e48c7c300ba"
+                "reference": "66118f5c2a7e4da77e743e69f74773c63b73e8f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/bfa3aa8e755377cd6cc2242cfd074e48c7c300ba",
-                "reference": "bfa3aa8e755377cd6cc2242cfd074e48c7c300ba",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/66118f5c2a7e4da77e743e69f74773c63b73e8f9",
+                "reference": "66118f5c2a7e4da77e743e69f74773c63b73e8f9",
                 "shasum": ""
             },
             "require": {
@@ -1759,7 +1759,7 @@
                 "read",
                 "write"
             ],
-            "time": "2017-10-20T08:03:26+00:00"
+            "time": "2017-11-28T08:29:49+00:00"
         },
         {
             "name": "league/flysystem",
@@ -2610,16 +2610,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.7",
+            "version": "2.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "f4b6a522dfa1fd1e477c9cfe5909d5b31f098c0b"
+                "reference": "c9a3fe35e20eb6eeaca716d6a23cde03f52d1558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/f4b6a522dfa1fd1e477c9cfe5909d5b31f098c0b",
-                "reference": "f4b6a522dfa1fd1e477c9cfe5909d5b31f098c0b",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/c9a3fe35e20eb6eeaca716d6a23cde03f52d1558",
+                "reference": "c9a3fe35e20eb6eeaca716d6a23cde03f52d1558",
                 "shasum": ""
             },
             "require": {
@@ -2698,7 +2698,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2017-10-23T05:04:54+00:00"
+            "time": "2017-11-29T06:38:08+00:00"
         },
         {
             "name": "predis/predis",
@@ -3101,16 +3101,16 @@
         },
         {
             "name": "spatie/db-dumper",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/db-dumper.git",
-                "reference": "1b5695da55695f9db3f0374e2a60ccff2c8b4090"
+                "reference": "f951560361afa05422ecfe9b21bda3547737963e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/1b5695da55695f9db3f0374e2a60ccff2c8b4090",
-                "reference": "1b5695da55695f9db3f0374e2a60ccff2c8b4090",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/f951560361afa05422ecfe9b21bda3547737963e",
+                "reference": "f951560361afa05422ecfe9b21bda3547737963e",
                 "shasum": ""
             },
             "require": {
@@ -3147,20 +3147,20 @@
                 "mysqldump",
                 "spatie"
             ],
-            "time": "2017-11-13T10:16:26+00:00"
+            "time": "2017-11-23T23:41:11+00:00"
         },
         {
             "name": "spatie/laravel-backup",
-            "version": "5.1.1",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-backup.git",
-                "reference": "b22f4bd526b2a99896479068c6930b784305f058"
+                "reference": "e5bd4690aa004320d2f691ff8caaf68b203ba493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/b22f4bd526b2a99896479068c6930b784305f058",
-                "reference": "b22f4bd526b2a99896479068c6930b784305f058",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/e5bd4690aa004320d2f691ff8caaf68b203ba493",
+                "reference": "e5bd4690aa004320d2f691ff8caaf68b203ba493",
                 "shasum": ""
             },
             "require": {
@@ -3177,7 +3177,7 @@
                 "symfony/finder": "^3.3"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.5",
+                "mockery/mockery": "^1.0",
                 "orchestra/testbench": "~3.5.0",
                 "phpunit/phpunit": "^6.2"
             },
@@ -3220,7 +3220,7 @@
                 "laravel-backup",
                 "spatie"
             ],
-            "time": "2017-11-03T15:16:15+00:00"
+            "time": "2017-11-26T22:31:39+00:00"
         },
         {
             "name": "spatie/temporary-directory",
@@ -4392,16 +4392,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.1.12",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a99f0b151846021ba7a73b4e3cba3ebc9f14f03e"
+                "reference": "c6081b8838686aa04f1e83ba7e91f78b7b2a23e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a99f0b151846021ba7a73b4e3cba3ebc9f14f03e",
-                "reference": "a99f0b151846021ba7a73b4e3cba3ebc9f14f03e",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/c6081b8838686aa04f1e83ba7e91f78b7b2a23e6",
+                "reference": "c6081b8838686aa04f1e83ba7e91f78b7b2a23e6",
                 "shasum": ""
             },
             "require": {
@@ -4410,7 +4410,7 @@
             },
             "require-dev": {
                 "mockery/mockery": "0.9.*",
-                "phpunit/phpunit": "^4.8 || ^5.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
                 "symfony/var-dumper": "^2.6 || ^3.0"
             },
             "suggest": {
@@ -4449,7 +4449,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2017-10-15T13:05:10+00:00"
+            "time": "2017-11-23T18:22:44+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -4875,29 +4875,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -4916,7 +4922,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4967,16 +4973,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -4988,7 +4994,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -5026,20 +5032,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.3",
+            "version": "5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
+                "reference": "033ec97498cf530cc1be4199264cad568b19be26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/033ec97498cf530cc1be4199264cad568b19be26",
+                "reference": "033ec97498cf530cc1be4199264cad568b19be26",
                 "shasum": ""
             },
             "require": {
@@ -5048,7 +5054,7 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0",
+                "phpunit/php-token-stream": "^2.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
@@ -5090,20 +5096,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-03T13:47:33+00:00"
+            "time": "2017-11-27T09:00:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -5137,7 +5143,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -5231,16 +5237,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -5276,7 +5282,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/database/migrations/2017_11_29_192248_make_quantity_index_on_posts.php
+++ b/database/migrations/2017_11_29_192248_make_quantity_index_on_posts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeQuantityIndexOnPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex('posts_quantity_index');
+        });
+    }
+}

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -181,6 +181,7 @@ Example Response:
     "id": 340,
     "signup_id": 784,
     "northstar_id": "5571df46a59db12346dsb456d",
+    "quantity": "6",
     "media": {
       "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_214.jpeg",
       "original_image_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/128-482cab927f6529c7f5e5c4bfd2594186-1501090354.jpeg",

--- a/tests/Http/Api/PostApiTest.php
+++ b/tests/Http/Api/PostApiTest.php
@@ -62,13 +62,13 @@ class PostApiTest extends TestCase
         $this->assertDatabaseHas('signups', [
             'campaign_id' => $campaign_id,
             'northstar_id' => $northstar_id,
-            'quantity' => $quantity,
         ]);
 
         $this->assertDatabaseHas('posts', [
             'northstar_id' => $northstar_id,
             'campaign_id' => $campaign_id,
             'status' => 'pending',
+            'quantity' => $quantity,
         ]);
     }
 
@@ -110,6 +110,7 @@ class PostApiTest extends TestCase
             'data' => [
                 'northstar_id' => $signup->northstar_id,
                 'status' => 'pending',
+                'quantity' => $quantity,
                 'media' => [
                     'caption' => $caption,
                 ],
@@ -121,6 +122,7 @@ class PostApiTest extends TestCase
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'status' => 'pending',
+            'quantity' => $quantity,
         ]);
     }
 
@@ -163,6 +165,7 @@ class PostApiTest extends TestCase
             'data' => [
                 'northstar_id' => $signup->northstar_id,
                 'status' => 'pending',
+                'quantity' => $quantity,
                 'media' => [
                     'caption' => $caption,
                 ],
@@ -174,6 +177,7 @@ class PostApiTest extends TestCase
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'status' => 'pending',
+            'quantity' => $quantity,
         ]);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This updates the `POST api/v2/posts` endpoint so that

* It stores quantity on the post.  551c826
* Returns quantity from the post in `PostTransformer` 926fe6a
* Updates `PostApiTests.php` so that we check that quantity was stored on the `post` in our tests 9478a2a

#### How should this be reviewed?

👀  

Tests should pass!  

#### Any background context you want to provide?

* For now we are storing quantity on _both_ the `post` and the `signup` so that we can continue to support both data schemas while we make this transition. 

* I made a quick little update to make the `quantity` column on `posts` be an index column because I added it the filterable index values in the model and that seemed to make sense. 

#### Relevant tickets
Addresses https://www.pivotaltracker.com/story/show/153072890

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.