### PR TITLE
POST /api/v3/posts - Update to store new post columns

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -106,20 +106,13 @@ class PostsController extends ApiController
 
         $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
 
-        $signupExists = ! is_null($signup);
-
-        if (! $signupExists) {
+        if (! $signup) {
             $signup = $this->signups->create($request->all(), $northstarId);
-            $post = $this->posts->create($request->all(), $signup->id);
-        } else {
-            $post = $this->posts->create($request->all(), $signup->id);
         }
 
-        // @TODO - We should probably only ever return a 201 here since all
-        // this does is create a resource.
-        $code = $signupExists ? 200 : 201;
+        $post = $this->posts->create($request->all(), $signup->id);
 
-        return $this->item($post, $code, [], null, 'signup');
+        return $this->item($post, 201, [], null, 'signup');
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -115,8 +115,8 @@ class PostsController extends ApiController
             $post = $this->posts->create($request->all(), $signup->id);
         }
 
-        // @TODO - We should probably only ever return a 201 here since all this does is
-        // create a resource.
+        // @TODO - We should probably only ever return a 201 here since all
+        // this does is create a resource.
         $code = $signupExists ? 200 : 201;
 
         return $this->item($post, $code, [], null, 'signup');

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -106,16 +106,18 @@ class PostsController extends ApiController
 
         $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
 
-        $updating = ! is_null($signup);
+        $signupExists = ! is_null($signup);
 
-        if (! $updating) {
+        if (! $signupExists) {
             $signup = $this->signups->create($request->all(), $northstarId);
             $post = $this->posts->create($request->all(), $signup->id);
         } else {
             $post = $this->posts->create($request->all(), $signup->id);
         }
 
-        $code = $updating ? 200 : 201;
+        // @TODO - We should probably only ever return a 201 here since all this does is
+        // create a resource.
+        $code = $signupExists ? 200 : 201;
 
         return $this->item($post, $code, [], null, 'signup');
     }

--- a/app/Http/Requests/Three/PostRequest.php
+++ b/app/Http/Requests/Three/PostRequest.php
@@ -27,7 +27,7 @@ class PostRequest extends Request
             'campaign_id' => 'required',
             'campaign_run_id' => 'required_with:campaign_id|integer',
             'northstar_id' => 'nullable|objectid',
-            'type' => 'required|string',
+            'type' => 'required|string|in:photo,voter-reg',
             'action' => 'required|string',
             'why_participated' => 'nullable|string',
             'caption' => 'required|nullable|string|max:140',

--- a/app/Http/Requests/Three/PostRequest.php
+++ b/app/Http/Requests/Three/PostRequest.php
@@ -27,11 +27,14 @@ class PostRequest extends Request
             'campaign_id' => 'required',
             'campaign_run_id' => 'required_with:campaign_id|integer',
             'northstar_id' => 'nullable|objectid',
+            'type' => 'required|string',
+            'action' => 'required|string',
             'why_participated' => 'nullable|string',
             'caption' => 'required|nullable|string|max:140',
             'quantity' => 'nullable|integer',
             'file' => 'image|dimensions:min_width=400,min_height=400',
             'status' => 'in:pending,accepted,rejected',
+            'details'=> 'json',
         ];
     }
 }

--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -35,8 +35,6 @@ class PostTransformer extends TransformerAbstract
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
-            'type' => $post->type,
-            'action' => $post->action,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.
             // @NOTE - Remove if we get rid of rotation.
@@ -51,7 +49,6 @@ class PostTransformer extends TransformerAbstract
                 'total' => isset($post->reactions_count) ? $post->reactions_count : null,
             ],
             'status' => $post->status,
-            'details' => $post->details,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];
@@ -60,6 +57,9 @@ class PostTransformer extends TransformerAbstract
             $response['tags'] = $post->tagSlugs();
             $response['source'] = $post->source;
             $response['remote_addr'] = $post->remote_addr;
+            $response['type'] = $post->type;
+            $response['action'] = $post->action;
+            $response['details'] = $post->details;
         }
 
         return $response;

--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -35,6 +35,8 @@ class PostTransformer extends TransformerAbstract
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
+            'type' => $post->type,
+            'action' => $post->action,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.
             // @NOTE - Remove if we get rid of rotation.
@@ -49,6 +51,7 @@ class PostTransformer extends TransformerAbstract
                 'total' => isset($post->reactions_count) ? $post->reactions_count : null,
             ],
             'status' => $post->status,
+            'details' => $post->details,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -84,7 +84,7 @@ class PostRepository
             'campaign_id' => $signup->campaign_id,
             'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
             'type' => isset($data['type']) ? $data['type'] : 'photo',
-            'action_bucket' => isset($data['action_bucket']) ? $data['action_bucket'] : null,
+            'action' => isset($data['action']) ? $data['action'] : null,
             'url' => $fileUrl,
             'caption' => isset($data['caption']) ? $data['caption'] : null,
             'status' => 'pending',

