### PR TITLE
Increase PHP memory limit.

### DIFF
--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,2 +1,3 @@
 upload_max_filesize = 10M
 post_max_size = 10M
+memory_limit = 256M


### PR DESCRIPTION
#### What's this PR do?
We're seeing errors whenever users try to upload files above ~1MB:

```
Dec 12 14:16:19 rogue-thor app/web.1:  [12-Dec-2017 22:16:18 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 24576 bytes) in /app/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php on line 136 
Dec 12 14:16:19 rogue-thor app/web.1:  [12-Dec-2017 22:16:18 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /app/vendor/symfony/debug/Exception/FatalErrorException.php on line 1 
Dec 12 14:16:26 rogue-thor app/web.1:  [12-Dec-2017 22:16:25 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 24576 bytes) in /app/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php on line 136 
Dec 12 14:16:26 rogue-thor app/web.1:  [12-Dec-2017 22:16:25 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /app/vendor/symfony/debug/Exception/FatalErrorException.php on line 1 
Dec 13 13:00:38 rogue-thor app/web.1:  [13-Dec-2017 21:00:37 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 16384 bytes) in /app/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php on line 136 
Dec 13 13:00:38 rogue-thor app/web.1:  [13-Dec-2017 21:00:37 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /app/vendor/symfony/debug/Exception/FatalErrorException.php on line 1 
Dec 13 13:01:53 rogue-thor app/web.1:  [13-Dec-2017 21:01:52 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 16384 bytes) in /app/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php on line 136 
Dec 13 13:01:53 rogue-thor app/web.1:  [13-Dec-2017 21:01:52 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /app/vendor/symfony/debug/Exception/FatalErrorException.php on line 1 
Dec 13 13:02:17 rogue-thor app/web.1:  [13-Dec-2017 21:02:16 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 16384 bytes) in /app/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php on line 136 
Dec 13 13:02:17 rogue-thor app/web.1:  [13-Dec-2017 21:02:16 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 73728 bytes) in /app/vendor/composer/ClassLoader.php on line 444 
Dec 13 13:05:57 rogue-thor app/web.1:  [13-Dec-2017 21:05:57 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 16384 bytes) in /app/vendor/intervention/image/src/Intervention/Image/Gd/Decoder.php on line 136 
Dec 13 13:05:57 rogue-thor app/web.1:  [13-Dec-2017 21:05:57 UTC] PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes) in /app/vendor/symfony/debug/Exception/FatalErrorException.php on line 1 
```

I'm a little surprised that the default setting isn't enough here, but it's worth a try!

#### How should this be reviewed?
🤷‍♂️

#### Any background context you want to provide?
📝

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.