### PR TITLE
Storage::put expects the file to be sent as a string

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -45,7 +45,7 @@ class ImportController extends Controller
         $upload = $request->file('upload-file');
         $path = 'uploads/files/'. $request->input('importType') .'-import'.Carbon::now().'.csv';
         $csv = Reader::createFromPath($upload->getRealPath());
-        $success = Storage::put($path, $csv);
+        $success = Storage::put($path, (string) $csv);
 
         if (! $success) {
             throw new HttpException(500, 'Unable read and store file to S3.');


### PR DESCRIPTION
#### What's this PR do?

When testing the turbovote csv import on thor I was getting this error:

```
Feb 01 13:52:44 rogue-thor app/web.1: [01-Feb-2018 21:52:43 UTC] [2018-02-01 21:52:43] thor.ERROR: fstat() expects parameter 1 to be resource, object given {"exception":"[object] (ErrorException(code: 0): fstat() expects parameter 1 to be resource, object given at /app/vendor/league/flysystem/src/Util.php:271)"} {"user_id":"5550f8ec469c64bf3d8b6a63","client_id":null,"request_id":"82d06f9b-a921-41ae-8b97-5552f4e5c66e"}
```

`Storage::put()` expects the second parameter to be a string but we were sending it the CSV object. So this casts the csv as a string before storing it. 

#### How should this be reviewed?
👀 


#### Relevant tickets
Fixes 🐛 

