### PR TITLE
Adds New Tags and Ability to Tag on Accepted and Rejected Posts 

### DIFF
--- a/resources/assets/components/Post/__snapshots__/test.js.snap
+++ b/resources/assets/components/Post/__snapshots__/test.js.snap
@@ -116,6 +116,107 @@ exports[`it renders correctly 1`] = `
             </button>
           </li>
         </ul>
+        <div>
+          <h4
+            className="disabled"
+          >
+            Tags
+          </h4>
+          <ul
+            className="aligned-actions"
+          >
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Good Photo
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Good Quote
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Hide In Gallery 👻
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Good For Sponsor
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Good For Storytelling
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Irrelevant
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Inappropriate
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Unrealistic Quantity
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Test
+              </button>
+            </li>
+            <li>
+              <button
+                className="tag"
+                disabled={true}
+                onClick={[Function]}
+              >
+                Incomplete Action
+              </button>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div
@@ -132,6 +233,7 @@ exports[`it renders correctly 1`] = `
         <span>
           Post ID
           : 
+          123
           <br />
         </span>
         <span>

--- a/resources/assets/components/Post/test.js
+++ b/resources/assets/components/Post/test.js
@@ -5,8 +5,10 @@ import Post from './index';
 
 test('it renders correctly', () => {
   const post = {
+    id: 123,
     caption: 'Here is my awesome caption!',
     status: 'pending',
+    tags: [],
   };
 
   const signup = {

--- a/resources/assets/components/ReviewBlock/__snapshots__/test.js.snap
+++ b/resources/assets/components/ReviewBlock/__snapshots__/test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`it renders accepted, rejected, and delete buttons 1`] = `
+exports[`it renders accepted, rejected, disabled tags, and delete buttons 1`] = `
 <div>
   <ul
     className="form-actions -inline"
@@ -23,48 +23,6 @@ exports[`it renders accepted, rejected, and delete buttons 1`] = `
         label="reject"
         setStatus={[Function]}
         status="pending"
-        type="rejected"
-      />
-    </li>
-  </ul>
-  <ul
-    className="form-actions -inline"
-  >
-    <li>
-      <button
-        className="button delete -tertiary"
-        onClick={[Function]}
-      >
-        Delete
-      </button>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`it renders the review block with tags 1`] = `
-<div>
-  <ul
-    className="form-actions -inline"
-    style={
-      Object {
-        "marginTop": 0,
-      }
-    }
-  >
-    <li>
-      <StatusButton
-        label="accept"
-        setStatus={[Function]}
-        status="accepted"
-        type="accepted"
-      />
-    </li>
-    <li>
-      <StatusButton
-        label="reject"
-        setStatus={[Function]}
-        status="accepted"
         type="rejected"
       />
     </li>
@@ -82,7 +40,8 @@ exports[`it renders the review block with tags 1`] = `
     </li>
   </ul>
   <Tags
-    id={71}
+    disabled={true}
+    id={1}
     onTag={[Function]}
     tagged={Array []}
   />

--- a/resources/assets/components/ReviewBlock/index.js
+++ b/resources/assets/components/ReviewBlock/index.js
@@ -22,7 +22,7 @@ class ReviewBlock extends React.Component {
         <ul className="form-actions -inline">
           <li><button className="button delete -tertiary" onClick={e => this.props.deletePost(post.id, e)}>Delete</button></li>
         </ul>
-        <Tags id={post.id} tagged={post.tags} onTag={this.props.onTag} disableTags={disableTags}/>
+        <Tags id={post.id} tagged={post.tags} onTag={this.props.onTag} disabled={disableTags}/>
       </div>
     );
   }

--- a/resources/assets/components/ReviewBlock/index.js
+++ b/resources/assets/components/ReviewBlock/index.js
@@ -11,7 +11,7 @@ class ReviewBlock extends React.Component {
 
   render() {
     const post = this.props.post;
-    const disableTags = post.status === 'accepted' || post.status === 'rejected' ? false : true;
+    const disableTags = ! (post.status === 'accepted' || post.status === 'rejected');
 
     return (
       <div>

--- a/resources/assets/components/ReviewBlock/index.js
+++ b/resources/assets/components/ReviewBlock/index.js
@@ -11,6 +11,7 @@ class ReviewBlock extends React.Component {
 
   render() {
     const post = this.props.post;
+    const disableTags = post.status === 'accepted' || post.status === 'rejected' ? false : true;
 
     return (
       <div>
@@ -21,9 +22,7 @@ class ReviewBlock extends React.Component {
         <ul className="form-actions -inline">
           <li><button className="button delete -tertiary" onClick={e => this.props.deletePost(post.id, e)}>Delete</button></li>
         </ul>
-        {post.status === 'accepted' ?
-          <Tags id={post.id} tagged={post.tags} onTag={this.props.onTag} />
-          : null}
+        <Tags id={post.id} tagged={post.tags} onTag={this.props.onTag} disableTags={disableTags}/>
       </div>
     );
   }

--- a/resources/assets/components/ReviewBlock/test.js
+++ b/resources/assets/components/ReviewBlock/test.js
@@ -52,84 +52,50 @@ test('it renders an active Accept button when clicked', () => {
   );
 
   // Tags should be disabled.
-  expect(component.find('.disabled').first().text()).toBe('Tags');
-  // expect(component.find('.tag').first().is('[disabled]')).toBe(true);
+  expect(component.find('.tag').first().is('[disabled]')).toBe(true);
 
   // Click the "Accept" button.
   component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').simulate('click');
   expect(onUpdate).toHaveBeenCalled();
 
-  component.update();
-  console.log(component.debug());
+  // The "Accept" button should be "loading".
+  expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first().hasClass('button -accepted is-loading'));
 
-  // It should now show the active "Accept" button.
-  expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first().hasClass('button -outlined-button -accepted is-selected'));
-  // const acceptButton = component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first();
-  // expect(acceptButton.props().status).to.equal('accepted');
-  // expect(component.find('.accepted').first().hasClass('button -outlined-button -accepted is-selected'));
-
-  // Tags should now be enabled.
-  // expect(component.find('.tag').first().is('[disabled]')).toBe(false);
-  // expect(component.find('.enabled').first().text()).toBe('Tags');
+  // The "Reject" button should not be "loading".
+  expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'rejected').first().hasClass('button -outlined-button -rejected'));
 });
 
-// test('it renders an active Reject button when clicked', () => {
-//   const post = {
-//     status: 'pending',
-//     tags: [],
-//     id: 71,
-//   };
+test('it renders an active Reject button when clicked', () => {
+  const post = {
+    status: 'pending',
+    tags: [],
+    id: 71,
+  };
 
-//   const deletePost = function () {
-//     return true;
-//   };
+  const deletePost = function () {
+    return true;
+  };
 
-//   const onUpdate = function () {
-//     return true;
-//   };
+  const onUpdate = jest.fn(() => Promise.resolve(true));
 
-//   const onTag = function () {
-//     return true;
-//   };
+  const onTag = function () {
+    return true;
+  };
 
-//   const component = mount(
-//     <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
-//   );
+  const component = mount(
+    <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
+  );
 
-//   // Click the "Reject" button.
-//   component.find('.rejected').first().simulate('click');
+  // Tags should be disabled.
+  expect(component.find('.tag').first().is('[disabled]')).toBe(true);
 
-//   // It should now show the active "Reject" button.
-//   expect(component.find('.rejected').first().hasClass('button -outlined-button -rejected is-selected'));
-// });
+  // Click the "Reject" button.
+  component.find('StatusButton').findWhere(n => n.prop('type') === 'rejected').simulate('click');
+  expect(onUpdate).toHaveBeenCalled();
 
-// test('it renders an active tag button when clicked', () => {
-//   const post = {
-//     status: 'accepted',
-//     tags: [],
-//     id: 71,
-//   };
+  // The "Reject" button should be "loading".
+  expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first().hasClass('button -rejected is-loading'));
 
-//   const deletePost = function () {
-//     return true;
-//   };
-
-//   const onUpdate = function () {
-//     return true;
-//   };
-
-//   const onTag = function () {
-//     return true;
-//   };
-
-//   const component = mount(
-//     <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
-//   );
-
-//   // Click a tag button.
-//   component.find('.tag').first().simulate('click');
-
-//   // It should now show the active tag button.
-//   expect(component.find('.tag').first().hasClass('is-active'));
-// });
-
+  // The "Accept" button should not be "loading".
+  expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'rejected').first().hasClass('button -outlined-button -accepted'));
+});

--- a/resources/assets/components/ReviewBlock/test.js
+++ b/resources/assets/components/ReviewBlock/test.js
@@ -41,9 +41,7 @@ test('it renders an active Accept button when clicked', () => {
     return true;
   };
 
-  const onUpdate = function () {
-    return true;
-  };
+  const onUpdate = jest.fn(() => Promise.resolve(true));
 
   const onTag = function () {
     return true;
@@ -54,42 +52,25 @@ test('it renders an active Accept button when clicked', () => {
   );
 
   // Tags should be disabled.
+  expect(component.find('.disabled').first().text()).toBe('Tags');
   // expect(component.find('.tag').first().is('[disabled]')).toBe(true);
-  // expect(component.find('.tag').first().disabled).toBe(true);
-  // expect(component.find('.tag').first()).toBe('disabled');
-  // expect(component.find('.disabled').first().toBe(true));
-  // expect(component.find('.tag.disabled').first().toBe(true));
-  // const disabledTag = component.find('.tag').first();
-  // expect(disabledTag.disabled).toEqual(true);
-  // expect(component.find('.disabled').first()).toBe('Tags');
-  // expect(component.find('.disabled').first()).toEqual('Tags');
-  // expect(component.find('.disabled').to.be('Tags'));
-  // expect(component.find('.disabled').toEqual('Tags'));
-  // expect(component.find('.disabled').first().text()).toBe('Tags');
-  // expect(component.find('.disabled').first().text()).toEqual('Tags');
-  // const disabledTag = component.find('.tag Tag').first();
-  // disabledTag.simulate('click');
-  // component.find('.tag').first().simulate('click');
-  // expect(disabledTag).toEqual(true);
 
-  // Click the "Accept" button and mock the handleClick function from the StatusButton component.
-  const mockUpdate = jest.fn(() => Promise.resolve(true));
-  const wrapper = mount(<ReviewBlock onUpdate={mockUpdate} />);
-  // …simulate the click
+  // Click the "Accept" button.
   component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').simulate('click');
-  expect(mockFn).toHaveBeenCalled();
-  // component.findWhere(n => n.name() === 'StatusButton' && n.prop('type') === 'accepted').simulate('click');
+  expect(onUpdate).toHaveBeenCalled();
+
+  component.update();
+  console.log(component.debug());
 
   // It should now show the active "Accept" button.
   expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first().hasClass('button -outlined-button -accepted is-selected'));
+  // const acceptButton = component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first();
+  // expect(acceptButton.props().status).to.equal('accepted');
+  // expect(component.find('.accepted').first().hasClass('button -outlined-button -accepted is-selected'));
 
   // Tags should now be enabled.
-  // const enabledTag = component.find('.tag').first();
-  // enabledTag.simulate('click');
-  // expect(enabledTag).toEqual(true);
-  // expect(enabled.enabled).toEqual(true);
-  // expect(component.find('.tag').first().is('[enabled]')).toBe(true);
-
+  // expect(component.find('.tag').first().is('[disabled]')).toBe(false);
+  // expect(component.find('.enabled').first().text()).toBe('Tags');
 });
 
 // test('it renders an active Reject button when clicked', () => {

--- a/resources/assets/components/ReviewBlock/test.js
+++ b/resources/assets/components/ReviewBlock/test.js
@@ -1,38 +1,14 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import ReviewBlock from './index';
 
-test('it renders accepted, rejected, and delete buttons', () => {
+test('it renders accepted, rejected, disabled tags, and delete buttons', () => {
   const post = {
-    status: 'pending',
-  };
-
-  const deletePost = function () {
-    return true;
-  };
-
-  const onUpdate = function () {
-    return true;
-  };
-
-  const onTag = function () {
-    return true;
-  };
-
-  const component = shallow(
-    <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
-  );
-
-  expect(toJson(component)).toMatchSnapshot();
-});
-
-test('it renders the review block with tags', () => {
-  const post = {
-    status: 'accepted',
+    id: 1,
     tags: [],
-    id: 71,
+    status: 'pending',
   };
 
   const deletePost = function () {
@@ -73,74 +49,106 @@ test('it renders an active Accept button when clicked', () => {
     return true;
   };
 
-  const component = shallow(
+  const component = mount(
     <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
   );
 
-  // Click the "Accept" button.
-  component.find('.accepted').first().simulate('click');
+  // Tags should be disabled.
+  // expect(component.find('.tag').first().is('[disabled]')).toBe(true);
+  // expect(component.find('.tag').first().disabled).toBe(true);
+  // expect(component.find('.tag').first()).toBe('disabled');
+  // expect(component.find('.disabled').first().toBe(true));
+  // expect(component.find('.tag.disabled').first().toBe(true));
+  // const disabledTag = component.find('.tag').first();
+  // expect(disabledTag.disabled).toEqual(true);
+  // expect(component.find('.disabled').first()).toBe('Tags');
+  // expect(component.find('.disabled').first()).toEqual('Tags');
+  // expect(component.find('.disabled').to.be('Tags'));
+  // expect(component.find('.disabled').toEqual('Tags'));
+  // expect(component.find('.disabled').first().text()).toBe('Tags');
+  // expect(component.find('.disabled').first().text()).toEqual('Tags');
+  // const disabledTag = component.find('.tag Tag').first();
+  // disabledTag.simulate('click');
+  // component.find('.tag').first().simulate('click');
+  // expect(disabledTag).toEqual(true);
+
+  // Click the "Accept" button and mock the handleClick function from the StatusButton component.
+  const mockUpdate = jest.fn(() => Promise.resolve(true));
+  const wrapper = mount(<ReviewBlock onUpdate={mockUpdate} />);
+  // …simulate the click
+  component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').simulate('click');
+  expect(mockFn).toHaveBeenCalled();
+  // component.findWhere(n => n.name() === 'StatusButton' && n.prop('type') === 'accepted').simulate('click');
 
   // It should now show the active "Accept" button.
-  expect(component.find('.accepted').first().hasClass('button -outlined-button -accepted is-selected'));
+  expect(component.find('StatusButton').findWhere(n => n.prop('type') === 'accepted').first().hasClass('button -outlined-button -accepted is-selected'));
+
+  // Tags should now be enabled.
+  // const enabledTag = component.find('.tag').first();
+  // enabledTag.simulate('click');
+  // expect(enabledTag).toEqual(true);
+  // expect(enabled.enabled).toEqual(true);
+  // expect(component.find('.tag').first().is('[enabled]')).toBe(true);
+
 });
 
-test('it renders an active Reject button when clicked', () => {
-  const post = {
-    status: 'pending',
-    tags: [],
-    id: 71,
-  };
+// test('it renders an active Reject button when clicked', () => {
+//   const post = {
+//     status: 'pending',
+//     tags: [],
+//     id: 71,
+//   };
 
-  const deletePost = function () {
-    return true;
-  };
+//   const deletePost = function () {
+//     return true;
+//   };
 
-  const onUpdate = function () {
-    return true;
-  };
+//   const onUpdate = function () {
+//     return true;
+//   };
 
-  const onTag = function () {
-    return true;
-  };
+//   const onTag = function () {
+//     return true;
+//   };
 
-  const component = shallow(
-    <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
-  );
+//   const component = mount(
+//     <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
+//   );
 
-  // Click the "Reject" button.
-  component.find('.rejected').first().simulate('click');
+//   // Click the "Reject" button.
+//   component.find('.rejected').first().simulate('click');
 
-  // It should now show the active "Reject" button.
-  expect(component.find('.rejected').first().hasClass('button -outlined-button -rejected is-selected'));
-});
+//   // It should now show the active "Reject" button.
+//   expect(component.find('.rejected').first().hasClass('button -outlined-button -rejected is-selected'));
+// });
 
-test('it renders an active tag button when clicked', () => {
-  const post = {
-    status: 'pending',
-    tags: [],
-    id: 71,
-  };
+// test('it renders an active tag button when clicked', () => {
+//   const post = {
+//     status: 'accepted',
+//     tags: [],
+//     id: 71,
+//   };
 
-  const deletePost = function () {
-    return true;
-  };
+//   const deletePost = function () {
+//     return true;
+//   };
 
-  const onUpdate = function () {
-    return true;
-  };
+//   const onUpdate = function () {
+//     return true;
+//   };
 
-  const onTag = function () {
-    return true;
-  };
+//   const onTag = function () {
+//     return true;
+//   };
 
-  const component = shallow(
-    <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
-  );
+//   const component = mount(
+//     <ReviewBlock post={post} deletePost={deletePost} onUpdate={onUpdate} onTag={onTag} />,
+//   );
 
-  // Click a tag button.
-  component.find('.tag').first().simulate('click');
+//   // Click a tag button.
+//   component.find('.tag').first().simulate('click');
 
-  // It should now show the active "Reject" button.
-  expect(component.find('.tag').first().hasClass('is-active'));
-});
+//   // It should now show the active tag button.
+//   expect(component.find('.tag').first().hasClass('is-active'));
+// });
 

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -52,6 +52,11 @@ class Tags extends React.Component {
       'hide-in-gallery': 'Hide In Gallery 👻',
       'good-for-sponsor': 'Good For Sponsor',
       'good-for-storytelling': 'Good For Storytelling',
+      'irrelevant': 'Irrelevant',
+      'inappropriate': 'Inappropriate',
+      'unrealistic-quantity': 'Unrealistic Quantity',
+      'test': 'Test',
+      'incomplete-action': 'Incomplete Action',
     };
 
     return (

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -30,7 +30,7 @@ class Tag extends React.Component {
   }
 
   render() {
-    return (<button
+    return (<button disabled={this.props.disable}
       className={classnames('tag', { 'is-active': this.props.isActive }, { 'is-loading': this.state.sending })}
       onClick={() => this.handleClick(this.props.label)}
     >{this.props.label}</button>);
@@ -65,7 +65,7 @@ class Tags extends React.Component {
         <ul className="aligned-actions">
           {map(tags, (label, key) => (
             <li key={key}>
-              <Tag isActive={this.props.tagged.includes(key)} isClicked={this.props.onTag} label={label} post={this.props.id} />
+              <Tag isActive={this.props.tagged.includes(key)} isClicked={this.props.onTag} label={label} post={this.props.id} disable={this.props.disableTags} />
             </li>
           ))}
         </ul>

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -30,7 +30,7 @@ class Tag extends React.Component {
   }
 
   render() {
-    return (<button disabled={this.props.disable}
+    return (<button disabled={this.props.disabled}
       className={classnames('tag', { 'is-active': this.props.isActive }, { 'is-loading': this.state.sending })}
       onClick={() => this.handleClick(this.props.label)}
     >{this.props.label}</button>);
@@ -59,7 +59,7 @@ class Tags extends React.Component {
       'incomplete-action': 'Incomplete Action',
     };
 
-    const h2ClassName = this.props.disableTags ? 'disabled' : 'enabled';
+    const h2ClassName = this.props.disabled ? 'disabled' : 'enabled';
 
     return (
       <div>
@@ -67,7 +67,7 @@ class Tags extends React.Component {
         <ul className="aligned-actions">
           {map(tags, (label, key) => (
             <li key={key}>
-              <Tag isActive={this.props.tagged.includes(key)} isClicked={this.props.onTag} label={label} post={this.props.id} disable={this.props.disableTags} />
+              <Tag isActive={this.props.tagged.includes(key)} isClicked={this.props.onTag} label={label} post={this.props.id} disabled={this.props.disabled} />
             </li>
           ))}
         </ul>

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -59,9 +59,11 @@ class Tags extends React.Component {
       'incomplete-action': 'Incomplete Action',
     };
 
+    const h2ClassName = this.props.disableTags ? 'disabled' : 'enabled';
+
     return (
       <div>
-        <h4>Tags</h4>
+        <h4 className={h2ClassName}>Tags</h4>
         <ul className="aligned-actions">
           {map(tags, (label, key) => (
             <li key={key}>

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -59,11 +59,11 @@ class Tags extends React.Component {
       'incomplete-action': 'Incomplete Action',
     };
 
-    const h2ClassName = this.props.disabled ? 'disabled' : 'enabled';
+    const showTags = this.props.disabled ? 'disabled' : 'enabled';
 
     return (
       <div>
-        <h4 className={h2ClassName}>Tags</h4>
+        <h4 className={showTags}>Tags</h4>
         <ul className="aligned-actions">
           {map(tags, (label, key) => (
             <li key={key}>

--- a/resources/assets/components/Tags/tags.scss
+++ b/resources/assets/components/Tags/tags.scss
@@ -20,6 +20,11 @@
     color: $white;
   }
 
+  &:hover {
+    background: $blue;
+    color: $white;
+  }
+
   &:focus {
     outline: 0;
   }

--- a/resources/assets/components/Tags/tags.scss
+++ b/resources/assets/components/Tags/tags.scss
@@ -1,5 +1,9 @@
 @import '~@dosomething/forge/scss/toolkit';
 
+h4.disabled {
+  color: $light-gray;
+}
+
 .tag {
   list-style-type: none;
   clear: both;
@@ -21,7 +25,15 @@
   }
 
   &:enabled {
+    border-color: $med-gray;
+    color: $med-gray;
+
     &:hover {
+      background: $blue;
+      color: $white;
+    }
+
+    &.is-active {
       background: $blue;
       color: $white;
     }

--- a/resources/assets/components/Tags/tags.scss
+++ b/resources/assets/components/Tags/tags.scss
@@ -20,9 +20,11 @@
     color: $white;
   }
 
-  &:hover {
-    background: $blue;
-    color: $white;
+  &:enabled {
+    &:hover {
+      background: $blue;
+      color: $white;
+    }
   }
 
   &:focus {


### PR DESCRIPTION
#### What's this PR do?
- Adds the following new tags: 
  - Irrelevant
  - Inappropriate
  - Unrealistic Quantity
  - Test
  - Incomplete Action
- Adds ability to tag both accepted and rejected posts
- Tag button will be disabled until a post's status is accepted or rejected 
- Once a post's status is accepted or rejected, tag buttons become enabled and when you hover over the tags, they will be highlighted in blue 

#### How should this be reviewed?
👀 
**Does all the above make sense? Those scenarios should work!** 
Approved and tagged post:
![screen shot 2018-01-05 at 10 49 00 am](https://user-images.githubusercontent.com/9019452/34616380-181bb68e-f206-11e7-8c7d-2f96d843d3bc.png)

**Rejected and tagged post:**
![screen shot 2018-01-05 at 10 49 37 am](https://user-images.githubusercontent.com/9019452/34616407-26fd07ca-f206-11e7-9939-498c7f9a5af5.png)

**Reviewed post with enabled tags vs unreviewed post with disabled tags:**
![screen shot 2018-01-05 at 10 45 51 am](https://user-images.githubusercontent.com/9019452/34616270-be14f25e-f205-11e7-86b0-6bca67b370f4.png)



#### Relevant tickets
Fixes these Pivotal Cards:
- https://www.pivotaltracker.com/n/projects/2019429/stories/150443391 
- https://www.pivotaltracker.com/n/projects/2019429/stories/152892878

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
  
  
  