### PR TITLE
Add additional fields to post Quasar payload

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -190,10 +190,13 @@ class Post extends Model
         return [
             'id' => $this->id,
             'signup_id' => $this->signup_id,
+            'campaign_id' => $this->campaign_id,
+            'campaign_run_id' => $this->signup->campaign_run_id,
             'northstar_id' => $this->northstar_id,
             'type' => $this->type,
             'action' => $this->action,
             'quantity' => $this->quantity,
+            'why_participated' => $this->signup->why_participated,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.
             // @NOTE - Remove if we get rid of rotation.
@@ -204,10 +207,13 @@ class Post extends Model
             'tags' => $this->tagSlugs(),
             'status' => $this->status,
             'source' => $this->source,
+            'signup_source' => $this->signup->source,
             'remote_addr' => $this->remote_addr,
             'details' => $this->details,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
+            'signup_created_at' => $this->signup->created_at->toIso8601String(),
+            'signup_updated_at' => $this->signup->updated_at->toIso8601String(),
             'meta' => [
                 'message_source' => 'rogue',
                 'type' => 'post',


### PR DESCRIPTION
#### What's this PR do?
1. Adds `campaign_id` (which was supposed to be there all along!)
2. Added some signup fields that were needed to ingest posts which were previously retrieved from the signup portion of the `/activity` response.

#### How should this be reviewed?
1. Is the signup reloaded each time we call `$this->signup`? I want to make sure this isn't too bad performance wise.
2. The signup fields were already sent with the signup, but this is how data currently expects it and it is a large lift on their side to alter that, while on our side we just need to add 5 easy lines.
3. From @sheyd : Next sprint, Team Storm will discuss changing Quasar data model to not necessitate sending signup data on posts anymore (as part of MySQL -> Postgres).

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/154725135)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.