### PR TITLE
Fixing edge cases where the signup is updated in Post Repository and not sent to Quasar

### DIFF
--- a/app/Jobs/SendDeletedPostToQuasar.php
+++ b/app/Jobs/SendDeletedPostToQuasar.php
@@ -48,9 +48,13 @@ class SendDeletedPostToQuasar implements ShouldQueue
         ];
 
         // Send to Quasar
-        gateway('blink')->post('v1/events/quasar-relay', $payload);
+        $shouldSendToQuasar = config('features.pushToQuasar');
+        if ($shouldSendToQuasar) {
+            gateway('blink')->post('v1/events/quasar-relay', $payload);
+        }
 
         // Log
-        info('Deleted post ' . $this->postId . ' sent to Quasar');
+        $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+        info('Deleted post ' . $this->postId . ' ' . $verb . ' sent to Quasar');
     }
 }

--- a/app/Jobs/SendDeletedSignupToQuasar.php
+++ b/app/Jobs/SendDeletedSignupToQuasar.php
@@ -47,11 +47,13 @@ class SendDeletedSignupToQuasar implements ShouldQueue
         ];
 
         // Send to Quasar
-        if (config('features.pushToQuasar')) {
+        $shouldSendToQuasar = config('features.pushToQuasar');
+        if ($shouldSendToQuasar) {
             gateway('blink')->post('v1/events/quasar-relay', $payload);
         }
 
         // Log
-        info('Deleted signup ' . $this->signupId . ' sent to Quasar');
+        $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+        info('Deleted signup ' . $this->signupId . ' ' . $verb . ' sent to Quasar');
     }
 }

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -41,9 +41,13 @@ class SendPostToQuasar implements ShouldQueue
         $payload = $this->post->toQuasarPayload();
 
         // Send to Quasar
-        gateway('blink')->post('v1/events/quasar-relay', $payload);
+        $shouldSendToQuasar = config('features.pushToQuasar');
+        if ($shouldSendToQuasar) {
+            gateway('blink')->post('v1/events/quasar-relay', $payload);
+        }
 
         // Log
-        info('Post ' . $this->post->id . ' sent to Quasar');
+        $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+        info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
     }
 }

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -41,9 +41,13 @@ class SendSignupToQuasar implements ShouldQueue
         $payload = $this->signup->toQuasarPayload();
 
         // Send to Quasar
-        gateway('blink')->post('v1/events/quasar-relay', $payload);
+        $shouldSendToQuasar = config('features.pushToQuasar');
+        if ($shouldSendToQuasar) {
+            gateway('blink')->post('v1/events/quasar-relay', $payload);
+        }
 
         // Log
-        info('Signup ' . $this->signup->id . ' sent to Quasar');
+        $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+        info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
     }
 }

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -134,7 +134,7 @@ class PostRepository
 
         // If the quantity was updated, update the total quantity on the signup.
         if (isset($data['quantity'])) {
-            $signup = Signup::find($post->signup_id);
+            $signup = $post->signup;
             $signup->quantity = $signup->posts->sum('quantity');
             $signup->save();
         }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -48,8 +48,9 @@ class PostService
             SendPostToBlink::dispatch($post);
         }
 
-        // Dispatch job to send post to Quasar
+        // Dispatch jobs to send post and signup to Quasar
         SendPostToQuasar::dispatch($post);
+        SendSignupToQuasar::dispatch($post->signup);
 
         // Log that a post was created.
         info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
@@ -102,7 +103,7 @@ class PostService
             info('post_created', ['id' => $postOrSignup->id, 'signup_id' => $postOrSignup->signup_id]);
         }
 
-        // Dispatch job to send Post to Quasar
+        // Dispatch job to send Post (or Post and Signup) to Quasar
         if ($postOrSignup instanceof Post) {
             SendPostToQuasar::dispatch($postOrSignup);
 

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -49,9 +49,7 @@ class PostService
         }
 
         // Dispatch job to send post to Quasar
-        if (config('features.pushToQuasar')) {
-            SendPostToQuasar::dispatch($post);
-        }
+        SendPostToQuasar::dispatch($post);
 
         // Log that a post was created.
         info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
@@ -70,9 +68,7 @@ class PostService
     {
         $reviewedPost = $this->repository->reviews($data);
 
-        if (config('features.pushToQuasar')) {
-            SendPostToQuasar::dispatch($reviewedPost);
-        }
+        SendPostToQuasar::dispatch($reviewedPost);
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -130,9 +130,7 @@ class PostService
         $trashed = $this->repository->destroy($postId);
 
         // Dispatch job to send post to Quasar
-        if (config('features.pushToQuasar')) {
-            SendDeletedPostToQuasar::dispatch($postId);
-        }
+        SendDeletedPostToQuasar::dispatch($postId);
 
         return $trashed;
     }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -103,12 +103,12 @@ class PostService
         }
 
         // Dispatch job to send Post to Quasar
