### PR TITLE
Adds orderBy filter for v3 Signup Index and tests & updates logic to save summed quantity on signup when post is created or updated

### DIFF
--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -94,7 +94,7 @@ class SignupsController extends ApiController
             $query = $query->withVisiblePosts();
         }
 
-        $orderBy = $request->query('order_by');
+        $orderBy = $request->query('orderBy');
 
         if ($orderBy) {
             list($column, $direction) = explode(',', $orderBy, 2);

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -94,10 +94,14 @@ class SignupsController extends ApiController
             $query = $query->withVisiblePosts();
         }
 
-        if ($request->query('orderByQuantity') === 'desc') {
-            $query = $query->orderBy('quantity', 'desc');
-        } elseif ($request->query('orderByQuantity') === 'asc') {
-            $query = $query->orderBy('quantity', 'asc');
+        $orderBy = $request->query('order_by');
+
+        if ($orderBy) {
+            list($column, $direction) = explode(',', $orderBy, 2);
+
+            if (in_array($column, Signup::$indexes)) {
+                $query = $query->orderBy($column, $direction);
+            }
         }
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -96,6 +96,8 @@ class SignupsController extends ApiController
 
         if ($request->query('orderByQuantity') === 'desc') {
             $query = $query->orderBy('quantity', 'desc');
+        } elseif ($request->query('orderByQuantity') === 'asc') {
+             $query = $query->orderBy('quantity', 'asc');
         }
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -94,6 +94,10 @@ class SignupsController extends ApiController
             $query = $query->withVisiblePosts();
         }
 
