### PR TITLE
Hit PostService when updating or deleting posts through v3 endpoints

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -151,6 +151,7 @@ class PostsController extends ApiController
      */
     public function update(Request $request, Post $post)
     {
+        info('update - postscontroller');
         $validatedRequest = $request->validate([
             'status' => 'in:pending,accepted,rejected',
             'caption' => 'nullable|string|max:140',
@@ -159,7 +160,8 @@ class PostsController extends ApiController
 
         // Only allow an admin or the user who owns the post to update.
         if (token()->role() === 'admin' || auth()->id() === $post->northstar_id) {
-            $post->update($validatedRequest);
+            info('we updating');
+            $this->posts->update($validatedRequest);
 
             return $this->item($post);
         }
@@ -176,7 +178,8 @@ class PostsController extends ApiController
      */
     public function destroy(Post $post)
     {
-        $post->delete();
+        info('destroy - postscontroller');
+        $this->posts->destroy($post->id);
 
         return $this->respond('Post deleted.', 200);
     }

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -116,6 +116,7 @@ class PostsController extends ApiController
         }
 
         $code = $updating ? 200 : 201;
+
         return $this->item($post, $code, [], null, 'signup');
     }
 

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -158,7 +158,6 @@ class PostsController extends ApiController
 
         // Only allow an admin or the user who owns the post to update.
         if (token()->role() === 'admin' || auth()->id() === $post->northstar_id) {
-            info('we updating');
             $this->posts->update($post, $validatedRequest);
 
             return $this->item($post);
@@ -176,7 +175,6 @@ class PostsController extends ApiController
      */
     public function destroy(Post $post)
     {
-        info('destroy - postscontroller');
         $this->posts->destroy($post->id);
 
         return $this->respond('Post deleted.', 200);

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -112,11 +112,10 @@ class PostsController extends ApiController
             $signup = $this->signups->create($request->all(), $northstarId);
             $post = $this->posts->create($request->all(), $signup->id);
         } else {
-            $post = $this->posts->update($signup, $request->all());
+            $post = $this->posts->create($request->all(), $signup->id);
         }
 
         $code = $updating ? 200 : 201;
-
         return $this->item($post, $code, [], null, 'signup');
     }
 

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -151,9 +151,7 @@ class PostsController extends ApiController
      */
     public function update(Request $request, Post $post)
     {
-        info('update - postscontroller');
         $validatedRequest = $request->validate([
-            'status' => 'in:pending,accepted,rejected',
             'caption' => 'nullable|string|max:140',
             'quantity' => 'nullable|integer',
         ]);
@@ -161,7 +159,7 @@ class PostsController extends ApiController
         // Only allow an admin or the user who owns the post to update.
         if (token()->role() === 'admin' || auth()->id() === $post->northstar_id) {
             info('we updating');
-            $this->posts->update($validatedRequest);
+            $this->posts->update($post, $validatedRequest);
 
             return $this->item($post);
         }

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -139,7 +139,6 @@ class PostRepository
      */
     public function destroy($postId)
     {
-        info('destroy - PostRepository');
         $post = Post::findOrFail($postId);
 
         // Delete the image file from AWS.

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -150,6 +150,7 @@ class PostRepository
      */
     public function destroy($postId)
     {
+        info('destroy - PostRepository');
         $post = Post::findOrFail($postId);
 
         // Delete the image file from AWS.

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -117,29 +117,18 @@ class PostRepository
     }
 
     /**
-     * Update an existing Post and Signup.
+     * Update an existing Post.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \Rogue\Models\Post $post
      * @param array $data
      *
-     * @return Signup|Post
+     * @return Post
      */
-    public function update($signup, $data)
+    public function update($post, $data)
     {
-        // Should only update why_participated on the signup.
-        if (isset($data['why_participated'])) {
-            $signup->fill(array_only($data, $data['why_participated']));
+        $post->update($data);
 
-            // Triggers model event that logs the updated signup in the events table.
-            $signup->save();
-        }
-
-        // If there is a file, create a new post.
-        if (array_key_exists('file', $data)) {
-            return $this->create($data, $signup->id);
-        }
-
-        return $signup;
+        return $post;
     }
 
     /**

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -37,7 +37,6 @@ class PostService
      */
     public function create($data, $signupId, $authenticatedUserRole = null)
     {
-        info('create - postservice v3');
         $post = $this->repository->create($data, $signupId, $authenticatedUserRole);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
@@ -61,24 +60,21 @@ class PostService
      * @param array $data
      * @return \Rogue\Models\Post|\Rogue\Models\Signup
      */
-    public function update($signup, $data)
+    public function update($post, $data)
     {
-        info('update - postservice v3');
-        $postOrSignup = $this->repository->update($signup, $data);
+        $post = $this->repository->update($post, $data);
 
-        if ($postOrSignup instanceof Post) {
-            // Save the new post in Customer.io, via Blink,
-            // unless 'dont_send_to_blink' is TRUE.
-            $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
-            if (config('features.blink') && $should_send_to_blink) {
-                SendPostToBlink::dispatch($postOrSignup);
-            }
-
-            // Log that a post was created.
-            info('post_created', ['id' => $postOrSignup->id, 'signup_id' => $postOrSignup->signup_id]);
+        // Save the new post in Customer.io, via Blink,
+        // unless 'dont_send_to_blink' is TRUE.
+        $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+        if (config('features.blink') && $should_send_to_blink) {
+            SendPostToBlink::dispatch($postOrSignup);
         }
 
-        return $postOrSignup;
+        // Log that a post was created.
+        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+
+        return $post;
     }
 
     /**
@@ -89,7 +85,6 @@ class PostService
      */
     public function destroy($postId)
     {
-        info('destroy - postservice');
         info('post_deleted', [
             'id' => $postId,
         ]);

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -68,7 +68,7 @@ class PostService
         // unless 'dont_send_to_blink' is TRUE.
         $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
         if (config('features.blink') && $should_send_to_blink) {
-            SendPostToBlink::dispatch($postOrSignup);
+            SendPostToBlink::dispatch($post);
         }
 
         // Log that a post was created.

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -37,6 +37,7 @@ class PostService
      */
     public function create($data, $signupId, $authenticatedUserRole = null)
     {
+        info('create - postservice v3');
         $post = $this->repository->create($data, $signupId, $authenticatedUserRole);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
@@ -62,6 +63,7 @@ class PostService
      */
     public function update($signup, $data)
     {
+        info('update - postservice v3');
         $postOrSignup = $this->repository->update($signup, $data);
 
         if ($postOrSignup instanceof Post) {
@@ -87,6 +89,7 @@ class PostService
      */
     public function destroy($postId)
     {
+        info('destroy - postservice');
         info('post_deleted', [
             'id' => $postId,
         ]);

--- a/documentation/endpoints/v3/posts.md
+++ b/documentation/endpoints/v3/posts.md
@@ -198,8 +198,6 @@ Example Response:
 PATCH /api/v3/posts/:post_id
 ```
 
-  - **status**: (string) 
-    The status of a post. Must be either pending, accepted, or rejected.
   - **caption**: (string) 
     The caption of the post.
   - **quantity**: (int)
@@ -208,7 +206,7 @@ PATCH /api/v3/posts/:post_id
 Example request body:
 ```
 [
-  "status" => "accepted"
+  "caption" => "Here is a brand new caption"
   "quantity" => "7"
 ]
 ```
@@ -223,7 +221,7 @@ Example response:
       "media": {
           "url": "http://localhost/storage/uploads/reportback-items/edited_332.jpeg?time=1509379493",
           "original_image_url": "http://localhost/storage/uploads/reportback-items/289-923df5957838355206574f72d5520f0f-1509115822.jpeg?time=1509379493",
-          "caption": "i love this cause"
+          "caption": "Here is a brand new caption"
       },
       "quantity": "7",
       "tags": [],

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -528,6 +528,8 @@ class PostTest extends TestCase
     {
         $post = factory(Post::class)->create();
 
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
         $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
             'caption' => 'new caption',
             'quantity' => 8,

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -529,7 +529,6 @@ class PostTest extends TestCase
         $post = factory(Post::class)->create();
 
         $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
-            'status' => 'accepted',
             'caption' => 'new caption',
             'quantity' => 8,
         ]);
@@ -537,7 +536,6 @@ class PostTest extends TestCase
         $response->assertStatus(200);
 
         // Make sure that the posts's new status and caption gets persisted in the database.
-        $this->assertEquals($post->fresh()->status, 'accepted');
         $this->assertEquals($post->fresh()->caption, 'new caption');
         $this->assertEquals($post->fresh()->quantity, 8);
     }
@@ -553,14 +551,14 @@ class PostTest extends TestCase
         $post = factory(Post::class)->create();
 
         $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
-            'status' => 'approved',
+            'quantity' => 'this is words not a number!',
             'caption' => 'This must be longer than 140 characters to break the validation rules so here I will create a caption that is longer than 140 characters to test.',
         ]);
 
         $response->assertStatus(422);
 
         $json = $response->json();
-        $this->assertEquals('The selected status is invalid.', $json['errors']['status'][0]);
+        $this->assertEquals('The quantity must be an integer.', $json['errors']['quantity'][0]);
         $this->assertEquals('The caption may not be greater than 140 characters.', $json['errors']['caption'][0]);
     }
 


### PR DESCRIPTION
#### What's this PR do?
This touches `v3/posts` `delete` and `patch`. Documentation is updated to reflect changes.

Delete:
- Call the existing `destroy` method in `PostService`
- No changes to `PostService` or `PostRepository`

Patch:
More changes here!
- Do not accept `status` because those changes will come in through `v3/reviews`
- Hit the `update` method of `PostService`
- In `PostService`, assume that we are always working with a Post and never a Signup
- In `PostRepository`, same deal, only update the Post and don't mess with Signups

#### How should this be reviewed?
Does this contain any breaking changes? See a better way to do anything?

#### Any background context you want to provide?
We need to always do alterations through the service classes to be sure that any business logic happens.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/154877666)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.