### PR TITLE
Add support for using ImageMagick on Heroku.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "league/csv": "^9.0",
     "dfurnes/environmentalist": "0.0.2",
     "ext-gd" : "*",
-    "ext-exif":"*"
+    "ext-exif":"*",
+    "ext-imagick": "*"
   },
   "require-dev": {
     "fzaninotto/faker": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "db2a21ac76ef1c11c1aee142821f2358",
+    "content-hash": "3f8ebea1c416612465a6228c8f0da1bc",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.45.3",
+            "version": "3.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "d0abb0b1194fa64973b135191f56df991bc5787c"
+                "reference": "6707345b9e6d670aa45209310b930857043a4557"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d0abb0b1194fa64973b135191f56df991bc5787c",
-                "reference": "d0abb0b1194fa64973b135191f56df991bc5787c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6707345b9e6d670aa45209310b930857043a4557",
+                "reference": "6707345b9e6d670aa45209310b930857043a4557",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-12-08T21:36:50+00:00"
+            "time": "2017-12-12T20:10:41+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -6226,7 +6226,8 @@
     "platform": {
         "php": "~7.0.0",
         "ext-gd": "*",
-        "ext-exif": "*"
+        "ext-exif": "*",
+        "ext-imagick": "*"
     },
     "platform-dev": []
 }

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports "GD Library" and "Imagick" to process images
+    | internally. You may choose one of them according to your PHP
+    | configuration. By default PHP's "GD Library" implementation is used.
+    |
+    | Supported: "gd", "imagick"
+    |
+    */
+
+    'driver' => env('IMAGE_DRIVER', 'gd'),
+
+];

--- a/wercker.yml
+++ b/wercker.yml
@@ -12,6 +12,12 @@ build:
           code: |-
             mysql -u homestead -psecret -e "CREATE DATABASE rogue_test;"
             cp .env.example .env
+      - script:
+          name: install imagemagick
+          code: |-
+            sudo apt-get update
+            sudo apt-get install -y imagemagick php-imagick
+            sudo service php7.0-fpm restart
       - leipert/composer-install@0.9.1
       - wercker/npm-install
       - script:


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `IMAGE_DRIVER` environment variable, and instructs Heroku to install the [ImageMagick PHP extension](http://php.net/manual/en/book.imagick.php) so we can test out `IMAGE_DRIVER = imagick` there.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Switching to use ImageMagick on Heroku should provide a good performance boost when resizing/cropping images, which will help us more efficiently handle larger image uploads.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.