+        if ($request->query('orderByQuantity') === 'desc') {
+            $query = $query->orderBy('quantity', 'desc');
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -97,7 +97,7 @@ class SignupsController extends ApiController
         if ($request->query('orderByQuantity') === 'desc') {
             $query = $query->orderBy('quantity', 'desc');
         } elseif ($request->query('orderByQuantity') === 'asc') {
-             $query = $query->orderBy('quantity', 'asc');
+            $query = $query->orderBy('quantity', 'asc');
         }
 
         return $this->paginatedCollection($query, $request);

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -41,7 +41,7 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'campaign_run_id', 'updated_at', 'northstar_id', 'id',
+        'campaign_id', 'campaign_run_id', 'updated_at', 'northstar_id', 'id', 'quantity',
     ];
 
     /**

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -113,6 +113,10 @@ class PostRepository
             $this->crop($data, $post->id);
         }
 
+        // Update the signup's total quantity.
+        $signup->quantity = $signup->posts->sum('quantity');
+        $signup->save();
+
         return $post;
     }
 
@@ -127,6 +131,13 @@ class PostRepository
     public function update($post, $data)
     {
         $post->update($data);
+
+        // If the quantity was updated, update the total quantity on the signup.
+        if ($data['quantity']) {
+            $signup = Signup::find($post->signup_id);
+            $signup->quantity = $signup->posts->sum('quantity');
+            $signup->save();
+        }
 
         return $post;
     }

--- a/database/migrations/2018_02_09_150930_add_quantity_index_to_signups_table.php
+++ b/database/migrations/2018_02_09_150930_add_quantity_index_to_signups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddQuantityIndexToSignupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->unique('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropUnique('quantity');
+        });
+    }
+}

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -22,7 +22,7 @@ GET /api/v2/activity
 - **orderBy** _(string)_
   - Determines order the results are returned, based on the signups's created_at timestamp.
   - If 'desc' is not passed through, defaults to return results by signup's created_at by ascending order. 
-  - e.g. `/activity'?orderByPost=desc`
+  - e.g. `/activity?orderByPost=desc`
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`

--- a/documentation/endpoints/activity.md
+++ b/documentation/endpoints/activity.md
@@ -22,7 +22,7 @@ GET /api/v2/activity
 - **orderBy** _(string)_
   - Determines order the results are returned, based on the signups's created_at timestamp.
   - If 'desc' is not passed through, defaults to return results by signup's created_at by ascending order. 
-  - e.g. `/activity?orderByPost=desc`
+  - e.g. `/activity?orderBy=desc`
 - **filter[updated_at]** _(timestamp)_
   - Return records that have been updated after the given `updated_at` value. 
   - e.g. `/activity?filter[updated_at]=2017-05-25 20:14:48`

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -54,11 +54,13 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
 - **include** _(string)_
   - Include additional related records in the response: `posts`
   - e.g. `/v3/signups?include=posts`
-- **filter[column]**
+- **filter[column]** _(string)_
   - Filter results by the given column: `northstar_id`, `campaign_id`, `campaign_run_id`
   - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
-
+- **orderByQuantity** _(string)_
+  - Determines order the results are returned, based on the signups's quantity.
+  - e.g. `/activity?orderBy=desc`
 Example Response: 
 
 ```

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -61,6 +61,7 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
 - **orderByQuantity** _(string)_
   - Determines order the results are returned, based on the signups's quantity.
   - e.g. `/activity?orderBy=desc`
+  - e.g. `/activity?orderBy=asc`
 Example Response: 
 
 ```

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -49,10 +49,15 @@ GET /api/v3/signups
 Only admins and signup owners will have `why_participated`, `source`, and `details` returned in the response.
 
 When using `?include=posts`, anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
+
 ### Optional Query Parameters
 - **include** _(string)_
   - Include additional related records in the response: `posts`
   - e.g. `/v3/signups?include=posts`
+- **filter[column]**
+  - Filter results by the given column: `northstar_id`, `campaign_id`, `campaign_run_id`
+  - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
+  - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
 
 Example Response: 
 

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -62,6 +62,13 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
   - Determines order the results are returned, based on the signups's index and direction.
   - e.g. `/signups?orderBy=quantity,desc`
   - e.g. `/signups?orderBy=quantity,asc`
+- **limit** _(default is 20)_
+  - Set the number of records to return in a single response.
+  - e.g. `/signups?limit=35`  
+- **page** _(integer)_
+  - For pagination, specify page of signups to return in the response.
+  - e.g. `/signups?page=2`
+
 Example Response: 
 
 ```

--- a/documentation/endpoints/v3/signups.md
+++ b/documentation/endpoints/v3/signups.md
@@ -58,10 +58,10 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
   - Filter results by the given column: `northstar_id`, `campaign_id`, `campaign_run_id`
   - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
-- **orderByQuantity** _(string)_
-  - Determines order the results are returned, based on the signups's quantity.
-  - e.g. `/activity?orderBy=desc`
-  - e.g. `/activity?orderBy=asc`
+- **orderBy** _(string)_
+  - Determines order the results are returned, based on the signups's index and direction.
+  - e.g. `/signups?orderBy=quantity,desc`
+  - e.g. `/signups?orderBy=quantity,asc`
 Example Response: 
 
 ```

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -284,7 +284,6 @@ class PostTest extends TestCase
 
         // Assert that signup quantity is sum of all posts' quantities.
         $this->assertEquals($signup->fresh()->quantity, $quantity + $secondQuantity);
-
     }
 
     /**

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -281,6 +281,10 @@ class PostTest extends TestCase
             'quantity' => $secondQuantity,
             'details' => json_encode($secondDetails),
         ]);
+
+        // Assert that signup quantity is sum of all posts' quantities.
+        $this->assertEquals($signup->fresh()->quantity, $quantity + $secondQuantity);
+
     }
 
     /**
@@ -727,6 +731,7 @@ class PostTest extends TestCase
     public function testUpdatingAPost()
     {
         $post = factory(Post::class)->create();
+        $signup = $post->signup;
 
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
@@ -740,6 +745,9 @@ class PostTest extends TestCase
         // Make sure that the posts's new status and caption gets persisted in the database.
         $this->assertEquals($post->fresh()->caption, 'new caption');
         $this->assertEquals($post->fresh()->quantity, 8);
+
+        // Make sure the signup's quantity gets updated.
+        $this->assertEquals($signup->fresh()->quantity, 8);
     }
 
     /**

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -388,7 +388,7 @@ class SignupTest extends TestCase
 
         $response->assertStatus(200);
 
-        // Assert results are returned in ascending order.
+        // Assert results are returned in descending order.
         $this->assertEquals(5, $decodedResponse['data'][0]['quantity']);
         $this->assertEquals(4, $decodedResponse['data'][1]['quantity']);
 

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -366,8 +366,8 @@ class SignupTest extends TestCase
     /**
      * Test for retrieving all signups as admin filtering by quantity (in ascending or descending order).
      *
-     * GET /api/v3/signups?orderByQuantity=desc
-     * GET /api/v3/signups?orderByQuantity=asc
+     * GET /api/v3/signups?orderBy=quantity,desc
+     * GET /api/v3/signups?orderBy=quantity,asc
      *
      * @return void
      */
