### PR TITLE
Removes middleware so OAuth works correctly with a non-admin user

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -159,7 +159,7 @@ class PostsController extends ApiController
             return $this->item($post);
         }
 
-        throw new AuthorizationException('You don\'t have the correct role to do update this post!');
+        throw new AuthorizationException('You don\'t have the correct role to update this post!');
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -49,7 +49,6 @@ class PostsController extends ApiController
         $this->transformer = $transformer;
 
         $this->middleware('auth:api', ['only' => ['store', 'update', 'destroy']]);
-        $this->middleware('role:admin', ['only' => ['store', 'update', 'destroy']]); // @TODO: Allow anyone to use this.
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -49,6 +49,7 @@ class PostsController extends ApiController
         $this->transformer = $transformer;
 
         $this->middleware('auth:api', ['only' => ['store', 'update', 'destroy']]);
+        $this->middleware('role:admin', ['only' => ['destroy']]);
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -159,7 +159,7 @@ class PostsController extends ApiController
             return $this->item($post);
         }
 
-        throw new AuthorizationException('You don\'t have the correct role to do that!');
+        throw new AuthorizationException('You don\'t have the correct role to do update this post!');
     }
 
     /**

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -391,7 +391,7 @@ class PostTest extends TestCase
 
         $json = $response->json();
 
-        $this->assertEquals('You don\'t have the correct role to do that!', $json['message']);
+        $this->assertEquals('You don\'t have the correct role to update this post!', $json['message']);
     }
 
     /**

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -373,44 +373,6 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test that non-authenticated user's/apps can't update posts.
-     *
-     * @return void
-     */
-    public function testUnauthenticatedUserUpdatingAPost()
-    {
-        $post = factory(Post::class)->create();
-
-        $response = $this->json('PATCH', 'api/v3/posts/' . $post->id, [
-            'status' => 'accepted',
-            'caption' => 'new caption',
-        ]);
-
-        $response->assertStatus(401);
-    }
-
-    /**
-     * Test that a non-staff member or non-admin can't update posts.
-     *
-     * @return void
-     */
-    public function testUnAuthorizedUserUpdatingPost()
-    {
-        $user = factory(User::class)->create();
-        $post = factory(Post::class)->create();
-
-        $response = $this->withAccessToken($user->id)->patchJson('api/v3/posts/' . $post->id, [
-            'status' => 'accepted',
-            'caption' => 'new caption',
-        ]);
-
-        $response->assertStatus(403);
-
-        $json = $response->json();
-        $this->assertEquals('Requires one of the following roles: admin', $json['error']['message']);
-    }
-
-    /**
      * Test that a post gets deleted when hitting the DELETE endpoint.
      *
      * @return void

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -373,6 +373,28 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test that a non-staff member or non-admin can't update posts.
+     *
+     * @return void
+     */
+    public function testUnAuthorizedUserUpdatingPost()
+    {
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create();
+
+        $response = $this->withAccessToken($user->id)->patchJson('api/v3/posts/' . $post->id, [
+            'status' => 'accepted',
+            'caption' => 'new caption',
+        ]);
+
+        $response->assertStatus(403);
+
+        $json = $response->json();
+
+        $this->assertEquals('You don\'t have the correct role to do that!', $json['message']);
+    }
+
+    /**
      * Test that a post gets deleted when hitting the DELETE endpoint.
      *
      * @return void


### PR DESCRIPTION
#### What's this PR do?
- Removes middleware so OAuth works correctly with a non-admin user (and any user can use v3 endpoints).
- Removes tests that only allow admins to make these requests (except for `DELETE /v3/posts`).
#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.