--- a/documentation/endpoints/v3/posts.md
+++ b/documentation/endpoints/v3/posts.md
@@ -6,7 +6,7 @@
 GET /api/v3/posts
 ```
 
-Posts are returned in reverse chronological order. 
+Posts are returned in reverse chronological order.
 
 Only admins and post owners will have `tags`, `source`, and `remote_addr` returned in the response.
 
@@ -109,7 +109,7 @@ Only admins and post owners will have `tags`, `source`, and `remote_addr` return
 
 Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 
-Example Response: 
+Example Response:
 
 ```
 {
@@ -146,8 +146,12 @@ POST /api/v3/posts
 ```
   - **campaign_id**: (int|string) required.
     The Drupal/Contentful ID of the campaign that the user's post is associated with.
-  - **campaign_run_id**: (int) optional.
+  - **campaign_run_id**: (int) required with campaign_id.
     The drupal campaign run node id of the campaign that the user's post is associated with.
+  - **type**: (string) required.
+    The type of post submitted e.g. photo, call, voter-reg
+  - **action**: (string) required.
+    Describes the action that the post is tied to.
   - **quantity**: (int|nullable) optional.
     The number of reportback nouns verbed. Can be `null`.
   - **why_participated**: (string).
@@ -156,8 +160,10 @@ POST /api/v3/posts
     Corresponding caption for the post.
   - **status**: (string).
     Option to set status upon creation if admin uploads post for user.
-  - **file**: (file) required.
+  - **file**: (file) required for photo posts.
     File string to save of post image.
+  - **details** (json).
+    A JSON field to store extra details about a post.
   - **dont_send_to_blink** (boolean) optional.
     If included and true, the data for this Post will not be sent to Blink.
 
@@ -189,7 +195,7 @@ Example Response:
 ```
 DELETE /api/v3/posts/:post_id
 ```
-Example Response: 
+Example Response:
 
 ```
 {
@@ -205,11 +211,11 @@ Example Response:
 PATCH /api/v3/posts/:post_id
 ```
 
-  - **caption**: (string) 
+  - **caption**: (string)
     The caption of the post.
   - **quantity**: (int)
-    The quantity of items in the post. 
-  
+    The quantity of items in the post.
+
 Example request body:
 ```
 [

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -24,6 +24,7 @@ class PostTest extends TestCase
         $campaignRunId = $this->faker->randomNumber(4);
         $quantity = $this->faker->numberBetween(10, 1000);
         $caption = $this->faker->sentence;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API calls.
         $this->mock(Blink::class)
@@ -34,10 +35,13 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,
             'campaign_run_id'  => $campaignRunId,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
             'caption'          => $caption,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+            'details'          => json_encode($details),
         ]);
 
         $response->assertStatus(201);
@@ -46,6 +50,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -58,6 +64,7 @@ class PostTest extends TestCase
                     'total',
                 ],
                 'status',
+                'details',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -74,8 +81,11 @@ class PostTest extends TestCase
         $this->assertDatabaseHas('posts', [
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
+            'type' => 'photo',
+            'action' => 'test-action',
             'status' => 'pending',
             'quantity' => $quantity,
+            'details' => json_encode($details),
         ]);
     }
 
@@ -89,6 +99,7 @@ class PostTest extends TestCase
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
         $caption = $this->faker->sentence;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -98,10 +109,13 @@ class PostTest extends TestCase
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
             'caption'          => $caption,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+            'details'          => json_encode($details),
         ]);
 
         $response->assertStatus(200);
@@ -110,6 +124,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -122,6 +138,7 @@ class PostTest extends TestCase
                     'total',
                 ],
                 'status',
+                'details',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -133,8 +150,11 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
+            'type' => 'photo',
+            'action' => 'test-action',
             'status' => 'pending',
             'quantity' => $quantity,
+            'details' => json_encode($details),
         ]);
     }
 
@@ -148,6 +168,7 @@ class PostTest extends TestCase
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
         $caption = $this->faker->sentence;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -157,10 +178,13 @@ class PostTest extends TestCase
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
             'caption'          => $caption,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+            'details'          => json_encode($details),
         ]);
 
         $response->assertStatus(200);
@@ -169,6 +193,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -181,6 +207,7 @@ class PostTest extends TestCase
                     'total',
                 ],
                 'status',
+                'details',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -192,21 +219,28 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
+            'type' => 'photo',
+            'action' => 'test-action',
             'status' => 'pending',
             'quantity' => $quantity,
+            'details' => json_encode($details),
         ]);
 
         // Create a second post without why_participated.
         $secondQuantity = $this->faker->numberBetween(10, 1000);
         $secondCaption = $this->faker->sentence;
