### PR TITLE
Log resource actions 

### DIFF
--- a/app/Http/Controllers/Api/ReviewsController.php
+++ b/app/Http/Controllers/Api/ReviewsController.php
@@ -57,6 +57,12 @@ class ReviewsController extends ApiController
         $reviewedPostCode = $this->code($reviewedPost);
 
         if (isset($reviewedPost)) {
+            info('post_reviewed', [
+                'id' => $reviewedPost->id,
+                'admin_northstar_id' => $review['admin_northstar_id'],
+                'status' => $reviewedPost->status,
+            ]);
+
             return $this->item($reviewedPost, $reviewedPostCode);
         } else {
             throw (new ModelNotFoundException)->setModel('Post');

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -59,6 +59,12 @@ class ReviewsController extends Controller
         $meta = [];
 
         if (isset($reviewedPost)) {
+            logger()->info('post_reviewed', [
+                'id' => $reviewedPost->id,
+                'admin_northstar_id' => $review['admin_northstar_id'],
+                'status' => $reviewedPost->status
+            ]);
+
             return $this->item($reviewedPost, $reviewedPostCode);
         } else {
             throw (new ModelNotFoundException)->setModel('Post');

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -59,10 +59,10 @@ class ReviewsController extends Controller
         $meta = [];
 
         if (isset($reviewedPost)) {
-            logger()->info('post_reviewed', [
+            info('post_reviewed', [
                 'id' => $reviewedPost->id,
                 'admin_northstar_id' => $review['admin_northstar_id'],
-                'status' => $reviewedPost->status
+                'status' => $reviewedPost->status,
             ]);
 
             return $this->item($reviewedPost, $reviewedPostCode);

--- a/app/Listeners/SendTaggedNotification.php
+++ b/app/Listeners/SendTaggedNotification.php
@@ -29,7 +29,10 @@ class SendTaggedNotification
         $post = $event->post;
         $tag = $event->tag;
 
-        info('Post tagged:', ['tag' => $tag->tag_name]);
+        info('post_tagged', [
+            'id' => $post->id,
+            'tag' => $tag->tag_slug,
+        ]);
 
         if ($tag->tag_slug === 'good-for-storytelling') {
             Notification::route('slack', config('services.slack.url'))

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -49,6 +49,9 @@ class PostService
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 
+        // Log that a post was created.
+        logger()->info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+
         return $post;
     }
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -89,6 +89,10 @@ class PostService
      */
     public function destroy($postId)
     {
+        info('post_deleted', [
+            'id' => $postId,
+        ]);
+
         return $this->repository->destroy($postId);
     }
 }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -50,7 +50,7 @@ class PostService
         request()->headers->set('X-Request-ID', $transactionId);
 
         // Log that a post was created.
-        logger()->info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
 
         return $post;
     }

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -47,6 +47,9 @@ class SignupService
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 
+        // Log that a signup was created.
+        logger()->info('signup_created', ['id' => $signup->id]);
+
         return $signup;
     }
 

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -48,7 +48,7 @@ class SignupService
         request()->headers->set('X-Request-ID', $transactionId);
 
         // Log that a signup was created.
-        logger()->info('signup_created', ['id' => $signup->id]);
+        info('signup_created', ['id' => $signup->id]);
 
         return $signup;
     }

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -51,7 +51,7 @@ class PostService
         request()->headers->set('X-Request-ID', $transactionId);
 
         // Log that a post was created.
-        logger()->info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
 
         return $post;
     }

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -90,6 +90,10 @@ class PostService
      */
     public function destroy($postId)
     {
+        info('post_deleted', [
+            'id' => $postId,
+        ]);
+
         return $this->repository->destroy($postId);
     }
 }

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -50,6 +50,9 @@ class PostService
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 
+        // Log that a post was created.
+        logger()->info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+
         return $post;
     }
 

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -48,6 +48,9 @@ class SignupService
         // Add new transaction id to header.
         request()->headers->set('X-Request-ID', $transactionId);
 
+        // Log that a signup was created.
+        logger()->info('signup_created', ['id' => $signup->id]);
+
         return $signup;
     }
 

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -49,7 +49,7 @@ class SignupService
         request()->headers->set('X-Request-ID', $transactionId);
 
         // Log that a signup was created.
-        logger()->info('signup_created', ['id' => $signup->id]);
+        info('signup_created', ['id' => $signup->id]);
 
         return $signup;
     }


### PR DESCRIPTION
#### What's this PR do?
Adds some low level log messages to rogue so we know when the basic significant events happen. 

Logs when a signup is created, a post is created, a post is reviewed, a post is tagged, a post is deleted. 

I standardized the log message format to be in the form of `resource_action` (i.e `signup_created`) 

This will allow us to do some easy searching in log aggregators like Papertrail and create some easy charts/alerts that will show us trends in how many of these events happen each day. 

#### How should this be reviewed?

👀 

I do most logging in the Service classes since it is sort of business logic and I don't want to pollute other functionality with log messages. However, for things such as tagging and reviewing, it had to be done in-line with where tagging and reviewing happen. 

#### Any background context you want to provide?

We want to be able to see if we see dips or spikes in our application easily. For example, if we know we usually get 1000 signups a day and we only got 500 one day, then something might be wrong. 

#### Relevant tickets
Addresses https://www.pivotaltracker.com/story/show/153524667