@@ -383,7 +383,7 @@ class SignupTest extends TestCase
         }
 
         // Order results by descending quantity
-        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderByQuantity=desc');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderBy=quantity,desc');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
@@ -393,7 +393,7 @@ class SignupTest extends TestCase
         $this->assertEquals(4, $decodedResponse['data'][1]['quantity']);
 
         // Order results by ascending quantity
-        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderByQuantity=asc');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderBy=quantity,asc');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -363,6 +363,46 @@ class SignupTest extends TestCase
         $this->assertEquals(5, $decodedResponse['meta']['cursor']['count']);
     }
 
+   /**
+     * Test for retrieving all signups as admin filtering by quantity (in ascending or descending order).
+     *
+     * GET /api/v3/signups?orderByQuantity=desc
+     * GET /api/v3/signups?orderByQuantity=asc
+     *
+     * @return void
+     */
+    public function testSignupsIndexAsAdminWithOrderByQuantityFilter()
+    {
+        // Create 5 signups with different quantities
+        $signups = factory(Signup::class, 5)->create();
+        $quantity = 1;
+
+        foreach ($signups as $signup) {
+            $signup->quantity = $quantity++;
+            $signup->save();
+        }
+
+        // Order results by descending quantity
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderByQuantity=desc');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+
+        // Assert results are returned in ascending order.
+        $this->assertEquals(5, $decodedResponse['data'][0]['quantity']);
+        $this->assertEquals(4, $decodedResponse['data'][1]['quantity']);
+
+        // Order results by ascending quantity
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderByQuantity=asc');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+
+        // Assert results are returned in ascending order.
+        $this->assertEquals(1, $decodedResponse['data'][0]['quantity']);
+        $this->assertEquals(2, $decodedResponse['data'][1]['quantity']);
+    }
+
     /**
      * Test for retrieving a specific signup as non-admin and non-owner.
      *

--- a/tests/Http/Three/SignupTest.php
+++ b/tests/Http/Three/SignupTest.php
@@ -363,7 +363,7 @@ class SignupTest extends TestCase
         $this->assertEquals(5, $decodedResponse['meta']['cursor']['count']);
     }
 
-   /**
+    /**
      * Test for retrieving all signups as admin filtering by quantity (in ascending or descending order).
      *
      * GET /api/v3/signups?orderByQuantity=desc


### PR DESCRIPTION
#### What's this PR do?
- Adds the `orderByQuantity` filter for `GET /v3/signups` 
  - Choose to return results with quantity in ascending or descending order
- Adds logic to update and save summed quantity on the signup when a post is created or updated via the v3 endpoints
- Adds tests for:
  - `?filter[northstar_id]`, `?filter[campaign_id]`, and `?filter[campaign_run_id]`
  - `?orderByQuantity=desc` and `?orderbyQuantity=asc`
  - updates PostTests to check for summing of quantity on signup
- Updates documentation 

#### How should this be reviewed?
- All tests should pass! 
- All filters should work in Postman/Paw! 
- Did I miss any logic for updating the total quantity on the signup? Does this need to happen anywhere else outside of the `POST /v3/posts` and `PATCH `/v3/posts/{post}` endpoints?

#### Relevant tickets
Fixes the first task in [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154579464) Pivotal Card

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.