### PR TITLE
Upgrade to Gateway 1.14.1 & attach 'client_id' to logs.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,7 @@ class AppServiceProvider extends ServiceProvider
         // Attach the user & request ID to context for all log messages.
         Log::getMonolog()->pushProcessor(function ($record) {
             $record['extra']['user_id'] = auth()->id();
+            $record['extra']['client_id'] = client_id();
             $record['extra']['request_id'] = request()->header('X-Request-Id');
 
             return $record;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -102,3 +102,15 @@ function is_staff_user()
 
     return false;
 }
+
+/**
+ * Get the name of the client executing the current request.
+ *
+ * @return string
+ */
+function client_id()
+{
+    // If this is an API request, use embedded client ID from the JWT. For
+    // web requests, check what this instance of Rogue is configured to use!
+    return token() ? token()->client_id : config('services.northstar.authorization_code.client_id');
+}

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.48.11",
+            "version": "3.48.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4159562ee5c2b2d322cfcccd2401d90bfaceaf1d"
+                "reference": "c7f3148d537db877e9b4b63308d61f52eaa253bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4159562ee5c2b2d322cfcccd2401d90bfaceaf1d",
-                "reference": "4159562ee5c2b2d322cfcccd2401d90bfaceaf1d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c7f3148d537db877e9b4b63308d61f52eaa253bc",
+                "reference": "c7f3148d537db877e9b4b63308d61f52eaa253bc",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-01-09T22:01:13+00:00"
+            "time": "2018-01-11T20:40:29+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -680,16 +680,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.14.0",
+            "version": "v1.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "6c807e4c4a985e11433b1022a55850f39b393a60"
+                "reference": "3126df34d278548b72cb924409419fe60f72be4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/6c807e4c4a985e11433b1022a55850f39b393a60",
-                "reference": "6c807e4c4a985e11433b1022a55850f39b393a60",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/3126df34d278548b72cb924409419fe60f72be4f",
+                "reference": "3126df34d278548b72cb924409419fe60f72be4f",
                 "shasum": ""
             },
             "require": {
@@ -699,6 +699,7 @@
                 "lcobucci/jwt": "^3.1",
                 "league/oauth2-client": "~2.2",
                 "nesbot/carbon": "~1.14",
+                "ramsey/uuid": "^3.7",
                 "symfony/psr-http-message-bridge": "^1.0",
                 "zendframework/zend-diactoros": "^1.3"
             },
@@ -736,7 +737,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2018-01-10T19:21:21+00:00"
+            "time": "2018-01-12T16:49:50+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -4097,29 +4098,29 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "ab03919dfd85a74ae0372f8baf9f3c7d5c03b04b"
+                "reference": "0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/ab03919dfd85a74ae0372f8baf9f3c7d5c03b04b",
-                "reference": "ab03919dfd85a74ae0372f8baf9f3c7d5c03b04b",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757",
+                "reference": "0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7",
-                "symfony/css-selector": "^2.7|~3.0"
+                "php": "^5.5 || ^7.0",
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8|5.1.*"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -4140,7 +4141,7 @@
             ],
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
-            "time": "2016-09-20T12:50:39+00:00"
+            "time": "2017-11-27T11:13:29+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -5496,16 +5497,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f"
+                "reference": "11c07feade1d65453e06df3b3b90171d6d982087"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
-                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/11c07feade1d65453e06df3b3b90171d6d982087",
+                "reference": "11c07feade1d65453e06df3b3b90171d6d982087",
                 "shasum": ""
             },
             "require": {
@@ -5556,7 +5557,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-12-22T14:50:35+00:00"
+            "time": "2018-01-12T06:34:42+00:00"
         },
         {
             "name": "sebastian/diff",


### PR DESCRIPTION
#### What's this PR do?
This pull request includes two updates for logging:

🆙 Updates to [Gateway 1.14.1](https://github.com/DoSomething/gateway/releases/tag/v1.14.1) w/ simplified request ID logic.

🆔 Also adds a `client_id()` helper (inspired by the same thing in Northstar's codebase), and attaches it to all log messages so we can quickly figure out where something came from. For web (or anonymous) requests, it attaches Rogue's specified Client ID.

#### How should this be reviewed?
Here's an example API request & web request in the logs:

```
[2018-01-12 19:25:07] local.INFO: post_created {"id":153,"signup_id":141} {"user_id":"5571f4f5a59dbf3c7a8b4569","client_id":"phoenix-oauth","request_id":"754546b2-a67f-47d1-9eda-203c8f989601"}
[2018-01-12 19:25:14] local.INFO: post_reviewed {"id":35,"admin_northstar_id":"5571f4f5a59dbf3c7a8b4569","status":"rejected"} {"user_id":"5571f4f5a59dbf3c7a8b4569","client_id":"rogue-oauth","request_id":"f679c325-562a-42da-ab9c-6e3b9707def3"}
```

#### Any background context you want to provide?
N/A

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.