### PR TITLE
In the quantity update script, if we save a post, send it to Quasar

### DIFF
--- a/app/Console/Commands/PostQuantity.php
+++ b/app/Console/Commands/PostQuantity.php
@@ -4,6 +4,7 @@ namespace Rogue\Console\Commands;
 
 use Rogue\Models\Signup;
 use Illuminate\Console\Command;
+use Rogue\Jobs\SendPostToQuasar;
 
 class PostQuantity extends Command
 {
@@ -94,6 +95,7 @@ class PostQuantity extends Command
             $mostRecentAcceptedPost = $acceptedPosts->first();
             $mostRecentAcceptedPost->quantity = $quantity;
             $mostRecentAcceptedPost->save();
+            SendPostToQuasar::dispatch($mostRecentAcceptedPost);
             usleep($sleeptime);
         }
         // If no accepted posts, put quantity on most recent post (based on creation)
@@ -101,6 +103,7 @@ class PostQuantity extends Command
             $mostRecentPost = $posts->sortByDesc('created_at')->first();
             $mostRecentPost->quantity = $quantity;
             $mostRecentPost->save();
+            SendPostToQuasar::dispatch($mostRecentPost);
             usleep($sleeptime);
         }
         // Put quantity of 0 on all other posts under this signup
@@ -108,6 +111,7 @@ class PostQuantity extends Command
             if (is_null($post->quantity)) {
                 $post->quantity = 0;
                 $post->save();
+                SendPostToQuasar::dispatch($post);
                 usleep($sleeptime);
             }
         }


### PR DESCRIPTION
#### What's this PR do?
- Anywhere that we call `save()` on something, we send it to Quasar!
    - We do this in three spots when we alter the quantity on the post, and that's the only time we update anything

#### How should this be reviewed?
Does this make sure that Quasar gets all the updates that this script makes?

#### Any background context you want to provide?
This is needed since we now push updates to Quasar.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/154979182)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.