### PR TITLE
Send updates through PostService

### DIFF
--- a/app/Jobs/ImportTurboVotePosts.php
+++ b/app/Jobs/ImportTurboVotePosts.php
@@ -113,8 +113,7 @@ class ImportTurboVotePosts implements ShouldQueue
                         // If a post already exists, check if status is the same on the CSV record and the existing post,
                         // if not update the post with the new status.
                         if ($record['voter-registration-status'] !== $post->status) {
-                            $post->status = $record['voter-registration-status'];
-                            $post->save();
+                            $postService->update($post, ['status' => $record['voter-registration-status']]);
                         }
                     }
                 } else {

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -133,7 +133,7 @@ class PostRepository
         $post->update($data);
 
         // If the quantity was updated, update the total quantity on the signup.
-        if ($data['quantity']) {
+        if (isset($data['quantity'])) {
             $signup = Signup::find($post->signup_id);
             $signup->quantity = $signup->posts->sum('quantity');
             $signup->save();

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -62,9 +62,9 @@ class PostService
     /**
      * Handles all business logic around updating posts.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \Rogue\Models\Post $post
      * @param array $data
-     * @return \Rogue\Models\Post|\Rogue\Models\Signup
+     * @return \Rogue\Models\Post
      */
     public function update($post, $data)
     {

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -81,8 +81,8 @@ class PostService
             SendPostToQuasar::dispatch($post);
         }
 
-        // Log that a post was created.
-        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+        // Log that a post was updated.
+        info('post_updated', ['id' => $post->id, 'signup_id' => $post->signup_id]);
 
         return $post;
     }


### PR DESCRIPTION
#### What's this PR do?
Updated the import CSV logic to run status updates through the `PostService@update` method so that all business logic is executed with the post update. That means that c.io should get the updated post status on their end. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Found this bug with @rapala61 and @ngjo . We did a test CSV import to rogue-thor with registration records from Rafa. We saw that while the initial signups and posts got into c.io successfully, one of the posts had an updated status that was not being sent to c.io. 

This fixes it so that post updates during an import will be sent to blink successfully.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/155090650

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.