### PR TITLE
Send null instead of 'default' to Blink if post has default image 

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -102,8 +102,7 @@ class Post extends Model
     public function getMediaUrl()
     {
         if ($this->url === 'default') {
-            // @TODO: We should either return a placeholder, or `null`.
-            return 'default';
+            return null;
         }
 
         // If Glide is enabled, provide the default image URL.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -101,7 +101,7 @@ class Post extends Model
      */
     public function getMediaUrl()
     {
-        if ($this->url === 'default') {
+        if ($this->url === null) {
             return null;
         }
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -70,7 +70,7 @@ class PostRepository
 
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
         } else {
-            $fileUrl = 'default';
+            $fileUrl = null;
         }
 
         $signup = Signup::withCount('posts')->find($signupId);

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -267,7 +267,7 @@ export function getImageUrlFromProp(photoProp) {
   }
 
 
-  if (photo_url == null) {
+  if (photo_url == 'default' || photo_url == null) {
     return 'https://www.dosomething.org/sites/default/files/JenBugError.png';
   }
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -267,7 +267,7 @@ export function getImageUrlFromProp(photoProp) {
   }
 
 
-  if (photo_url == 'default') {
+  if (photo_url == null) {
     return 'https://www.dosomething.org/sites/default/files/JenBugError.png';
   }
 


### PR DESCRIPTION
#### What's this PR do?
If a post has a default image, send `null` instead of `default` to Blink. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/152517900) Pivotal Ticket.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.