### PR TITLE
GET /v3/posts?include=signup bug

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -69,7 +69,6 @@ class PostsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)
-            ->with('signup')
             ->withCount('reactions')
             ->with('tags')
             ->orderBy('created_at', 'desc');

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -69,6 +69,7 @@ class PostsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)
+            ->with('signup')
             ->withCount('reactions')
             ->with('tags')
             ->orderBy('created_at', 'desc');

--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -5,7 +5,6 @@ namespace Rogue\Http\Transformers\Three;
 use Carbon\Carbon;
 use Rogue\Models\Post;
 use League\Fractal\TransformerAbstract;
-use Rogue\Http\Transformers\Three\SignupTransformer;
 
 class PostTransformer extends TransformerAbstract
 {

--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -5,6 +5,7 @@ namespace Rogue\Http\Transformers\Three;
 use Carbon\Carbon;
 use Rogue\Models\Post;
 use League\Fractal\TransformerAbstract;
+use Rogue\Http\Transformers\Three\SignupTransformer;
 
 class PostTransformer extends TransformerAbstract
 {
@@ -65,10 +66,7 @@ class PostTransformer extends TransformerAbstract
      */
     public function includeSignup(Post $post)
     {
-        // Don't include posts but include the user.
-        $transformer = (new SignupTransformer)->setDefaultIncludes(['user']);
-
-        return $this->item($post->signup, $transformer);
+        return $this->item($post->signup, new SignupTransformer);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Fixed bug to get `GET /v3/posts?include=signup` working again.

#### How should this be reviewed?
- Hit `GET /v3/posts?include=signup` and you should receive posts with their associated signup. 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/153458101) Pivotal ticket

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.