### PR TITLE
Updates SignupTransformer and PostTransformer to only return sensitive info. to admins and owners

### DIFF
--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -31,7 +31,7 @@ class PostTransformer extends TransformerAbstract
             $reacted = $post->reactions->isNotEmpty();
         }
 
-        return [
+        $response = [
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
@@ -44,17 +44,22 @@ class PostTransformer extends TransformerAbstract
                 'caption' => $post->caption,
             ],
             'quantity' => $post->quantity,
-            'tags' => $post->tagSlugs(),
             'reactions' => [
                 'reacted' => $reacted,
                 'total' => isset($post->reactions_count) ? $post->reactions_count : null,
             ],
             'status' => $post->status,
-            'source' => $post->source,
-            'remote_addr' => $post->remote_addr,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];
+
+        if (is_staff_user() || auth()->id() === $post->northstar_id) {
+            $response['tags'] = $post->tagSlugs();
+            $response['source'] = $post->source;
+            $response['remote_addr'] = $post->remote_addr;
+        }
+
+        return $response;
     }
 
     /**

--- a/app/Http/Transformers/Three/SignupTransformer.php
+++ b/app/Http/Transformers/Three/SignupTransformer.php
@@ -31,7 +31,6 @@ class SignupTransformer extends TransformerAbstract
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
             'quantity' => $signup->getQuantity(),
-            'source' => $signup->source,
             'details' => $signup->details,
             'created_at' => $signup->created_at->toIso8601String(),
             'updated_at' => $signup->updated_at->toIso8601String(),
@@ -39,6 +38,7 @@ class SignupTransformer extends TransformerAbstract
 
         if (is_staff_user() || auth()->id() === $signup->northstar_id) {
             $response['why_participated'] = $signup->why_participated;
+            $response['source'] = $signup->source;
         }
 
         return $response;

--- a/app/Http/Transformers/Three/SignupTransformer.php
+++ b/app/Http/Transformers/Three/SignupTransformer.php
@@ -25,18 +25,23 @@ class SignupTransformer extends TransformerAbstract
      */
     public function transform(Signup $signup)
     {
-        return [
+        $response = [
             'id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
             'quantity' => $signup->getQuantity(),
-            'why_participated' => $signup->why_participated,
             'source' => $signup->source,
             'details' => $signup->details,
             'created_at' => $signup->created_at->toIso8601String(),
             'updated_at' => $signup->updated_at->toIso8601String(),
         ];
+
+        if (is_staff_user() || auth()->id() === $signup->northstar_id) {
+            $response['why_participated'] = $signup->why_participated;
+        }
+
+        return $response;
     }
 
     /**

--- a/documentation/endpoints/v3/posts.md
+++ b/documentation/endpoints/v3/posts.md
@@ -6,7 +6,11 @@
 GET /api/v3/posts
 ```
 
-Posts are returned in reverse chronological order. Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
+Posts are returned in reverse chronological order. 
+
+Only admins and post owners will have `tags`, `source`, and `remote_addr` returned in the response.
+
+Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 
 ### Optional Query Parameters
 - **limit**
@@ -100,6 +104,9 @@ Example Response:
 ```
 GET /api/v3/posts/:post_id
 ```
+
+Only admins and post owners will have `tags`, `source`, and `remote_addr` returned in the response.
+
 Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 
 Example Response: 

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -45,6 +45,8 @@ Example response:
 ```
 GET /api/v3/signups
 ```
+Only admins and signup owners will have `why_participated` returned in the response.
+
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
 - **include** _(string)_
@@ -101,6 +103,8 @@ Example Response:
 ```
 GET /api/v3/signups/:signup_id
 ```
+Only admins and signup owners will have `why_participated` returned in the response.
+
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
 - **include** _(string)_

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -45,6 +45,7 @@ Example response:
 ```
 GET /api/v3/signups
 ```
+
 Only admins and signup owners will have `why_participated` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
@@ -103,6 +104,7 @@ Example Response:
 ```
 GET /api/v3/signups/:signup_id
 ```
+
 Only admins and signup owners will have `why_participated` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -31,11 +31,11 @@ Example response:
         "campaign_id": "362",
         "campaign_run_id": null,
         "quantity": null,
-        "why_participated": "to test",
-        "source": null,
         "details": null,
         "created_at": "2017-12-01T19:48:16+00:00",
         "updated_at": "2017-12-01T19:48:16+00:00"
+        "why_participated": "to test",
+        "source": null,
     }
 }
 ```
@@ -46,7 +46,7 @@ Example response:
 GET /api/v3/signups
 ```
 
-Only admins and signup owners will have `why_participated` returned in the response.
+Only admins and signup owners will have `why_participated` and `source` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
@@ -66,7 +66,6 @@ Example Response:
       "campaign_run_id": 6519,
       "quantity": null,
       "why_participated": "Eos architecto et quibusdam quasi.",
-      "source": "phoenix-web",
       "details": null,
       "created_at": "2017-08-14T21:20:51+00:00",
       "updated_at": "2017-08-15T16:03:25+00:00"
@@ -77,11 +76,12 @@ Example Response:
       "campaign_id": 1631,
       "campaign_run_id": 1626,
       "quantity": null,
-      "why_participated": "Non nobis ab asperiores fuga.",
       "source": "phoenix-web",
       "details": null,
       "created_at": "2017-08-14T21:20:51+00:00",
       "updated_at": "2017-08-30T19:08:25+00:00"
+      "why_participated": "Non nobis ab asperiores fuga.",
+      "source": "phoenix-web",
     },
   ],
   "meta": {
@@ -105,7 +105,7 @@ Example Response:
 GET /api/v3/signups/:signup_id
 ```
 
-Only admins and signup owners will have `why_participated` returned in the response.
+Only admins and signup owners will have `why_participated` and `source` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
@@ -123,11 +123,11 @@ Example Response:
     "campaign_id": 1173,
     "campaign_run_id": 6519,
     "quantity": null,
-    "why_participated": "Eos architecto et quibusdam quasi.",
-    "source": "phoenix-web",
     "details": null,
     "created_at": "2017-08-14T21:20:51+00:00",
     "updated_at": "2017-08-15T16:03:25+00:00",
+    "why_participated": "Eos architecto et quibusdam quasi.",
+    "source": "phoenix-web",
     "posts": {
       "data": []
     }
@@ -153,11 +153,11 @@ Example response:
         "campaign_id": "362",
         "campaign_run_id": null,
         "quantity": null,
-        "why_participated": "to test update",
-        "source": null,
         "details": null,
         "created_at": "2017-12-01T16:39:03+00:00",
         "updated_at": "2017-12-01T19:24:22+00:00"
+        "source": null,
+        "why_participated": "to test update",
     }
 }
 ```

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -31,8 +31,7 @@ class PostTest extends TestCase
             ->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($northstarId
-        )->json('POST', 'api/v3/posts', [
+        $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,
             'campaign_run_id'  => $campaignRunId,
             'quantity'         => $quantity,

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -31,7 +31,8 @@ class PostTest extends TestCase
             ->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($northstarId, 'admin')->json('POST', 'api/v3/posts', [
+        $response = $this->withAccessToken($northstarId
+        )->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,
             'campaign_run_id'  => $campaignRunId,
             'quantity'         => $quantity,
@@ -94,7 +95,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -153,7 +154,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -200,7 +201,7 @@ class PostTest extends TestCase
         $secondQuantity = $this->faker->numberBetween(10, 1000);
         $secondCaption = $this->faker->sentence;
 
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -257,7 +258,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -314,7 +315,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -385,12 +386,13 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test for retrieving all posts.
+     * Test for retrieving all posts as non-admin and non-owner.
+     * Non-admins/non-owners should not see tags, source, and remote_addr.
      *
      * GET /api/v3/posts
      * @return void
      */
-    public function testPostsIndex()
+    public function testPostsIndexAsNonAdminNonOwner()
     {
         // Anonymous requests should only see accepted posts.
         factory(Post::class, 'accepted', 10)->create();
@@ -413,14 +415,11 @@ class PostTest extends TestCase
                         'caption',
                     ],
                     'quantity',
-                    'tags' => [],
                     'reactions' => [
                         'reacted',
                         'total',
                     ],
                     'status',
-                    'source',
-                    'remote_addr',
                     'created_at',
                     'updated_at',
                 ],
