### PR TITLE
Syslog default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_LOG=
+APP_LOG=daily
 APP_LOG_LEVEL=debug
 APP_URL=http://rogue.dev
 ROGUE_API_KEY=abc123

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
+APP_LOG=
 APP_LOG_LEVEL=debug
 APP_URL=http://rogue.dev
 ROGUE_API_KEY=abc123

--- a/config/app.php
+++ b/config/app.php
@@ -130,7 +130,7 @@ return [
     |
     */
 
-    'log' => env('APP_LOG', 'daily'),
+    'log' => env('APP_LOG', 'syslog'),
 
     'log_level' => env('APP_LOG_LEVEL', 'debug'),
 


### PR DESCRIPTION
#### What's this PR do?

Updates our logging configuration to write to the `syslog` by default, unless otherwise specified by the `APP_LOG` environment variable.

#### How should this be reviewed?

👀 

Also- any suggestions about how to confirm this is working on other environments?

#### Any background context you want to provide?

I am setting `APP_LOG=daily` on my local to continue getting daily log files for my development work, but using `syslog` on our other environments should allow us to see logs in heroku, logstash, etc.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/153261132

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.