### PR TITLE
Disregards posts that have been soft deleted in query for post totals

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -198,9 +198,9 @@ class CampaignService
         return DB::table('signups')
                 ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
                 ->select('signups.campaign_id',
-                    DB::raw('SUM(case when posts.status = "accepted" then 1 else 0 end) as accepted_count'),
-                    DB::raw('SUM(case when posts.status = "pending" then 1 else 0 end) as pending_count'),
-                    DB::raw('SUM(case when posts.status = "rejected" then 1 else 0 end) as rejected_count'))
+                    DB::raw('SUM(case when posts.status = "accepted" && posts.deleted_at is null then 1 else 0 end) as accepted_count'),
+                    DB::raw('SUM(case when posts.status = "pending" && posts.deleted_at is null then 1 else 0 end) as pending_count'),
+                    DB::raw('SUM(case when posts.status = "rejected" && posts.deleted_at is null then 1 else 0 end) as rejected_count'))
                 ->where('signups.campaign_id', '=', $campaign['id'])
                 ->groupBy('signups.campaign_id')
                 ->first();


### PR DESCRIPTION
#### What's this PR do?
- Doesn't include posts that have been soft deleted (where `deleted_at` is not `null`) when summing accepted, pending, and rejected posts. 

#### How should this be reviewed?
:eyes:

#### Any background context you want to provide?
On the campaign single page, the pending post count was inaccurate. Aki flagged when he was reviewing, it said "18 Pending" posts but when he clicked to review them, there were none. This is because it was counting posts that had been soft deleted.

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154804464) Pivotal Card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.