### PR TITLE
Update to v3/signups and v3/reactions endpoints

### DIFF
--- a/app/Http/Controllers/Three/ReactionController.php
+++ b/app/Http/Controllers/Three/ReactionController.php
@@ -30,7 +30,6 @@ class ReactionController extends ApiController
         $this->transformer = new ReactionTransformer;
 
         $this->middleware('auth:api', ['only' => ['store']]);
-        $this->middleware('role:admin', ['only' => ['store']]); // @TODO: Allow anyone to use this.
     }
 
     /**

--- a/app/Http/Controllers/Three/ReactionController.php
+++ b/app/Http/Controllers/Three/ReactionController.php
@@ -41,13 +41,10 @@ class ReactionController extends ApiController
      */
     public function store(Request $request, Post $post)
     {
-        $this->validate($request, [
-            'northstar_id' => 'required|string',
-        ]);
+        $northstarId = getNorthstarId($request);
 
-        $userId = $request['northstar_id'];
         // Check to see if the post has a reaction from this particular user with id of northstar_id. If not, create one.
-        $reaction = Reaction::withTrashed()->firstOrCreate(['northstar_id' => $userId, 'post_id' => $post->id]);
+        $reaction = Reaction::withTrashed()->firstOrCreate(['northstar_id' => $northstarId, 'post_id' => $post->id]);
 
         if ($reaction->wasRecentlyCreated || $reaction->trashed()) {
             // We're adding a new reaction in these cases.

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -43,7 +43,6 @@ class SignupsController extends ApiController
         $this->transformer = new SignupTransformer;
 
         $this->middleware('auth:api', ['only' => ['store', 'update', 'destroy']]);
-        $this->middleware('role:admin', ['only' => ['store', 'update', 'destroy']]); // @TODO: Allow anyone to use this.
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Allows anyone to store, update, or delete signups. 
- Allows anyone to store a reaction. 
- Updates `/reactions` endpoint to use `auth()->id()` to get Northstar ID instead of requiring it to be passed as a param. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154524951) Pivotal Card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.