### PR TITLE
`/v3/signups` updated viewing permissions 

### DIFF
--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -111,13 +111,13 @@ class SignupsController extends ApiController
     public function show(Request $request, Signup $signup)
     {
         // Only allow an admin, staff, or the user who owns the signup to see the signup.
-        $signup = Signup::whereVisible()->first();
-
         if ($signup) {
-            return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
-        }
+            if (is_staff_user() || auth()->id() === $signup->northstar_id) {
+                return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
+            }
 
-        throw new AuthorizationException('You don\'t have the correct role to see this signup!');
+            throw new AuthorizationException('You don\'t have the correct role to see this signup!');
+        }
     }
 
     /**

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -89,10 +89,13 @@ class SignupsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Signup::$indexes);
 
-        // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
+        // Only allow an admin, staff, or the user who owns the signup to see the signup's unapproved posts.
         if ($request->query('include') === 'posts') {
             $query = $query->withVisiblePosts();
         }
+
+        // Only allow admins, staff, or the user who owns the signup to see the signup.
+        $query = $query->whereVisible();
 
         return $this->paginatedCollection($query, $request);
     }
@@ -107,7 +110,7 @@ class SignupsController extends ApiController
      */
     public function show(Request $request, Signup $signup)
     {
-        // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
+        // Only allow an admin, staff, or the user who owns the signup to see the signup's unapproved posts.
         if ($request->query('include') === 'posts') {
             $signup = Signup::withVisiblePosts()->first();
         }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -112,9 +112,7 @@ class SignupsController extends ApiController
     {
         // Only allow an admin, staff, or the user who owns the signup to see the signup.
         $signup = Signup::whereVisible()->first();
-        // if ($request->query('include') === 'posts') {
-        //     $signup = Signup::withVisiblePosts()->first();
-        // }
+
         if ($signup) {
             return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
         }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -110,12 +110,16 @@ class SignupsController extends ApiController
      */
     public function show(Request $request, Signup $signup)
     {
-        // Only allow an admin, staff, or the user who owns the signup to see the signup's unapproved posts.
-        if ($request->query('include') === 'posts') {
-            $signup = Signup::withVisiblePosts()->first();
+        // Only allow an admin, staff, or the user who owns the signup to see the signup.
+        $signup = Signup::whereVisible()->first();
+        // if ($request->query('include') === 'posts') {
+        //     $signup = Signup::withVisiblePosts()->first();
+        // }
+        if ($signup) {
+            return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
         }
 
-        return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
+        throw new AuthorizationException('You don\'t have the correct role to see this signup!');
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -252,7 +252,7 @@ class Post extends Model
     {
         if (! is_staff_user()) {
             return $query->where('status', 'accepted')
-                         ->orWhere('northstar_id', auth()->id());
+                   ->orWhere('northstar_id', auth()->id());
         }
     }
 }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -171,4 +171,16 @@ class Signup extends Model
             }]);
         }
     }
+
+    /**
+     * Scope a query to only return signups if a user is an admin, staff, or is owner of signup.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWhereVisible($query)
+    {
+        if (! is_staff_user()) {
+            return $query->where('northstar_id', auth()->id());
+        }
+    }
 }

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -45,7 +45,7 @@ Example response:
 ```
 GET /api/v3/signups
 ```
-When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
+Anonymous requests will not return anything. Logged-in users can only see signups that belong to them. Staff can see anything!
 ### Optional Query Parameters
 - **include** _(string)_
   - Include additional related records in the response: `posts`
@@ -101,6 +101,7 @@ Example Response:
 ```
 GET /api/v3/signups/:signup_id
 ```
+Anonymous requests will return a 403 Authorization error. Logged-in users can only see signups that belong to them. Staff can see anything!
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
 - **include** _(string)_
@@ -130,6 +131,7 @@ Example Response:
 ```
 
 ## Update a Signup
+Only admins or users who own the signup can update a signup.
 
 ```
 PATCH /api/v3/signups/:signup_id
@@ -157,6 +159,7 @@ Example response:
 ```
 
 ## Delete a Signup
+Only admins or users who own the signup can delete a signup. 
 
 ```
 DELETE /api/v3/signups/:signup_id

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -325,6 +325,9 @@ class SignupTest extends TestCase
      */
     public function testQuantityOnSignupIndex()
     {
+        // Turn on feature flag that supports quantity splitting.
+        config(['features.v3QuantitySupport' => true]);
+
         // Create a signup with a quantity.
         $firstSignup = factory(Signup::class)->create();
         $firstSignup->quantity = 8;
@@ -339,7 +342,7 @@ class SignupTest extends TestCase
         $secondSignup->quantity = $secondSignup->getQuantity();
         $secondSignup->save();
 
-        $response = $this->getJson('api/v3/signups');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups');
 
         $response->assertStatus(200);
         $response->assertJson([


### PR DESCRIPTION
#### What's this PR do?
- Updates `GET /v3/signups` and `GET /v3/signups/{signup}` to only return a user's own signup(s) unless they're an admin so that we're keeping more data protected
- Updates tests and deletes tests that are now irrelevant 
- Updates documentation

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
In particular, we want to gate this information as we can see the `why_participated` values containing sensitive user information

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154611572) Pivotal Card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.