### PR TITLE
Don't append query-string to Glide URLs.

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -40,7 +40,7 @@ class PostTransformer extends TransformerAbstract
             // most recent version of the image.
             // @NOTE - Remove if we get rid of rotation.
             'media' => [
-                'url' => $post->getMediaUrl() . '?time='. Carbon::now()->timestamp,
+                'url' => $post->getMediaUrl(),
                 'original_image_url' => $post->url . '?time='. Carbon::now()->timestamp,
                 'caption' => $post->caption,
             ],

--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -39,7 +39,7 @@ class PostTransformer extends TransformerAbstract
             // most recent version of the image.
             // @NOTE - Remove if we get rid of rotation.
             'media' => [
-                'url' => $post->getMediaUrl() . '?time='. Carbon::now()->timestamp,
+                'url' => $post->getMediaUrl(),
                 'original_image_url' => $post->url . '?time='. Carbon::now()->timestamp,
                 'caption' => $post->caption,
             ],

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Models;
 
+use Carbon\Carbon;
 use Rogue\Events\PostTagged;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
@@ -114,7 +115,7 @@ class Post extends Model
         // Ask the storage driver for the path to the image for this post.
         $path = Storage::url('uploads/reportback-items/edited_' . $this->id . '.jpeg');
 
-        return url($path);
+        return url($path) . '?time='. Carbon::now()->timestamp;
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request pulls the hackified timestamp query-string into the `getMediaUrl` method on the model, so that we can only apply it if Glide is disabled.

#### How should this be reviewed?
Note: The part where we return Glide URLs (without the timestamp querystring) is hidden in the diff!

#### Any background context you want to provide?
We can probably clean up all these code paths in a future PR.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.