### PR TITLE
Log less in the PostQuantity script by chunking by 10,000

### DIFF
--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -42,7 +42,7 @@ class PostQuantity extends Command
         $start = $this->argument('start');
 
         // Get all signups starting from $start in order of ID
-        Signup::where('id', '>=', $start)->orderBy('id')->with('posts')->chunk(1000, function ($signups) {
+        Signup::where('id', '>=', $start)->orderBy('id')->with('posts')->chunk(10000, function ($signups) {
             foreach ($signups as $signup) {
                 // Get the posts for the signup
                 $posts = $signup->posts;

--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -12,7 +12,7 @@ class PostQuantity extends Command
      *
      * @var string
      */
-    protected $signature = 'rogue:postquantity {start=1} {sleeptime=0}';
+    protected $signature = 'rogue:postquantity {start=1} {sleeptime=0} {chunk=1000}';
 
     /**
      * The console command description.
@@ -40,9 +40,10 @@ class PostQuantity extends Command
     {
         // Signup that we should start with
         $start = $this->argument('start');
+        $chunk = $this->argument('chunk');
 
         // Get all signups starting from $start in order of ID
-        Signup::where('id', '>=', $start)->orderBy('id')->with('posts')->chunk(10000, function ($signups) {
+        Signup::where('id', '>=', $start)->orderBy('id')->with('posts')->chunk($chunk, function ($signups) {
             foreach ($signups as $signup) {
                 // Get the posts for the signup
                 $posts = $signup->posts;


### PR DESCRIPTION
#### What's this PR do?
Turns out I don't know how to estimate how much storage stuff takes up in PaperTrail! We need to log less! Going to try doing this by chunking by 10,000.

#### How should this be reviewed?
Can anything bad happen in production if we chunk 10x as many things? 5000 would be another option to chunk by.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.