-        if (config('features.pushToQuasar')) {
-            if ($postOrSignup instanceof Post) {
-                SendPostToQuasar::dispatch($postOrSignup);
-            } elseif ($postOrSignup instanceof Signup) {
-                SendSignupToQuasar::dispatch($postOrSignup);
-            }
+        if ($postOrSignup instanceof Post) {
+            SendPostToQuasar::dispatch($postOrSignup);
+
+            SendSignupToQuasar::dispatch($postOrSignup->signup);
+        } elseif ($postOrSignup instanceof Signup) {
+            SendSignupToQuasar::dispatch($postOrSignup);
         }
 
         return $postOrSignup;

--- a/app/Services/SignupService.php
+++ b/app/Services/SignupService.php
@@ -45,9 +45,7 @@ class SignupService
         }
 
         // Dispatch job to send signup to Quasar
-        if (config('features.pushToQuasar')) {
-            SendSignupToQuasar::dispatch($signup);
-        }
+        SendSignupToQuasar::dispatch($signup);
 
         // Log that a signup was created.
         info('signup_created', ['id' => $signup->id, 'northstar_id' => $signup->northstar_id]);

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -49,9 +49,7 @@ class PostService
             SendPostToBlink::dispatch($post);
         }
 
-        if (config('features.pushToQuasar')) {
-            SendPostToQuasar::dispatch($post);
-        }
+        SendPostToQuasar::dispatch($post);
 
         // Log that a post was created.
         info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
@@ -77,9 +75,7 @@ class PostService
             SendPostToBlink::dispatch($post);
         }
 
-        if (config('features.pushToQuasar')) {
-            SendPostToQuasar::dispatch($post);
-        }
+        SendPostToQuasar::dispatch($post);
 
         // Log that a post was updated.
         info('post_updated', ['id' => $post->id, 'signup_id' => $post->signup_id]);
@@ -98,9 +94,8 @@ class PostService
     {
         $post = $this->repository->reviews($post, $data, $comment);
 
-        if (config('features.pushToQuasar')) {
-            SendPostToQuasar::dispatch($post);
-        }
+        SendPostToQuasar::dispatch($post);
+
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -96,7 +96,6 @@ class PostService
 
         SendPostToQuasar::dispatch($post);
 
-
         // Log that a post was reviewed.
         info('post_reviewed', [
             'id' => $post->id,
@@ -122,9 +121,7 @@ class PostService
         $trashed = $this->repository->destroy($postId);
 
         // Dispatch job to send post to Quasar
-        if (config('features.pushToQuasar')) {
-            SendDeletedPostToQuasar::dispatch($postId);
-        }
+        SendDeletedPostToQuasar::dispatch($postId);
 
         return $trashed;
     }

--- a/app/Services/Three/SignupService.php
+++ b/app/Services/Three/SignupService.php
@@ -47,9 +47,7 @@ class SignupService
         }
 
         // Dispatch job to send signup to Quasar
-        if (config('features.pushToQuasar')) {
-            SendSignupToQuasar::dispatch($signup);
-        }
+        SendSignupToQuasar::dispatch($signup);
 
         // Log that a signup was created.
         info('signup_created', ['id' => $signup->id]);
@@ -69,9 +67,7 @@ class SignupService
         $signup = $this->signup->update($signup, $data);
 
         // Dispatch job to send signup to Quasar
-        if (config('features.pushToQuasar')) {
-            SendSignupToQuasar::dispatch($signup);
-        }
+        SendSignupToQuasar::dispatch($signup);
 
         // Log that a signup was updated.
         info('signup_updated', ['id' => $signup->id]);


### PR DESCRIPTION
#### What's this PR do?
1. Update the send signup and post to Quasar jobs to check for the sending to quasar feature flag in the job itself so locally you can still get (altered to say that they WOULD HAVE BEEN sent to Quasar) log messages and know that you are hitting the job. This has been a pain point for me when working on these jobs.

2. There are two times in the `PostService` where we go on to alter a signup, so we should be calling the signup job alongside the post job.

#### How should this be reviewed?
Passing tests? Feature flags still working?

#### Any background context you want to provide?
When testing it became evident that we were missing some signup updates!

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/155199023)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.