### PR TITLE
Removes endpoint from documentation that doesn't exist

### DIFF
--- a/documentation/endpoints/posts.md
+++ b/documentation/endpoints/posts.md
@@ -162,20 +162,3 @@ Example Response:
   }
 }
 ```
-
-## Delete a post 
-
-Allows admins to delete a post. Posts get soft deleted from the database.
-
-```
-DELETE /api/v2/posts/{post_id}
-```
-
-Example Response:
-
-```
-{
-  "code": 200,
-  "message": "Post deleted."
-}
-```


### PR DESCRIPTION
#### What's this PR do?
Removes `DELETE /api/v2/posts/{post_id}` from documentation because this doesn't exist (this is a web route!) 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Should we add web routes to the documentation? 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.