### PR TITLE
Script to make default urls null

### DIFF
--- a/app/Console/Commands/MakeDefaultURLsNull.php
+++ b/app/Console/Commands/MakeDefaultURLsNull.php
@@ -40,11 +40,14 @@ class MakeDefaultURLsNull extends Command
     {
         info('rogue:nullurl: Starting!');
 
-        // Create the progress bar
-        $bar = $this->output->createProgressBar(Post::where('url', 'default')->count());
+        // All posts that have "default" set as their url
+        $query = Post::where('url', 'default');
 
-        // Get all posts with "default" for the url
-        $posts = Post::where('url', 'default')->chunkById(100, function ($posts) use ($bar) {
+        // Create the progress bar
+        $bar = $this->output->createProgressBar($query->count());
+
+        // Update all the posts
+        $query->chunkById(100, function ($posts) use ($bar) {
             // Set all of the "default"s to null
             foreach ($posts as $post) {
                 info('rogue:nullurl: Nulling url for post ' . $post->id);
@@ -54,6 +57,7 @@ class MakeDefaultURLsNull extends Command
             }
         });
 
+        // Finish the progress bar
         $bar->finish();
         info('rogue:nullurl: All done!');
     }

--- a/app/Console/Commands/MakeDefaultURLsNull.php
+++ b/app/Console/Commands/MakeDefaultURLsNull.php
@@ -40,19 +40,19 @@ class MakeDefaultURLsNull extends Command
     {
         info('rogue:nullurl: Starting!');
 
-        // Get all posts with "default" for the url
-        $posts = Post::where('url', 'default')->get();
-
         // Create the progress bar
-        $bar = $this->output->createProgressBar($posts->count());
+        $bar = $this->output->createProgressBar(Post::where('url', 'default')->count());
 
-        // Set all of the "default"s to null
-        foreach ($posts as $post) {
-            info('rogue:nullurl: Nulling url for post ' . $post->id);
-            $post->url = null;
-            $post->save();
-            $bar->advance();
-        }
+        // Get all posts with "default" for the url
+        $posts = Post::where('url', 'default')->orderBy('id')->chunk(100, function ($posts) use ($bar) {
+            // Set all of the "default"s to null
+            foreach ($posts as $post) {
+                info('rogue:nullurl: Nulling url for post ' . $post->id);
+                $post->url = null;
+                $post->save();
+                $bar->advance();
+            }
+        });
 
         $bar->finish();
         info('rogue:nullurl: All done!');

--- a/app/Console/Commands/MakeDefaultURLsNull.php
+++ b/app/Console/Commands/MakeDefaultURLsNull.php
@@ -44,7 +44,7 @@ class MakeDefaultURLsNull extends Command
         $bar = $this->output->createProgressBar(Post::where('url', 'default')->count());
 
         // Get all posts with "default" for the url
-        $posts = Post::where('url', 'default')->orderBy('id')->chunk(100, function ($posts) use ($bar) {
+        $posts = Post::where('url', 'default')->chunkById(100, function ($posts) use ($bar) {
             // Set all of the "default"s to null
             foreach ($posts as $post) {
                 info('rogue:nullurl: Nulling url for post ' . $post->id);

--- a/app/Console/Commands/MakeDefaultURLsNull.php
+++ b/app/Console/Commands/MakeDefaultURLsNull.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Post;
+use Illuminate\Console\Command;
+
+class MakeDefaultURLsNull extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:nullurl';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Change "default" URLs in the Posts table to null';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        info('rogue:nullurl: Starting!');
+
+        // Get all posts with "default" for the url
+        $posts = Post::where('url', 'default')->get();
+
+        // Create the progress bar
+        $bar = $this->output->createProgressBar($posts->count());
+
+        // Set all of the "default"s to null
+        foreach ($posts as $post) {
+            info('rogue:nullurl: Nulling url for post ' . $post->id);
+            $post->url = null;
+            $post->save();
+            $bar->advance();
+        }
+
+        $bar->finish();
+        info('rogue:nullurl: All done!');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends ConsoleKernel
         Commands\ImportSignupsCommand::class,
         Commands\PostQuantity::class,
         Commands\PostCleanup::class,
+        Commands\MakeDefaultURLsNull::class,
     ];
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This is a shiny new artisan command to go through all of our posts with a `url` of `default` and set that to `null` instead. We probably do not want to run this until we are storing incoming borked images as `null` or we will have to run it twice (running it twice is no problem technically though).

#### How should this be reviewed?
Will this do what I said it would?

#### Relevant tickets
[card](https://www.pivotaltracker.com/story/show/153491711)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.