### PR TITLE
Allow filtering signup index.

### DIFF
--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -80,6 +80,9 @@ class SignupsController extends ApiController
     {
         $query = $this->newQuery(Signup::class);
 
+        $filters = $request->query('filter');
+        $query = $this->filter($query, $filters, Signup::$indexes);
+
         return $this->paginatedCollection($query, $request);
     }
 


### PR DESCRIPTION
#### What's this PR do?
Just a tiny update! I wanted to be able to `filter[id]=1,2,3,4` & noticed it wasn't hooked up.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This allows other services to batch up requests for a handful of signups.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.