### PR TITLE
Log post event anytime we send to blink

### DIFF
--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -73,6 +73,9 @@ class PostService
         // Save the new post in Customer.io, via Blink.
         if (config('features.blink') && $postOrSignup instanceof Post && $should_send_to_blink) {
             SendPostToBlink::dispatch($postOrSignup);
+
+            // Log that a post was created.
+            info('post_created', ['id' => $postOrSignup->id, 'signup_id' => $postOrSignup->signup_id]);
         }
 
         // Add new transaction id to header.

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -48,7 +48,7 @@ class SignupService
         request()->headers->set('X-Request-ID', $transactionId);
 
         // Log that a signup was created.
-        info('signup_created', ['id' => $signup->id]);
+        info('signup_created', ['id' => $signup->id, 'northstar_id' => $signup->northstar_id]);
 
         return $signup;
     }

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -74,6 +74,9 @@ class PostService
         // Save the new post in Customer.io, via Blink.
         if (config('features.blink') && $postOrSignup instanceof Post && $should_send_to_blink) {
             SendPostToBlink::dispatch($postOrSignup);
+
+            // Log that a post was created.
+            info('post_created', ['id' => $postOrSignup->id, 'signup_id' => $postOrSignup->signup_id]);
         }
 
         // Add new transaction id to header.


### PR DESCRIPTION
#### What's this PR do?
Just a small update to follow up on my previous PR (#559 )

We need to send the `post_created` event when we move through the update functionality even though we are creating a post. This follows the logic of when we send posts to blink.

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

We have a card in our backlog to work through this logic. When we create a new post we shouldn't consider it an update. 

