### PR TITLE
Use Review & Signup Service & Repository for Patch and Delete and send that to Quasar

### DIFF
--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -3,7 +3,7 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Post;
-use Rogue\Repositories\PostRepository;
+use Rogue\Services\PostService;
 use Rogue\Http\Requests\ReviewsRequest;
 use Rogue\Http\Transformers\PostTransformer;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -28,7 +28,7 @@ class ReviewsController extends Controller
      * @param  PostContract $posts
      * @return void
      */
-    public function __construct(PostRepository $post)
+    public function __construct(PostService $post)
     {
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
@@ -54,17 +54,11 @@ class ReviewsController extends Controller
 
         // Append admin's ID to the request for the "reviews" service.
         $review['admin_northstar_id'] = auth()->user()->northstar_id;
-        $reviewedPost = $this->post->reviews($review);
+        $reviewedPost = $this->post->review($review);
         $reviewedPostCode = $this->code($reviewedPost);
         $meta = [];
 
         if (isset($reviewedPost)) {
-            info('post_reviewed', [
-                'id' => $reviewedPost->id,
-                'admin_northstar_id' => $review['admin_northstar_id'],
-                'status' => $reviewedPost->status,
-            ]);
-
             return $this->item($reviewedPost, $reviewedPostCode);
         } else {
             throw (new ModelNotFoundException)->setModel('Post');

--- a/app/Http/Controllers/Three/ReviewsController.php
+++ b/app/Http/Controllers/Three/ReviewsController.php
@@ -4,7 +4,7 @@ namespace Rogue\Http\Controllers\Three;
 
 use Rogue\Models\Post;
 use Illuminate\Http\Request;
-use Rogue\Repositories\Three\PostRepository;
+use Rogue\Services\Three\PostService;
 use Rogue\Http\Controllers\Api\ApiController;
 use Rogue\Http\Transformers\Three\PostTransformer;
 
@@ -28,7 +28,7 @@ class ReviewsController extends ApiController
      * @param  PostContract $posts
      * @return void
      */
-    public function __construct(PostRepository $post)
+    public function __construct(PostService $post)
     {
         $this->post = $post;
         $this->transformer = new PostTransformer;
@@ -52,13 +52,7 @@ class ReviewsController extends ApiController
         ]);
 
         $post = Post::findOrFail($request['post_id']);
-        $reviewedPost = $this->post->reviews($post, $request['status'], $request['comment']);
-
-        info('post_reviewed', [
-            'id' => $reviewedPost->id,
-            'admin_northstar_id' => auth()->id(),
-            'status' => $reviewedPost->status,
-        ]);
+        $reviewedPost = $this->post->review($post, $request['status'], $request['comment']);
 
         return $this->item($reviewedPost, 201);
     }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -149,8 +149,12 @@ class SignupsController extends ApiController
      */
     public function destroy(Signup $signup)
     {
-        $this->signups->destroy($signup->id);
+        $trashed = $this->signups->destroy($signup->id);
 
-        return $this->respond('Signup deleted.', 200);
+        if ($trashed) {
+            return $this->respond('Signup deleted.', 200);
+        }
+
+        return response()->json(['code' => 500, 'message' => 'There was an error deleting the post']);
     }
 }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -125,15 +125,14 @@ class SignupsController extends ApiController
      */
     public function update(Request $request, Signup $signup)
     {
-        $this->validate($request, [
+        $validatedRequest = $this->validate($request, [
             'why_participated' => 'required',
         ]);
 
         // Only allow an admin or the user who owns the signup to update.
         if (token()->role() === 'admin' || auth()->id() === $signup->northstar_id) {
-            $signup->update(
-                $request->only('why_participated')
-            );
+            // why_participated is the only thing that can be changed
+            $this->signups->update($signup, $validatedRequest);
 
             return $this->item($signup);
         }

--- a/app/Http/Controllers/Three/SignupsController.php
+++ b/app/Http/Controllers/Three/SignupsController.php
@@ -149,7 +149,7 @@ class SignupsController extends ApiController
      */
     public function destroy(Signup $signup)
     {
-        $signup->delete();
+        $this->signups->destroy($signup->id);
 
         return $this->respond('Signup deleted.', 200);
     }

--- a/app/Jobs/SendDeletedPostToQuasar.php
+++ b/app/Jobs/SendDeletedPostToQuasar.php
@@ -40,7 +40,7 @@ class SendDeletedPostToQuasar implements ShouldQueue
     {
         $payload = [
             'id' => $this->postId,
-            'deleted_at' => Carbon::now(),
+            'deleted_at' => Carbon::now()->toIso8601String(),
             'meta' => [
                 'message_source' => 'rogue',
                 'type' => 'post',

--- a/app/Jobs/SendDeletedSignupToQuasar.php
+++ b/app/Jobs/SendDeletedSignupToQuasar.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rogue\Jobs;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SendDeletedSignupToQuasar implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The signup to send to Quasar via Blink.
+     *
+     * @var int
+     */
+    protected $signupId;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($signupId)
+    {
+        $this->signupId = $signupId;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $payload = [
+            'id' => $this->signupId,
+            'deleted_at' => Carbon::now(),
+            'meta' => [
+                'message_source' => 'rogue',
+                'type' => 'signup',
+            ],
+        ];
+
+        // Send to Quasar
+        gateway('blink')->post('v1/events/quasar-relay', $payload);
+
+        // Log
+        info('Deleted signup ' . $this->signupId . ' sent to Quasar');
+    }
+}

--- a/app/Jobs/SendDeletedSignupToQuasar.php
+++ b/app/Jobs/SendDeletedSignupToQuasar.php
@@ -47,7 +47,9 @@ class SendDeletedSignupToQuasar implements ShouldQueue
         ];
 
         // Send to Quasar
-        gateway('blink')->post('v1/events/quasar-relay', $payload);
+        if (config('features.pushToQuasar')) {
+            gateway('blink')->post('v1/events/quasar-relay', $payload);
+        }
 
         // Log
         info('Deleted signup ' . $this->signupId . ' sent to Quasar');

--- a/app/Jobs/SendDeletedSignupToQuasar.php
+++ b/app/Jobs/SendDeletedSignupToQuasar.php
@@ -39,7 +39,7 @@ class SendDeletedSignupToQuasar implements ShouldQueue
     {
         $payload = [
             'id' => $this->signupId,
-            'deleted_at' => Carbon::now(),
+            'deleted_at' => Carbon::now()->toIso8601String(),
             'meta' => [
                 'message_source' => 'rogue',
                 'type' => 'signup',

--- a/app/Repositories/Three/SignupRepository.php
+++ b/app/Repositories/Three/SignupRepository.php
@@ -30,6 +30,20 @@ class SignupRepository
     }
 
     /**
+     * Update a signup.
+     *
+     * @param array $data
+     * @param array $data
+     * @return \Rogue\Models\Signup
+     */
+    public function update($signup, $data)
+    {
+        $signup->update($data);
+
+        return $signup;
+    }
+
+    /**
      * Get a signup based on unique fields.
      *
      * @param  string $northstarId

--- a/app/Repositories/Three/SignupRepository.php
+++ b/app/Repositories/Three/SignupRepository.php
@@ -77,5 +77,4 @@ class SignupRepository
 
         return $signup->trashed();
     }
-
 }

--- a/app/Repositories/Three/SignupRepository.php
+++ b/app/Repositories/Three/SignupRepository.php
@@ -61,4 +61,21 @@ class SignupRepository
 
         return $signup;
     }
+
+    /**
+     * Delete a signup.
+     *
+     * @param int $signupId
+     * @return $post;
+     */
+    public function destroy($signupId)
+    {
+        $signup = Signup::findOrFail($signupId);
+
+        // Soft delete the post.
+        $signup->delete();
+
+        return $signup->trashed();
+    }
+
 }

--- a/app/Repositories/Three/SignupRepository.php
+++ b/app/Repositories/Three/SignupRepository.php
@@ -72,7 +72,7 @@ class SignupRepository
     {
         $signup = Signup::findOrFail($signupId);
 
-        // Soft delete the post.
+        // Soft delete the signup.
         $signup->delete();
 
         return $signup->trashed();

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -60,6 +60,31 @@ class PostService
     }
 
     /**
+     * Handles all business logic around reviewing posts.
+     *
+     * @param array $data
+     * @param int $signupId
+     * @return \Rogue\Models\Post
+     */
+    public function review($data)
+    {
+        $reviewedPost = $this->repository->reviews($data);
+
+        if (config('features.pushToQuasar')) {
+            SendPostToQuasar::dispatch($reviewedPost);
+        }
+
+        // Log that a post was reviewed.
+        info('post_reviewed', [
+            'id' => $reviewedPost->id,
+            'admin_northstar_id' => $data['admin_northstar_id'],
+            'status' => $reviewedPost->status,
+        ]);
+
+        return $reviewedPost;
+    }
+
+    /**
      * Handles all business logic around updating posts.
      *
      * @param \Rogue\Models\Signup $signup

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -90,13 +90,13 @@ class PostService
     /**
      * Handles all business logic around reviewing posts.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \Rogue\Models\Post $post
      * @param array $data
-     * @return \Rogue\Models\Post|\Rogue\Models\Signup
+     * @return \Rogue\Models\Post
      */
-    public function review($post, $data)
+    public function review($post, $data, $comment)
     {
-        $post = $this->repository->reviews($post, $data);
+        $post = $this->repository->reviews($post, $data, $comment);
 
         if (config('features.pushToQuasar')) {
             SendPostToQuasar::dispatch($post);

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -88,6 +88,31 @@ class PostService
     }
 
     /**
+     * Handles all business logic around reviewing posts.
+     *
+     * @param \Rogue\Models\Signup $signup
+     * @param array $data
+     * @return \Rogue\Models\Post|\Rogue\Models\Signup
+     */
+    public function review($post, $data)
+    {
+        $post = $this->repository->reviews($post, $data);
+
+        if (config('features.pushToQuasar')) {
+            SendPostToQuasar::dispatch($post);
+        }
+
+        // Log that a post was reviewed.
+        info('post_reviewed', [
+            'id' => $post->id,
+            'admin_northstar_id' => auth()->id(),
+            'status' => $post->status,
+        ]);
+
+        return $post;
+    }
+
+    /**
      * Handle all business logic around deleting a post.
      *
      * @param int $postId

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -60,9 +60,9 @@ class SignupService
     /**
      * Handles all business logic around updating signups.
      *
+     * @param Rogue\Models\Signup $signup
      * @param array $data
-     * @param string $northstarId
-     * @return Illuminate\Database\Eloquent\Model $model
+     * @return Rogue\Models\Signup $model
      */
     public function update($signup, $data)
     {

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -67,7 +67,10 @@ class SignupService
     {
         $signup = $this->signup->update($signup, $data);
 
-        // add business logic here
+        // Dispatch job to send signup to Quasar
+        if (config('features.pushToQuasar')) {
+            SendSignupToQuasar::dispatch($signup);
+        }
 
         // Log that a signup was updated.
         info('signup_updated', ['id' => $signup->id]);

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -95,9 +95,7 @@ class SignupService
             ]);
 
             // Dispatch job to send post to Quasar
-            if (config('features.pushToQuasar')) {
-                SendDeletedSignupToQuasar::dispatch($signupId);
-            }
+            SendDeletedSignupToQuasar::dispatch($signupId);
         }
 
         return $trashed;

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -87,15 +87,17 @@ class SignupService
      */
     public function destroy($signupId)
     {
-        info('signup_deleted', [
-            'id' => $signupId,
-        ]);
-
         $trashed = $this->signup->destroy($signupId);
 
-        // Dispatch job to send post to Quasar
-        if (config('features.pushToQuasar')) {
-            SendDeletedSignupToQuasar::dispatch($signupId);
+        if ($trashed) {
+            info('signup_deleted', [
+                'id' => $signupId,
+            ]);
+
+            // Dispatch job to send post to Quasar
+            if (config('features.pushToQuasar')) {
+                SendDeletedSignupToQuasar::dispatch($signupId);
+            }
         }
 
         return $trashed;

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -4,6 +4,7 @@ namespace Rogue\Services\Three;
 
 use Rogue\Jobs\SendSignupToBlink;
 use Rogue\Jobs\SendSignupToQuasar;
+use Rogue\Jobs\SendDeletedSignupToQuasar;
 use Rogue\Repositories\Three\SignupRepository;
 
 class SignupService
@@ -76,6 +77,28 @@ class SignupService
         info('signup_updated', ['id' => $signup->id]);
 
         return $signup;
+    }
+
+    /**
+     * Handle all business logic around deleting a signup.
+     *
+     * @param int $signupId
+     * @return bool
+     */
+    public function destroy($signupId)
+    {
+        info('signup_deleted', [
+            'id' => $signupId,
+        ]);
+
+        $trashed = $this->signup->destroy($signupId);
+
+        // Dispatch job to send post to Quasar
+        if (config('features.pushToQuasar')) {
+            SendDeletedSignupToQuasar::dispatch($signupId);
+        }
+
+        return $trashed;
     }
 
     /*

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -56,6 +56,25 @@ class SignupService
         return $signup;
     }
 
+    /**
+     * Handles all business logic around updating signups.
+     *
+     * @param array $data
+     * @param string $northstarId
+     * @return Illuminate\Database\Eloquent\Model $model
+     */
+    public function update($signup, $data)
+    {
+        $signup = $this->signup->update($signup, $data);
+
+        // add business logic here
+
+        // Log that a signup was updated.
+        info('signup_updated', ['id' => $signup->id]);
+
+        return $signup;
+    }
+
     /*
      * Handles all business logic around retrieving a signup.
      *


### PR DESCRIPTION
#### What's this PR do?
1. `PATCH v3/signups` now calls new `update` method in `SignupService`, which in turn calls new `update` method in `SignupRepository`. This mirrors `PATCH v3/posts`.
    - `SignupService` also triggers the `SendSignupToQuasar` job.
2. `DELETE v3/signups` now calls new `destroy` method in `SignupService`, which in turn calls new `destroy` method in `SignupRepository`. This mirrors `PATCH v3/posts`.
    - `SignupService` also triggers the new `SendDeletedSignupToQuasar` job.

#### How should this be reviewed?
Do both of these flows make sense?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/154968896)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.