### PR TITLE
Fixes /api/v3/signups?include=user

### DIFF
--- a/app/Http/Transformers/Three/UserTransformer.php
+++ b/app/Http/Transformers/Three/UserTransformer.php
@@ -19,13 +19,13 @@ class UserTransformer extends TransformerAbstract
             $response = [
                 'first_name' => $user->first_name,
             ];
-        }
 
-        if (is_staff_user() || auth()->id() === $user->id) {
-            $response['last_name'] = $user->last_name;
-            $response['birthdate'] = $user->birthdate;
-            $response['email'] = $user->email;
-            $response['mobile'] = $user->mobile;
+            if (is_staff_user() || auth()->id() === $user->id) {
+                $response['last_name'] = $user->last_name;
+                $response['birthdate'] = $user->birthdate;
+                $response['email'] = $user->email;
+                $response['mobile'] = $user->mobile;
+            }
         }
 
         return isset($response) ? $response : [];


### PR DESCRIPTION
#### What's this PR do?
- `/api/v3/signups?orderBy=quantity,desc&include=user,posts` was breaking on thor with this error:
```
Feb 13 12:58:21 rogue-thor app/web.1:  [13-Feb-2018 17:58:14 UTC] [2018-02-13 17:58:14] thor.ERROR: Trying to get property of non-object {"exception":"[object] (ErrorException(code: 0): Trying to get property of non-object at /app/app/Http/Transformers/Three/UserTransformer.php:24)"} {"user_id":null,"client_id":null,"request_id":"98aca44d-28ca-40e8-9fff-cb9a6a4ea29c"} 
```
- This PR fixes it by wrapping the check for `$user->id` in the `if ($user)` conditional so it doesn't break if there is no user.

#### How should this be reviewed?
👀 


#### Relevant tickets
Fixes error from #619 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.