@@ -437,54 +436,144 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test for retrieving all posts as a user.
-     *
-     * GET /api/v3/posts
-     * @return void
-     */
-    public function testPostsIndexAsUser()
-    {
-        $userId = $this->faker->northstar_id;
-
-        // The user should only see accepted posts & their own.
-        factory(Post::class, 'accepted', 10)->create();
-        factory(Post::class, 3)->create(['northstar_id' => $userId]);
-        factory(Post::class, 'rejected', 5)->create();
-
-        $response = $this->withAccessToken($userId)->getJson('api/v3/posts');
-
-        $response->assertStatus(200);
-        $response->assertJsonCount(13, 'data');
-    }
-
-    /**
-     * Test for retrieving all posts as an admin.
+     * Test for retrieving all posts as admin
+     * Admins should see tags, source, and remote_addr.
      *
      * GET /api/v3/posts
      * @return void
      */
     public function testPostsIndexAsAdmin()
     {
-        $userId = $this->faker->northstar_id;
-
-        // The admin should be able to see all of these posts!
+        // Admins should see all posts.
         factory(Post::class, 'accepted', 10)->create();
-        factory(Post::class, 3)->create(['northstar_id' => $userId]);
         factory(Post::class, 'rejected', 5)->create();
 
-        $response = $this->withAccessToken($userId, 'admin')->getJson('api/v3/posts');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/posts');
 
         $response->assertStatus(200);
-        $response->assertJsonCount(18, 'data');
+        $response->assertJsonCount(15, 'data');
+
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'signup_id',
+                    'northstar_id',
+                    'media' => [
+                        'url',
+                        'original_image_url',
+                        'caption',
+                    ],
+                    'quantity',
+                    'reactions' => [
+                        'reacted',
+                        'total',
+                    ],
+                    'status',
+                    'created_at',
+                    'updated_at',
+                    'tags' => [],
+                    'source',
+                    'remote_addr',
+                ],
+            ],
+            'meta' => [
+                'cursor' => [
+                    'current',
+                    'prev',
+                    'next',
+                    'count',
+                ],
+            ],
+        ]);
     }
 
     /**
-     * Test for retrieving a specific post.
+     * Test for retrieving all posts as owner.
+     * Owners should see tags, source, and remote_addr.
+     *
+     * GET /api/v3/posts
+     * @return void
+     */
+    public function testPostsIndexAsOwner()
+    {
+        // Owners should only see accepted posts and their own pending/rejected posts.
+        $posts = factory(Post::class, 2)->create();
+        $rejectedPosts = factory(Post::class, 'rejected', 3)->create();
+
+        $northstarId = $this->faker->northstar_id;
+
+        foreach ($posts as $post) {
+            $post->northstar_id = $northstarId;
+            $post->save();
+        }
+
+        foreach ($rejectedPosts as $rejectedPost) {
+            $rejectedPost->northstar_id = $this->faker->northstar_id;
+            $rejectedPost->save();
+        }
+
+        $response = $this->withAccessToken($northstarId)->getJson('api/v3/posts');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'signup_id',
+                    'northstar_id',
+                    'media' => [
+                        'url',
+                        'original_image_url',
+                        'caption',
+                    ],
+                    'quantity',
+                    'reactions' => [
+                        'reacted',
+                        'total',
+                    ],
+                    'status',
+                    'created_at',
+                    'updated_at',
+                    'tags' => [],
+                    'source',
+                    'remote_addr',
+                ],
+            ],
+            'meta' => [
+                'cursor' => [
+                    'current',
+                    'prev',
+                    'next',
+                    'count',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Test for retrieving a specific post as non-admin and non-owner.
      *
      * GET /api/v3/post/:post_id
      * @return void
      */
-    public function testPostShow()
+    public function testPostShowAsNonAdminNonOwner()
+    {
+        $post = factory(Post::class)->create();
+        $response = $this->getJson('api/v3/posts/' . $post->id);
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * Test for retrieving a specific post as admin.
+     *
+     * GET /api/v3/post/:post_id
+     * @return void
+     */
+    public function testPostShowAsAdmin()
     {
         $post = factory(Post::class)->create();
         $response = $this->withAdminAccessToken()->getJson('api/v3/posts/' . $post->id);
@@ -501,16 +590,56 @@ class PostTest extends TestCase
                     'caption',
                 ],
                 'quantity',
-                'tags' => [],
                 'reactions' => [
                     'reacted',
                     'total',
                 ],
                 'status',
-                'source',
-                'remote_addr',
                 'created_at',
                 'updated_at',
+                'tags' => [],
+                'source',
+                'remote_addr',
+            ],
+        ]);
+
+        $json = $response->json();
+        $this->assertEquals($post->id, $json['data']['id']);
+    }
+
+    /**
+     * Test for retrieving a specific post as owner.
+     *
+     * GET /api/v3/post/:post_id
+     * @return void
+     */
+    public function testPostShowAsOwner()
+    {
+        $post = factory(Post::class)->create();
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/posts/' . $post->id);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'signup_id',
+                'northstar_id',
+                'media' => [
+                    'url',
+                    'original_image_url',
+                    'caption',
+                ],
+                'quantity',
+                'reactions' => [
+                    'reacted',
+                    'total',
+                ],
+                'status',
+                'created_at',
+                'updated_at',
+                'tags' => [],
+                'source',
+                'remote_addr',
             ],
         ]);
 

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -191,15 +191,12 @@ class SignupTest extends TestCase
      */
     public function testSignupsIndexAsOwner()
     {
-        $signups = factory(Signup::class, 10)->create();
+        $northstarId = $this->faker->northstar_id;
+        $signups = factory(Signup::class, 10)->create([
+           'northstar_id' => $northstarId,
+        ]);
 
-        foreach ($signups as $signup) {
-            $signup->northstar_id = $this->faker->northstar_id;
-            $signup->save();
-        }
-
-        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups');
-
+        $response = $this->withAccessToken($northstarId)->getJson('api/v3/signups');
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data' => [

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -105,7 +105,7 @@ class SignupTest extends TestCase
 
     /**
      * Test for retrieving all signups as non-admin and non-owner.
-     * Non-admins/non-owners should not see why_participated in response.
+     * Non-admins/non-owners should not see why_participated or source in response.
      *
      * GET /api/v3/signups
      * @return void
@@ -125,7 +125,6 @@ class SignupTest extends TestCase
                     'campaign_id',
                     'campaign_run_id',
                     'quantity',
-                    'source',
                     'details',
                     'created_at',
                     'updated_at',
@@ -144,7 +143,7 @@ class SignupTest extends TestCase
 
     /**
      * Test for retrieving all signups as admin.
-     * Admins should see why_participated in response.
+     * Admins should see why_participated and source in response.
      *
      * GET /api/v3/signups
      * @return void
@@ -164,11 +163,11 @@ class SignupTest extends TestCase
                     'campaign_id',
                     'campaign_run_id',
                     'quantity',
-                    'source',
                     'details',
                     'created_at',
                     'updated_at',
                     'why_participated',
+                    'source',
                 ],
             ],
             'meta' => [
@@ -184,7 +183,7 @@ class SignupTest extends TestCase
 
     /**
      * Test for retrieving all signups as owner.
-     * Signup owner should see why_participated in response.
+     * Signup owner should see why_participated and source in response.
      *
      * GET /api/v3/signups
      * @return void
@@ -206,11 +205,11 @@ class SignupTest extends TestCase
                     'campaign_id',
                     'campaign_run_id',
                     'quantity',
-                    'source',
                     'details',
                     'created_at',
                     'updated_at',
                     'why_participated',
+                    'source',
                 ],
             ],
             'meta' => [
@@ -303,7 +302,6 @@ class SignupTest extends TestCase
                 'campaign_id',
                 'campaign_run_id',
                 'quantity',
-                'source',
                 'details',
                 'created_at',
                 'updated_at',
@@ -330,11 +328,11 @@ class SignupTest extends TestCase
                 'campaign_id',
                 'campaign_run_id',
                 'quantity',
-                'source',
                 'details',
                 'created_at',
                 'updated_at',
                 'why_participated',
+                'source',
             ],
         ]);
     }
@@ -358,11 +356,11 @@ class SignupTest extends TestCase
                 'campaign_id',
                 'campaign_run_id',
                 'quantity',
-                'source',
                 'details',
                 'created_at',
                 'updated_at',
                 'why_participated',
+                'source',
             ],
         ]);
     }

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -25,7 +25,7 @@ class SignupTest extends TestCase
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
 
-        $response = $this->withAccessToken($northstarId, 'admin')->postJson('api/v3/signups', [
+        $response = $this->withAccessToken($northstarId)->postJson('api/v3/signups', [
             'campaign_id' => $campaignId,
             'campaign_run_id' => $campaignRunId,
             'details' => 'affiliate-messaging',
@@ -67,7 +67,7 @@ class SignupTest extends TestCase
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
 
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->postJson('api/v3/signups', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/signups', [
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'source' => 'the-fox-den',
@@ -198,7 +198,7 @@ class SignupTest extends TestCase
             $signup->save();
         }
 
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->getJson('api/v3/signups');
+        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups');
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -280,7 +280,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that posts are returned.
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->getJson('api/v3/signups' . '?include=posts');
+        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups' . '?include=posts');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -351,7 +351,7 @@ class SignupTest extends TestCase
     public function testSignupShowAsOwner()
     {
         $signup = factory(Signup::class)->create();
-        $response = $this->withAccessToken($signup->northstar_id, 'admin')->getJson('api/v3/signups/' . $signup->id);
+        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups/' . $signup->id);
 
         $response->assertStatus(200);
         $response->assertJsonStructure([

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -276,7 +276,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that posts are returned.
-        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups' . '?include=posts');
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/signups' . '?include=posts');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 


### PR DESCRIPTION
#### What's this PR do?
- Updates SignupTransformer and PostTransformer to only return sensitive info. to admins and owners: 
  - Only admins and signup owners will get `why_participated` returned in the response
  - Only admins and post owners will get `tags`, `source`, and `remote_addr` returned in the response
- Updates tests
- Updates documentation

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154611572) Pivotal Card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.