### PR TITLE
Quantity validation bug

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -154,7 +154,7 @@ class Post extends Model
     public function toBlinkPayload()
     {
         // Blink expects quantity to be a number.
-        $quantity = $this->quantity = null ? 0 : $this->quantity;
+        $quantity = $this->quantity === null ? 0 : $this->quantity;
 
         return [
             'id' => $this->id,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -153,10 +153,13 @@ class Post extends Model
      */
     public function toBlinkPayload()
     {
+        // Blink expects quantity to be a number.
+        $quantity = $this->quantity = null ? 0 : $this->quantity;
+
         return [
             'id' => $this->id,
             'signup_id' => $this->signup_id,
-            'quantity' => $this->quantity,
+            'quantity' => $quantity,
             'why_participated' => $this->signup->why_participated,
             'campaign_id' => (string) $this->campaign_id,
             'campaign_run_id' => (string) $this->signup->campaign_run_id,

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -115,12 +115,15 @@ class Signup extends Model
      */
     public function toBlinkPayload()
     {
+        // Blink expects quantity to be a number.
+        $quantity = $this->quantity === null ? 0 : $this->quantity;
+
         return [
             'id' => $this->id,
             'northstar_id' => $this->northstar_id,
             'campaign_id' => (string) $this->campaign_id,
             'campaign_run_id' => (string) $this->campaign_run_id,
-            'quantity' => $this->quantity,
+            'quantity' => $quantity,
             'why_participated' => $this->why_participated,
             'source' => $this->source,
             'created_at' => $this->created_at->toIso8601String(),


### PR DESCRIPTION
#### What's this PR do?

Blink is sending us a bunch of validation errors because we are sending `null` quantity over to it now. This is related to the most recent deploy, but I am not clear on how to rollback the deploy on jenkins. This is a hotfix that will just send over 0 if quantity is `null` which should clear up the errors. 


#### How should this be reviewed?

👀 

#### Any background context you want to provide?
https://dosomething.slack.com/archives/C0YGXUE01/p1513010104000973

