### PR TITLE
Only return a client_id on OAuth requests.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,7 +23,7 @@ class AppServiceProvider extends ServiceProvider
         // Attach the user & request ID to context for all log messages.
         Log::getMonolog()->pushProcessor(function ($record) {
             $record['extra']['user_id'] = auth()->id();
-            $record['extra']['client_id'] = client_id();
+            $record['extra']['client_id'] = token()->client();
             $record['extra']['request_id'] = request()->header('X-Request-Id');
 
             return $record;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -102,15 +102,3 @@ function is_staff_user()
 
     return false;
 }
-
-/**
- * Get the name of the client executing the current request.
- *
- * @return string
- */
-function client_id()
-{
-    // If this is an API request, use embedded client ID from the JWT. For
-    // web requests, check what this instance of Rogue is configured to use!
-    return token()->exists() ? token()->client : config('services.northstar.authorization_code.client_id');
-}


### PR DESCRIPTION
#### What's this PR do?
One last change and I'm done! I was looking at #578/#579 on Thor and noticed that this is very confusing to default it to the OAuth client name... it makes it look like legacy API key requests are coming from `rogue-oauth`. Bleh!

```
Jan 12 11:54:17 rogue-thor app/web.1:  [12-Jan-2018 19:54:12 UTC] [2018-01-12 19:54:12] thor.INFO: signup_created {"id":8496462,"northstar_id":"5a59126110707d215f46fd0a"} {"user_id":null,"client_id":"rogue-oauth","request_id":"2558d4af-a520-44df-b987-0248809d646a"} 
Jan 12 11:55:42 rogue-thor app/web.1:  [12-Jan-2018 19:55:37 UTC] [2018-01-12 19:55:37] thor.INFO: Request made. {"method":"POST","uri":"https://blink-staging.dosomething.org/api/v1/events/user-signup-post","request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} {"user_id":null,"client_id":"rogue-oauth","request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} 
Jan 12 11:55:42 rogue-thor app/web.1:  [12-Jan-2018 19:55:37 UTC] [2018-01-12 19:55:37] thor.INFO: Post 432715 sent to Blink [] {"user_id":null,"client_id":"rogue-oauth","request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} 
Jan 12 11:55:42 rogue-thor app/web.1:  [12-Jan-2018 19:55:37 UTC] [2018-01-12 19:55:37] thor.INFO: post_created {"id":432715,"signup_id":8496462} {"user_id":null,"client_id":"rogue-oauth","request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} 
```

I think returning `null` here is less confusing, and gives us a good incentive to get all our traffic to use the newer OAuth routes. 😄 

#### How should this be reviewed?
This would cause the above logs to instead read like this:

```
Jan 12 11:54:17 rogue-thor app/web.1:  [12-Jan-2018 19:54:12 UTC] [2018-01-12 19:54:12] thor.INFO: signup_created {"id":8496462,"northstar_id":"5a59126110707d215f46fd0a"} {"user_id":null,"client_id":null,"request_id":"2558d4af-a520-44df-b987-0248809d646a"} 
Jan 12 11:55:42 rogue-thor app/web.1:  [12-Jan-2018 19:55:37 UTC] [2018-01-12 19:55:37] thor.INFO: Request made. {"method":"POST","uri":"https://blink-staging.dosomething.org/api/v1/events/user-signup-post","request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} {"user_id":null,"client_id":null,"request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} 
Jan 12 11:55:42 rogue-thor app/web.1:  [12-Jan-2018 19:55:37 UTC] [2018-01-12 19:55:37] thor.INFO: Post 432715 sent to Blink [] {"user_id":null,"client_id":null,"request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} 
Jan 12 11:55:42 rogue-thor app/web.1:  [12-Jan-2018 19:55:37 UTC] [2018-01-12 19:55:37] thor.INFO: post_created {"id":432715,"signup_id":8496462} {"user_id":null,"client_id":null,"request_id":"c7b0f03b-c243-4765-a62d-23e2d42b2ee0"} 
```

#### Any background context you want to provide?
🚳

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.