### PR TITLE
Updates query in source script to also grab soft deleted signups/posts

### DIFF
--- a/app/Console/Commands/MakeSourceSms.php
+++ b/app/Console/Commands/MakeSourceSms.php
@@ -43,7 +43,7 @@ class MakeSourceSms extends Command
         info('rogue:smssource: Starting to update signups!');
 
         // Get all signups that have "sms-mobilecommons" set as their source and update to "sms"
-        Signup::where('source', 'sms-mobilecommons')->chunkById(100, function ($signups) {
+        Signup::withTrashed()->where('source', 'sms-mobilecommons')->chunkById(100, function ($signups) {
             foreach ($signups as $signup) {
                 info('rogue:smssource: changing source to sms for signup ' . $signup->id);
                 $signup->source = 'sms';
@@ -58,7 +58,7 @@ class MakeSourceSms extends Command
         info('rogue:smssource: Starting to update posts!');
 
         // Get all posts that have "sms-mobilecommons" set as their source and update to "sms"
-        Post::where('source', 'sms-mobilecommons')->chunkById(100, function ($posts) {
+        Post::withTrashed()->where('source', 'sms-mobilecommons')->chunkById(100, function ($posts) {
             foreach ($posts as $post) {
                 info('rogue:smssource: changing source to sms for post ' . $post->id);
                 $post->source = 'sms';


### PR DESCRIPTION
#### What's this PR do?
Updates query in source script to also grab soft deleted signups/posts.

#### How should this be reviewed?
When you run the script, even soft deleted signups/posts should have an updated source from `sms-mobilecommons` to `sms` 

#### Any background context you want to provide?
We want this so **no** records in the database have `sms-mobilecommons` as the source.

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154410187) Pivotal Card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.