### PR TITLE
Post source details

### DIFF
--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -56,6 +56,7 @@ class PostTransformer extends TransformerAbstract
         if (is_staff_user() || auth()->id() === $post->northstar_id) {
             $response['tags'] = $post->tagSlugs();
             $response['source'] = $post->source;
+            $response['source_details'] = $post->source_details;
             $response['remote_addr'] = $post->remote_addr;
             $response['type'] = $post->type;
             $response['action'] = $post->action;

--- a/app/Jobs/ImportTurboVotePosts.php
+++ b/app/Jobs/ImportTurboVotePosts.php
@@ -96,7 +96,7 @@ class ImportTurboVotePosts implements ShouldQueue
                     if (! $post) {
                         $tvCreatedAtMonth = strtolower(Carbon::parse($record['created-at'])->format('F-Y'));
                         $sourceDetails = isset($referralCodeValues['source_details']) ? $referralCodeValues['source_details'] : null;
-                        $postDetails = $this->extractDetails($record, ['source-details' => $sourceDetails]);
+                        $postDetails = $this->extractDetails($record);
 
                         $postData = [
                             'campaign_id' => $referralCodeValues['campaign_id'],
@@ -105,6 +105,7 @@ class ImportTurboVotePosts implements ShouldQueue
                             'action' => $tvCreatedAtMonth . '-turbovote',
                             'status' => $record['voter-registration-status'],
                             'source' => $referralCodeValues['source'],
+                            'source_details' => $sourceDetails,
                             'details' => $postDetails,
                         ];
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -30,7 +30,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'details', 'quantity', 'url', 'caption', 'status', 'source', 'remote_addr'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'details', 'quantity', 'url', 'caption', 'status', 'source', 'source_details', 'remote_addr'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -89,6 +89,7 @@ class PostRepository
             'caption' => isset($data['caption']) ? $data['caption'] : null,
             'status' => 'pending',
             'source' => token()->client(),
+            'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
             'remote_addr' => request()->ip(),
         ]);

--- a/database/migrations/2018_02_20_193349_add_source_details_column_to_posts.php
+++ b/database/migrations/2018_02_20_193349_add_source_details_column_to_posts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSourceDetailsColumnToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('source_details')->after('source')->nullable()->comment('Extra details about the post source, like newsletter ID');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('source_details');
+        });
+    }
+}

--- a/database/migrations/2018_02_20_193349_add_source_details_column_to_posts.php
+++ b/database/migrations/2018_02_20_193349_add_source_details_column_to_posts.php
@@ -14,7 +14,7 @@ class AddSourceDetailsColumnToPosts extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->string('source_details')->after('source')->nullable()->comment('Extra details about the post source, like newsletter ID');
+            $table->string('source_details')->after('source')->index()->nullable()->comment('Extra details about the post source, like newsletter ID');
         });
     }
 


### PR DESCRIPTION
#### What's this PR do?

Adds a `source_details` column to the `posts` table so we can store things like newletter ID there instead of in the json stored in the `details  column. 

![image](https://user-images.githubusercontent.com/1700409/36446351-0afaeaca-164f-11e8-8acd-93dba2bffaab.png)

#### How should this be reviewed?

:eyes:

#### Any background context you want to provide?

Before this, I was extracting `source_details` from the TV referral code and adding it to the JSON object that we stored in the `details` column. After talking with the team, we decided to store this separately. 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/155132110

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.