### PR TITLE
Parse REDIS_URL into corresponding environment vars.

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,15 @@
 <?php
 
+// Convert Heroku's `REDIS_URL` to standard `REDIS_HOST`, `REDIS_PORT`,
+// and `REDIS_PASSWORD` environment variables:
+if (env('REDIS_URL')) {
+    $url = parse_url(env('REDIS_URL'));
+
+    putenv('REDIS_HOST='.$url['host']);
+    putenv('REDIS_PORT='.$url['port']);
+    putenv('REDIS_PASSWORD='.$url['pass']);
+}
+
 return [
 
     /*


### PR DESCRIPTION
#### What's this PR do?
This pull request allows us to use the configured [Heroku Redis](https://devcenter.heroku.com/articles/heroku-redis) addons on each of our applications, which automatically set a `REDIS_URL` environment variable that needs to be parsed into the expected `REDIS_HOST`, `REDIS_PASSWORD`, and `REDIS_PORT`.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
We were connecting both production & Thor environments to the same ElastiCache instance which is like, very not ideal. This will let us quickly get Thor on it's own instance, and we can consider pushing this up to production tomorrow as well.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.