### PR TITLE
Add action columns

### DIFF
--- a/database/migrations/2018_01_18_191700_add_columns_to_categorize_posts.php
+++ b/database/migrations/2018_01_18_191700_add_columns_to_categorize_posts.php
@@ -14,8 +14,8 @@ class AddColumnsToCategorizePosts extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->string('type')->after('northstar_id')->default('photo')->comment('Describes the type of post submitted e.g. photo, call, voter-reg');
-            $table->string('action_bucket')->after('type')->comment('Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throught the life of the campaign.');
+            $table->string('type')->index()->after('northstar_id')->default('photo')->comment('Describes the type of post submitted e.g. photo, call, voter-reg');
+            $table->string('action_bucket')->index()->after('type')->comment('Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throught the life of the campaign.');
             $table->text('details')->after('remote_addr')->comment('A JSON field to store extra details about a post.');
         });
     }

--- a/database/migrations/2018_01_18_191700_add_columns_to_categorize_posts.php
+++ b/database/migrations/2018_01_18_191700_add_columns_to_categorize_posts.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddColumnsToCategorizePosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('type')->after('northstar_id')->default('photo')->comment('Describes the type of post submitted e.g. photo, call, voter-reg');
+            $table->string('action_bucket')->after('type')->comment('Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throught the life of the campaign.');
+            $table->text('details')->after('remote_addr')->comment('A JSON field to store extra details about a post.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('type');
+            $table->dropColumn('bucket');
+            $table->dropColumn('details');
+        });
+    }
+}

--- a/database/migrations/2018_01_18_191700_add_columns_to_categorize_posts.php
+++ b/database/migrations/2018_01_18_191700_add_columns_to_categorize_posts.php
@@ -29,7 +29,7 @@ class AddColumnsToCategorizePosts extends Migration
     {
         Schema::table('posts', function (Blueprint $table) {
             $table->dropColumn('type');
-            $table->dropColumn('bucket');
+            $table->dropColumn('action_bucket');
             $table->dropColumn('details');
         });
     }


### PR DESCRIPTION
#### What's this PR do?
Adds columns to the `posts` table to store `type`, `action_bucket`, and `details`

the `details` column should be `JSON` but our current DB version doesn't support that column type so it is `TEXT` for now.

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

A full thread on how we decided to add these columns: https://github.com/orgs/DoSomething/teams/team-bleed/discussions/12

**Question** 
* Should we have a default value for `action_bucket`? Old posts won't have a value in it, but it is not nullable because we want it to be required. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/154212087

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.