### PR TITLE
Excludes soft deleted posts in count for pending posts per campaign 

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -220,7 +220,7 @@ class CampaignService
                 ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
                 ->selectRaw('signups.campaign_id, count(posts.id) as pending_count')
                 ->where('status', '=', 'pending')
-                ->where('posts.deleted_at', '=', NULL)
+                ->where('posts.deleted_at', '=', null)
                 ->wherein('signups.campaign_id', $ids)
                 ->groupBy('signups.campaign_id')
                 ->get();

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -220,6 +220,7 @@ class CampaignService
                 ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
                 ->selectRaw('signups.campaign_id, count(posts.id) as pending_count')
                 ->where('status', '=', 'pending')
+                ->where('posts.deleted_at', '=', NULL)
                 ->wherein('signups.campaign_id', $ids)
                 ->groupBy('signups.campaign_id')
                 ->get();

--- a/resources/assets/components/Table/CampaignRow.js
+++ b/resources/assets/components/Table/CampaignRow.js
@@ -10,6 +10,7 @@ class CampaignRow extends React.Component {
   }
 
   createCampaignRow(campaign) {
+    console.log('hi');
     const row = [
       {
         url: campaign ? `/campaigns/${campaign.id}` : '/campaigns',

--- a/resources/assets/components/Table/CampaignRow.js
+++ b/resources/assets/components/Table/CampaignRow.js
@@ -10,7 +10,6 @@ class CampaignRow extends React.Component {
   }
 
   createCampaignRow(campaign) {
-    console.log('hi');
     const row = [
       {
         url: campaign ? `/campaigns/${campaign.id}` : '/campaigns',


### PR DESCRIPTION
#### What's this PR do?
- This PR fixes the bug we were seeing with inconsistent Pending Post counts on the Campaign Overview page (the Pending number would be 2 but then when clicking review, there would be no posts to review in the inbox). 
- This was because it was counting posts that had been soft deleted when making the count query. However, when pulling the actual posts that needed to be reviewed in the campaign inbox page, it did not include posts that have been soft deleted.
- This PR adds a line in the query to only count those posts whose `deleted_at = NULL`

#### How should this be reviewed?
👀 
- To test on local, find a campaign that has 0 pending posts to review. 
- Change a post's status to pending (that has been soft deleted). 
- You should still see the Pending count on the Campaign Overview page for the campaign to say 0. 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/152892786) Pivotal Ticket. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.