### PR TITLE
Update to how we return signup quantity

### DIFF
--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -145,7 +145,7 @@ class Signup extends Model
         // logic to store everything in the quanity column and not use the quanity_pending
         // column at all. We only want to return what is in the quanity_pending column
         // if is the only place quanity is stored.
-        if (! config('features.v3QuantitySupport') || $this->posts->isEmpty() || is_null($this->posts->first()->quantity)) {
+        if (! config('features.v3QuantitySupport') || $this->posts->isEmpty()) {
             if (! is_null($this->quantity_pending) && is_null($this->quantity)) {
                 return $this->quantity_pending;
             }

--- a/tests/Http/Api/PostApiTest.php
+++ b/tests/Http/Api/PostApiTest.php
@@ -18,13 +18,10 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPostAndSignup()
     {
-        // Turn off feature flag that supports quantity splitting.
-        config(['features.v3QuantitySupport' => false]);
-
         $northstar_id = $this->faker->uuid;
         $campaign_id = $this->faker->randomNumber(4);
         $campaign_run_id = $this->faker->randomNumber(4);
-        $quantity = $this->faker->numberBetween(10, 1000);
+        $quantity = 10;
         $caption = $this->faker->sentence;
 
         // Mock the Blink API calls.
@@ -82,11 +79,8 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPost()
     {
-        // Turn off feature flag that supports quantity splitting.
-        config(['features.v3QuantitySupport' => false]);
-
         $signup = factory(Signup::class)->create();
-        $quantity = $this->faker->numberBetween(10, 1000);
+        $quantity = 10;
         $caption = $this->faker->sentence;
 
         // Mock the Blink API call.
@@ -116,7 +110,9 @@ class PostApiTest extends TestCase
             'data' => [
                 'northstar_id' => $signup->northstar_id,
                 'status' => 'pending',
-                'quantity' => $signup->getQuantity(),
+                // If we are supporting quantity on the post, this value will be the submitted quantity,
+                // otherwise, we don't put anything on the post and it will be null.
+                'quantity' => config('features.v3QuantitySupport') ? $quantity : null,
                 'media' => [
                     'caption' => $caption,
                 ],
@@ -138,11 +134,8 @@ class PostApiTest extends TestCase
      */
     public function testCreatingMultiplePosts()
     {
-        // Turn off feature flag that supports quantity splitting.
-        config(['features.v3QuantitySupport' => false]);
-
         $signup = factory(Signup::class)->create();
-        $quantity = $this->faker->numberBetween(10, 1000);
+        $quantity = 30;
         $caption = $this->faker->sentence;
 
         // Mock the Blink API call.
@@ -172,7 +165,9 @@ class PostApiTest extends TestCase
             'data' => [
                 'northstar_id' => $signup->northstar_id,
                 'status' => 'pending',
-                'quantity' => $signup->getQuantity(),
+                // If we are supporting quantity on the post, this value will be the submitted quantity,
+                // otherwise, we don't put anything on the post and it will be null.
+                'quantity' => config('features.v3QuantitySupport') ? $quantity : null,
                 'media' => [
                     'caption' => $caption,
                 ],
@@ -187,7 +182,7 @@ class PostApiTest extends TestCase
         ]);
 
         // Create a second post without why_participated.
-        $secondQuantity = $this->faker->numberBetween(10, 1000);
+        $secondQuantity = 40;
         $secondCaption = $this->faker->sentence;
 
         $secondResponse = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
@@ -208,11 +203,15 @@ class PostApiTest extends TestCase
         ]);
 
         $secondResponse->assertStatus(200);
+
         $secondResponse->assertJson([
             'data' => [
                 'northstar_id' => $signup->northstar_id,
                 'status' => 'pending',
-                'quantity' => $signup->getQuantity(),
+                // If we are supporting quantity on the post,
+                // this value should be the the new, posted quantity minus
+                // the previous total, otherwise it is null.
+                'quantity' => config('features.v3QuantitySupport') ? 10 : null,
                 'media' => [
                     'caption' => $secondCaption,
                 ],
@@ -236,11 +235,8 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPostFromContentful()
     {
-        // Turn off feature flag that supports quantity splitting.
-        config(['features.v3QuantitySupport' => false]);
-
         $signup = factory(Signup::class)->states('contentful')->create();
-        $quantity = $this->faker->numberBetween(10, 1000);
+        $quantity = 10;
         $caption = $this->faker->sentence;
 
         // Mock the Blink API call.
@@ -269,7 +265,9 @@ class PostApiTest extends TestCase
             'data' => [
                 'northstar_id' => $signup->northstar_id,
                 'status' => 'pending',
-                'quantity' => $signup->getQuantity(),
+                // If we are supporting quantity on the post, this value will be the submitted quantity,
+                // otherwise, we don't put anything on the post and it will be null.
+                'quantity' => config('features.v3QuantitySupport') ? $quantity : null,
                 'media' => [
                     'caption' => $caption,
                 ],

--- a/tests/Http/Api/PostApiTest.php
+++ b/tests/Http/Api/PostApiTest.php
@@ -18,6 +18,9 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPostAndSignup()
     {
+        // Turn off feature flag that supports quantity splitting.
+        config(['features.v3QuantitySupport' => false]);
+
         $northstar_id = $this->faker->uuid;
         $campaign_id = $this->faker->randomNumber(4);
         $campaign_run_id = $this->faker->randomNumber(4);
@@ -79,6 +82,9 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPost()
     {
+        // Turn off feature flag that supports quantity splitting.
+        config(['features.v3QuantitySupport' => false]);
+
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
         $caption = $this->faker->sentence;
@@ -132,6 +138,9 @@ class PostApiTest extends TestCase
      */
     public function testCreatingMultiplePosts()
     {
+        // Turn off feature flag that supports quantity splitting.
+        config(['features.v3QuantitySupport' => false]);
+
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
         $caption = $this->faker->sentence;
@@ -227,6 +236,9 @@ class PostApiTest extends TestCase
      */
     public function testCreatingAPostFromContentful()
     {
+        // Turn off feature flag that supports quantity splitting.
+        config(['features.v3QuantitySupport' => false]);
+
         $signup = factory(Signup::class)->states('contentful')->create();
         $quantity = $this->faker->numberBetween(10, 1000);
         $caption = $this->faker->sentence;


### PR DESCRIPTION
#### What's this PR do?

This fixes a bug that was flagged by @weerd .

There was a bug in how we return quantity on a signup in `Signup::getQuantity()`

in  `Signup::getQuantity()` we made a decision on how to return `quantity` based on three things: 

1) If `features.v3QuantitySupport` was *not* true, then we were *not* supporting the splitting of quantity across posts and we should just return the quantity as stored in the `signup` table.

2) If there were no `posts` under a signup then we return the quantity as stored in the `signup` table.

3) If the first post under a signup did not have a quantity on it, then we made the assumption that it was an old post from before we split quantity on the post and returned the quantity as stored in the `signup` table.
  - This is where the issue was! If someone submitted a post *before* we split quantity on the post, quantity was `NULL` on the post. They then submitted a new post with a quantity but we were not accounting for that when we returned quantity on the signup. 

ALLLLL of that to say - this PR removes that test to see if the first post is null. 

This PR also fixes some of our `V2` API post tests which were  testing that the quantity on the post equalled the signup quantity which it should not check against. 

#### How should this be reviewed?

:eyes:


#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/154819638

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.