### PR TITLE
Gates details in SignupTransformer for only admins and owners of signup to see 

### DIFF
--- a/app/Http/Transformers/Three/SignupTransformer.php
+++ b/app/Http/Transformers/Three/SignupTransformer.php
@@ -31,7 +31,6 @@ class SignupTransformer extends TransformerAbstract
             'campaign_id' => $signup->campaign_id,
             'campaign_run_id' => $signup->campaign_run_id,
             'quantity' => $signup->getQuantity(),
-            'details' => $signup->details,
             'created_at' => $signup->created_at->toIso8601String(),
             'updated_at' => $signup->updated_at->toIso8601String(),
         ];
@@ -39,6 +38,7 @@ class SignupTransformer extends TransformerAbstract
         if (is_staff_user() || auth()->id() === $signup->northstar_id) {
             $response['why_participated'] = $signup->why_participated;
             $response['source'] = $signup->source;
+            $response['details'] = $signup->details;
         }
 
         return $response;

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -31,11 +31,11 @@ Example response:
         "campaign_id": "362",
         "campaign_run_id": null,
         "quantity": null,
-        "details": null,
         "created_at": "2017-12-01T19:48:16+00:00",
         "updated_at": "2017-12-01T19:48:16+00:00"
         "why_participated": "to test",
         "source": null,
+        "details": null,
     }
 }
 ```
@@ -46,7 +46,7 @@ Example response:
 GET /api/v3/signups
 ```
 
-Only admins and signup owners will have `why_participated` and `source` returned in the response.
+Only admins and signup owners will have `why_participated`, `source`, and `details` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
@@ -65,10 +65,11 @@ Example Response:
       "campaign_id": 1173,
       "campaign_run_id": 6519,
       "quantity": null,
-      "why_participated": "Eos architecto et quibusdam quasi.",
-      "details": null,
       "created_at": "2017-08-14T21:20:51+00:00",
       "updated_at": "2017-08-15T16:03:25+00:00"
+      "why_participated": "Eos architecto et quibusdam quasi.",
+      "source": "phoenix-web",
+      "details": null,
     },
     {
       "id": 2,
@@ -76,12 +77,11 @@ Example Response:
       "campaign_id": 1631,
       "campaign_run_id": 1626,
       "quantity": null,
-      "source": "phoenix-web",
-      "details": null,
       "created_at": "2017-08-14T21:20:51+00:00",
       "updated_at": "2017-08-30T19:08:25+00:00"
       "why_participated": "Non nobis ab asperiores fuga.",
       "source": "phoenix-web",
+      "details": null,
     },
   ],
   "meta": {
@@ -105,7 +105,7 @@ Example Response:
 GET /api/v3/signups/:signup_id
 ```
 
-Only admins and signup owners will have `why_participated` and `source` returned in the response.
+Only admins and signup owners will have `why_participated`, `source`, and `details` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 ### Optional Query Parameters
@@ -123,11 +123,11 @@ Example Response:
     "campaign_id": 1173,
     "campaign_run_id": 6519,
     "quantity": null,
-    "details": null,
     "created_at": "2017-08-14T21:20:51+00:00",
     "updated_at": "2017-08-15T16:03:25+00:00",
     "why_participated": "Eos architecto et quibusdam quasi.",
     "source": "phoenix-web",
+    "details": null,
     "posts": {
       "data": []
     }
@@ -153,11 +153,11 @@ Example response:
         "campaign_id": "362",
         "campaign_run_id": null,
         "quantity": null,
-        "details": null,
         "created_at": "2017-12-01T16:39:03+00:00",
         "updated_at": "2017-12-01T19:24:22+00:00"
-        "source": null,
         "why_participated": "to test update",
+        "source": null,
+        "details": null,
     }
 }
 ```

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -105,7 +105,7 @@ class SignupTest extends TestCase
 
     /**
      * Test for retrieving all signups as non-admin and non-owner.
-     * Non-admins/non-owners should not see why_participated or source in response.
+     * Non-admins/non-owners should not see why_participated, source, or details in response.
      *
      * GET /api/v3/signups
      * @return void
@@ -125,7 +125,6 @@ class SignupTest extends TestCase
                     'campaign_id',
                     'campaign_run_id',
                     'quantity',
-                    'details',
                     'created_at',
                     'updated_at',
                 ],
@@ -143,7 +142,7 @@ class SignupTest extends TestCase
 
     /**
      * Test for retrieving all signups as admin.
-     * Admins should see why_participated and source in response.
+     * Admins should see why_participated, source, and details in response.
      *
      * GET /api/v3/signups
      * @return void
@@ -163,11 +162,11 @@ class SignupTest extends TestCase
                     'campaign_id',
                     'campaign_run_id',
                     'quantity',
-                    'details',
                     'created_at',
                     'updated_at',
                     'why_participated',
                     'source',
+                    'details',
                 ],
             ],
             'meta' => [
@@ -183,7 +182,7 @@ class SignupTest extends TestCase
 
     /**
      * Test for retrieving all signups as owner.
-     * Signup owner should see why_participated and source in response.
+     * Signup owner should see why_participated, source, and details in response.
      *
      * GET /api/v3/signups
      * @return void
@@ -205,11 +204,11 @@ class SignupTest extends TestCase
                     'campaign_id',
                     'campaign_run_id',
                     'quantity',
-                    'details',
                     'created_at',
                     'updated_at',
                     'why_participated',
                     'source',
+                    'details',
                 ],
             ],
             'meta' => [
@@ -328,11 +327,11 @@ class SignupTest extends TestCase
                 'campaign_id',
                 'campaign_run_id',
                 'quantity',
-                'details',
                 'created_at',
                 'updated_at',
                 'why_participated',
                 'source',
+                'details',
             ],
         ]);
     }
@@ -356,11 +355,11 @@ class SignupTest extends TestCase
                 'campaign_id',
                 'campaign_run_id',
                 'quantity',
-                'details',
                 'created_at',
                 'updated_at',
                 'why_participated',
                 'source',
+                'details',
             ],
         ]);
     }

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -301,7 +301,6 @@ class SignupTest extends TestCase
                 'campaign_id',
                 'campaign_run_id',
                 'quantity',
-                'details',
                 'created_at',
                 'updated_at',
             ],


### PR DESCRIPTION
#### What's this PR do?
- Gates details in SignupTransformer for only admins and owners of signup to see 
- Updates tests
- Updates documentation 

#### How should this be reviewed?
👀 

#### Relevant tickets
Relevant work in #608 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.