### PR TITLE
Move properties to correct level in JSON object

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,20 @@
 {
   "name": "rogue",
   "description": ":sparkles:",
+  "scripts": {
+    "postdeploy": "php artisan migrate:refresh --seed"
+  },
+  "addons": [
+    "papertrail"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/php"
+    },
+    {
+      "url": "heroku/nodejs"
+    }
+  ],
   "env": {
     "APP_ENV": "local",
     "APP_DEBUG": "false",
@@ -10,20 +24,6 @@
     },
     "APP_LOG": "errorlog",
     "APP_URL": "https://ds-rogue-staging.herokuapp.com/",
-    "scripts": {
-      "postdeploy": "php artisan migrate:refresh --seed"
-    },
-    "addons": [
-      "papertrail"
-    ],
-    "buildpacks": [
-      {
-        "url": "heroku/php"
-      },
-      {
-        "url": "heroku/nodejs"
-      }
-    ],
     "BLINK_URL": {
       "required": true
     },


### PR DESCRIPTION
#### What's this PR do?
the `scripts`, `addons`, and `buildpacks` properties should be at the same level as `env` not embedded in it. 

#### How should this be reviewed?
👀 
