### PR TITLE
If quantity is not stored on post, send Quasar quantity from signup

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -195,7 +195,7 @@ class Post extends Model
             'northstar_id' => $this->northstar_id,
             'type' => $this->type,
             'action' => $this->action,
-            'quantity' => $this->quantity ? $this->quantity : $this->signup->quantity,
+            'quantity' => $this->getQuantity(),
             'why_participated' => $this->signup->why_participated,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.
@@ -219,6 +219,21 @@ class Post extends Model
                 'type' => 'post',
             ],
         ];
+    }
+
+    /**
+     * If we are storing quanity on the post, return that!
+     * If the quantity is not on the post, return the quantity from the signup.
+     *
+     * @return int
+     */
+    public function getQuantity()
+    {
+        if (! config('features.v3QuantitySupport')) {
+            return $this->signup->getQuantity();
+        }
+
+        return $this->quantity;
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -195,7 +195,7 @@ class Post extends Model
             'northstar_id' => $this->northstar_id,
             'type' => $this->type,
             'action' => $this->action,
-            'quantity' => $this->quantity,
+            'quantity' => $this->quantity ? $this->quantity : $this->signup->quantity,
             'why_participated' => $this->signup->why_participated,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.


### PR DESCRIPTION
#### What's this PR do?
When a user submits a post, we send the updated post to Quasar. However, while the quantity lives on the signup, they don't get that updated quantity! For now, let's send the quantity on the post only if it is not null, otherwise grab the quantity from the signup.

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.