+        $secondDetails = ['source-detail' => 'broadcast-333', 'other' => 'other'];
 
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'quantity'         => $secondQuantity,
             'caption'          => $secondCaption,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+            'details'          => json_encode($secondDetails),
         ]);
 
         $response->assertStatus(200);
@@ -215,6 +249,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -227,6 +263,7 @@ class PostTest extends TestCase
                     'total',
                 ],
                 'status',
+                'details',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -238,8 +275,11 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
+            'type' => 'photo',
+            'action' => 'test-action',
             'status' => 'pending',
-            'quantity' => $quantity,
+            'quantity' => $secondQuantity,
+            'details' => json_encode($secondDetails),
         ]);
     }
 
@@ -252,6 +292,7 @@ class PostTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
         $caption = $this->faker->sentence;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -261,9 +302,12 @@ class PostTest extends TestCase
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'quantity'         => null,
             'caption'          => $caption,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+            'details'          => json_encode($details),
         ]);
 
         $response->assertStatus(200);
@@ -272,6 +316,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -284,6 +330,7 @@ class PostTest extends TestCase
                     'total',
                 ],
                 'status',
+                'details',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -295,8 +342,11 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
+            'type' => 'photo',
+            'action' => 'test-action',
             'status' => 'pending',
             'quantity' => null,
+            'details' => json_encode($details),
         ]);
     }
 
@@ -318,6 +368,8 @@ class PostTest extends TestCase
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'caption'          => $caption,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
         ]);
@@ -328,6 +380,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -340,6 +394,7 @@ class PostTest extends TestCase
                     'total',
                 ],
                 'status',
+                'details',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -351,8 +406,11 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
+            'type' => 'photo',
+            'action' => 'test-action',
             'status' => 'pending',
             'quantity' => null,
+            'details' => null,
         ]);
     }
 
@@ -375,6 +433,8 @@ class PostTest extends TestCase
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'photo',
+            'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
             'caption'          => $caption,
@@ -458,6 +518,8 @@ class PostTest extends TestCase
                     'id',
                     'signup_id',
                     'northstar_id',
+                    'type',
+                    'action',
                     'media' => [
                         'url',
                         'original_image_url',
@@ -473,6 +535,7 @@ class PostTest extends TestCase
                     'updated_at',
                     'tags' => [],
                     'source',
+                    'details',
                     'remote_addr',
                 ],
             ],
@@ -523,6 +586,8 @@ class PostTest extends TestCase
                     'id',
                     'signup_id',
                     'northstar_id',
+                    'type',
+                    'action',
                     'media' => [
                         'url',
                         'original_image_url',
@@ -538,6 +603,7 @@ class PostTest extends TestCase
                     'updated_at',
                     'tags' => [],
                     'source',
+                    'details',
                     'remote_addr',
                 ],
             ],
@@ -583,6 +649,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -598,6 +666,7 @@ class PostTest extends TestCase
                 'updated_at',
                 'tags' => [],
                 'source',
+                'details',
                 'remote_addr',
             ],
         ]);
@@ -623,6 +692,8 @@ class PostTest extends TestCase
                 'id',
                 'signup_id',
                 'northstar_id',
+                'type',
+                'action',
                 'media' => [
                     'url',
                     'original_image_url',
@@ -638,6 +709,7 @@ class PostTest extends TestCase
                 'updated_at',
                 'tags' => [],
                 'source',
+                'details',
                 'remote_addr',
             ],
         ]);

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -118,7 +118,7 @@ class PostTest extends TestCase
             'details'          => json_encode($details),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
         $response->assertJsonStructure([
             'data' => [
                 'id',
@@ -187,7 +187,7 @@ class PostTest extends TestCase
             'details'          => json_encode($details),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
         $response->assertJsonStructure([
             'data' => [
                 'id',
@@ -243,7 +243,7 @@ class PostTest extends TestCase
             'details'          => json_encode($secondDetails),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
         $response->assertJsonStructure([
             'data' => [
                 'id',
@@ -310,7 +310,7 @@ class PostTest extends TestCase
             'details'          => json_encode($details),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
         $response->assertJsonStructure([
             'data' => [
                 'id',
@@ -374,7 +374,7 @@ class PostTest extends TestCase
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
         $response->assertJsonStructure([
             'data' => [
                 'id',


### PR DESCRIPTION
#### What's this PR do?
This updates the `POST /api/v3/posts` API endpoint to validate, store, and return the new `type`, `action`, and `details` columns that we added to support multiple actions. 

Updates the `Three\PostTransformer` to return these new columns, but only returns them for admins and post-owners. *Thoughts on gating all of these columns?*

Updates V3 PostAPITest. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Going to go through each endpoint individually to see how it could be updated to support these new columns. This is just the first one but I think updating `PostTransformer` gets us most of the way there. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/154154145

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.