### PR TITLE
Some example stuff we can do with OAuth on v3 routes!

### DIFF
--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -57,6 +57,7 @@ class SignupsController extends ApiController
         ]);
 
         $transactionId = incrementTransactionId($request);
+
         // Check to see if the signup exists before creating one.
         $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -71,7 +71,7 @@ Endpoint                                       | Functionality
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `POST /api/v3/posts`                           | [Create a post](endpoints/posts.md#create-a-post-and/or-create/Update-a-signup)
-`GET /api/v3/posts`                            | [Get posts](endpoints/posts.md#retrieve-all-posts)
+`GET /api/v3/posts`                            | [Get posts](endpoints/v3/posts.md#retrieve-all-posts)
 `GET /api/v3/posts/:post_id`                   | [Get a post](endpoints/posts.md#retrieve-a-specific-post)
 `DELETE /api/v3/posts/:post_id`                | [Delete a post](endpoints/posts.md#delete-a-post)
 `PATCH /api/v3/posts/:post_id`                 | [Update a post](endpoints/posts.md#update-a-post)

--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -3,7 +3,7 @@
 ## Retrieve all Posts
 
 ```
-GET /api/v2/posts or GET /api/v3/posts
+GET /api/v2/posts
 ```
 
 Posts are returned in reverse chronological order.

--- a/documentation/endpoints/v3/posts.md
+++ b/documentation/endpoints/v3/posts.md
@@ -27,9 +27,6 @@ Posts are returned in reverse chronological order. Anonymous requests will only 
 - **filter[exclude]** _(integer)_
   - The post id(s) to exclude in response.
   - e.g. `/posts?filter[exclude]=2,3,4`
-- **as_user** _(string)_
-  - The logged in user to display if they have reacted to the post or not.
-  - e.g. `/posts?as_user=1234`
 - **filter[tag]** _(string)_
   - The tag(s) to filter the response by.
   - Tag is passed in as tag_slug.

--- a/documentation/endpoints/v3/posts.md
+++ b/documentation/endpoints/v3/posts.md
@@ -1,0 +1,99 @@
+## Posts (v3)
+
+## Retrieve All Posts
+
+```
+GET /api/v3/posts
+```
+
+Posts are returned in reverse chronological order. Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
+
+### Optional Query Parameters
+- **limit**
+  - Set the number of records to return in a single response.
+  - e.g. `/posts?limit=35`
+- **page** _(integer)_
+  - For pagination, specify page of activity to return in the response.
+  - e.g. `/posts?page=2`
+- **filter[campaign_id]** _(integer)_
+  - The campaign ID to filter the response by.
+  - e.g. `/posts?filter[campaign_id]=47`
+- **filter[northstar_id]** _(integer)_
+  - The northstar_id to filter the response by.
+  - e.g. `/posts?filter[northstar_id]=47asdf23abc`
+- **filter[status]** _(string)_
+  - The string to filter the response by.
+  - e.g. `/posts?filter[status]=accepted`
+- **filter[exclude]** _(integer)_
+  - The post id(s) to exclude in response.
+  - e.g. `/posts?filter[exclude]=2,3,4`
+- **as_user** _(string)_
+  - The logged in user to display if they have reacted to the post or not.
+  - e.g. `/posts?as_user=1234`
+- **filter[tag]** _(string)_
+  - The tag(s) to filter the response by.
+  - Tag is passed in as tag_slug.
+  - e.g. `/posts?filter[tag]=good-photo,good-for-sponsor`
+- **include** _(string)_
+  - Include additional related records in the response: `signup`, `siblings`
+  - e.g. `/posts?include=signup,siblings`
+
+Example Response:
+
+```
+{
+    "data": [
+        {
+            "id": 2984,
+            "signup_id": 4673,
+            "northstar_id": "5594429fa59dbfc9578b48f4",
+            "media": {
+                "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_2984.jpeg",
+                "caption": null
+            },
+            "tags": [],
+            "reactions": {
+                "reacted": true,
+                "total": 2
+            },
+            "status": "accepted",
+            "source": null,
+            "remote_addr": "52.3.68.224, 52.3.68.224",
+            "created_at": "2016-11-30T21:21:24+00:00",
+            "updated_at": "2017-08-02T14:11:26+00:00"
+        },
+        {
+            "id": 3655,
+            "signup_id": 5787,
+            "northstar_id": "5575e568a59dbf3b7a8b4572",
+            "media": {
+                "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_3655.jpeg",
+                "caption": "Perhaps you CAN be of some assistance, Bill"
+            },
+            "tags": [],
+            "reactions": {
+                "reacted": false,
+                "total": 8
+            },
+            "status": "accepted",
+            "source": null,
+            "remote_addr": "207.110.19.130, 207.110.19.130",
+            "created_at": "2016-02-10T16:19:25+00:00",
+            "updated_at": "2017-08-02T14:11:35+00:00"
+        }
+    ],
+    "meta": {
+        "pagination": {
+            "total": 53,
+            "count": 2,
+            "per_page": 2,
+            "current_page": 1,
+            "total_pages": 27,
+            "links": {
+                "next": "http://rogue.app/api/v2/posts?filter%5Bcampaign_id%5D=1631%2C12&filter%5Bstatus%5D=accepted&filter%5Bexclude%5D=2962%2C3654&limit=2&as_user=559442cca59dbfc&page=2"
+            }
+        }
+    }
+}
+```
+

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -241,12 +241,12 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test for retrieving all posts.
+     * Test for retrieving all posts as a user.
      *
      * GET /api/v3/posts
      * @return void
      */
-    public function testPostsIndexAsAnony()
+    public function testPostsIndexAsUser()
     {
         $userId = $this->faker->northstar_id;
 
@@ -262,7 +262,7 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test for retrieving all posts.
+     * Test for retrieving all posts as an admin.
      *
      * GET /api/v3/posts
      * @return void

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -195,17 +195,14 @@ class PostTest extends TestCase
      */
     public function testPostsIndex()
     {
-        $userId = $this->faker->northstar_id;
-
-        // The user should only see accepted posts & their own.
+        // Anonymous requests should only see accepted posts.
         factory(Post::class, 'accepted', 10)->create();
-        factory(Post::class, 3)->create(['northstar_id' => $userId]);
         factory(Post::class, 'rejected', 5)->create();
 
-        $response = $this->withAccessToken($userId)->getJson('api/v3/posts');
+        $response = $this->getJson('api/v3/posts');
 
         $response->assertStatus(200);
-        $response->assertJsonCount(13, 'data');
+        $response->assertJsonCount(10, 'data');
 
         $response->assertJsonStructure([
             'data' => [
@@ -241,6 +238,27 @@ class PostTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Test for retrieving all posts.
+     *
+     * GET /api/v3/posts
+     * @return void
+     */
+    public function testPostsIndexAsAnony()
+    {
+        $userId = $this->faker->northstar_id;
+
+        // The user should only see accepted posts & their own.
+        factory(Post::class, 'accepted', 10)->create();
+        factory(Post::class, 3)->create(['northstar_id' => $userId]);
+        factory(Post::class, 'rejected', 5)->create();
+
+        $response = $this->withAccessToken($userId)->getJson('api/v3/posts');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(13, 'data');
     }
 
     /**

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -195,11 +195,18 @@ class PostTest extends TestCase
      */
     public function testPostsIndex()
     {
-        factory(Post::class, 10)->create();
+        $userId = $this->faker->northstar_id;
 
-        $response = $this->getJson('api/v3/posts');
+        // The user should only see accepted posts & their own.
+        factory(Post::class, 'accepted', 10)->create();
+        factory(Post::class, 3)->create(['northstar_id' => $userId]);
+        factory(Post::class, 'rejected', 5)->create();
+
+        $response = $this->withAccessToken($userId)->getJson('api/v3/posts');
 
         $response->assertStatus(200);
+        $response->assertJsonCount(13, 'data');
+
         $response->assertJsonStructure([
             'data' => [
                 '*' => [
@@ -234,6 +241,27 @@ class PostTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Test for retrieving all posts.
+     *
+     * GET /api/v3/posts
+     * @return void
+     */
+    public function testPostsIndexAsAdmin()
+    {
+        $userId = $this->faker->northstar_id;
+
+        // The admin should be able to see all of these posts!
+        factory(Post::class, 'accepted', 10)->create();
+        factory(Post::class, 3)->create(['northstar_id' => $userId]);
+        factory(Post::class, 'rejected', 5)->create();
+
+        $response = $this->withAccessToken($userId, 'admin')->getJson('api/v3/posts');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(18, 'data');
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This is just a quick demo of what we can do with OAuth now on our v3 routes! This pull request adds some rudimentary access control to the `v3/posts` index:

🤺 Users will now automatically see their own reaction count based on their OAuth token, rather than having to send an `as_user` parameter with a user ID.

✋ Users will not see other people's posts until they've been approved (unless they're an admin)!

#### How should this be reviewed?
I'd check commit-by-commit since e29b6a5 just extracts the `index` method out of the trait.

#### Any background context you want to provide?
This is just to demonstrate the cool things we can do with OAuth tokens (and because I want to use this as part of my GraphQL demo 😁), I'll work with @ngjo to put together some cards with other places we can do things like this in Rogue!

#### Relevant tickets
[#152602162](https://www.pivotaltracker.com/story/show/152602162)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.