### PR TITLE
Add script that will clean up extraneous posts we received

### DIFF
--- a/app/Console/Commands/PostCleanup.php
+++ b/app/Console/Commands/PostCleanup.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use DB;
+use Rogue\Models\Post;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class PostCleanup extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:postcleanup {date=2017-12-11}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clean up duplicate posts caused by blink erroring out and resending post requests';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Date of bug
+        $date = $this->argument('date');
+
+        // Grab all the posts we received on the given date and
+        // group by the submissions having more than 1 of the same caption.
+        $postsByCaption = Post::select(DB::raw('signup_id, caption, COUNT(caption) as caption_count'))
+            ->whereDate('created_at', $date)
+            ->groupBy(['caption', 'signup_id'])
+            ->having('caption_count', '>', 1)
+            ->get();
+
+        $this->info('There are ' . $postsByCaption->count() . ' posts with more than 1 of the same caption');
+
+        // Loop through all the posts that have the
+        // same caption per signup and delete all but the most recent one.
+        foreach ($postsByCaption as $postCaption) {
+            $this->info('Getting posts under signup ' . $postCaption->signup_id);
+            $userPosts = Post::where('signup_id', $postCaption->signup_id)
+                ->whereDate('created_at', $date)
+                ->orderBy('created_at', 'asc')
+                ->get();
+
+            $mostRecent = $userPosts->pop();
+
+            foreach ($userPosts as $post) {
+                if ($mostRecent->id !== $post->id) {
+                    $this->info('Deleting post ' . $post->id);
+
+                    Storage::delete($post->url);
+
+                    // Force delete so we really get rid of extraneous records.
+                    $post->forceDelete();
+
+                    $this->info('post ' . $post->id . ' deleted!');
+                }
+
+            }
+        }
+
+        $this->info('Cleanup Complete!');
+    }
+}

--- a/app/Console/Commands/PostCleanup.php
+++ b/app/Console/Commands/PostCleanup.php
@@ -77,7 +77,6 @@ class PostCleanup extends Command
 
                     $this->info('post ' . $post->id . ' deleted!');
                 }
-
             }
         }
 

--- a/app/Console/Commands/PostCleanup.php
+++ b/app/Console/Commands/PostCleanup.php
@@ -57,7 +57,9 @@ class PostCleanup extends Command
         // same caption per signup and delete all but the most recent one.
         foreach ($postsByCaption as $postCaption) {
             $this->info('Getting posts under signup ' . $postCaption->signup_id);
+
             $userPosts = Post::where('signup_id', $postCaption->signup_id)
+                ->where('caption', $postCaption->caption)
                 ->whereDate('created_at', $date)
                 ->orderBy('created_at', 'asc')
                 ->get();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -17,6 +17,7 @@ class Kernel extends ConsoleKernel
         Commands\SetupCommand::class,
         Commands\ImportSignupsCommand::class,
         Commands\PostQuantity::class,
+        Commands\PostCleanup::class,
     ];
 
     /**


### PR DESCRIPTION
#### What's this PR do?

This PR adds a command `php artisan rogue:postcleanup {date}` that will go through all the posts we received on the given date, find the duplicate submissions (by checking for duplicate `captions`) and then delete all but the most recent submission from the DB. 

#### How should this be reviewed?

👀 

Definitely double check the deletion logic: 

I used `$post->forceDelete()` to truly delete the record from the DB because we don't want a record of these bad posts. 

I used `Storage::delete({path_to_file})` to delete the image from storage. 

#### Any background context you want to provide?

This script is meant to clean up the duplicate posts we receive because of this bug: 
https://github.com/orgs/DoSomething/teams/team-bleed/discussions/5

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.