### PR TITLE
Box shows 0 if there is no quantity on the post 

### DIFF
--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -59,7 +59,7 @@ class Post extends React.Component {
     const user = this.props.user ? this.props.user : null;
     const signup = this.props.signup;
     const campaign = this.props.campaign;
-    let quantity = post.quantity != null ? post.quantity : 0;
+    const quantity = post.quantity != null ? post.quantity : 0;
 
     return (
       <div className="post container__row">

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -95,7 +95,7 @@ class Post extends React.Component {
         {/* User and Post information */}
         <div className="container__block -third">
           <UserInformation user={user} linkSignup={signup.signup_id}>
-            {post.quantity && this.props.showQuantity ?
+            {this.props.showQuantity ?
               <Quantity quantity={post.quantity} noun={campaign.reportback_info.noun} verb={campaign.reportback_info.verb} />
               : null}
 

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -59,6 +59,7 @@ class Post extends React.Component {
     const user = this.props.user ? this.props.user : null;
     const signup = this.props.signup;
     const campaign = this.props.campaign;
+    let quantity = post.quantity != null ? post.quantity : 0;
 
     return (
       <div className="post container__row">
@@ -96,7 +97,7 @@ class Post extends React.Component {
         <div className="container__block -third">
           <UserInformation user={user} linkSignup={signup.signup_id}>
             {this.props.showQuantity ?
-              <Quantity quantity={post.quantity} noun={campaign.reportback_info.noun} verb={campaign.reportback_info.verb} />
+              <Quantity quantity={quantity} noun={campaign.reportback_info.noun} verb={campaign.reportback_info.verb} />
               : null}
 
             {this.props.allowHistory ?


### PR DESCRIPTION
#### What's this PR do?
- Box shows `0` if there is no quantity on the post (instead of the box not showing up all together)
Before:
![screen shot 2018-02-23 at 2 16 52 pm](https://user-images.githubusercontent.com/9019452/36612977-13d5c558-18a6-11e8-8810-00850b67f4d9.png)

After:
![screen shot 2018-02-23 at 2 46 07 pm](https://user-images.githubusercontent.com/9019452/36613709-51a950c8-18a8-11e8-9ce0-00367d430fe5.png)

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This shouldn't matter for most of the posts, only those posts that were created before we turned on the flag to support quantity on post. 

The only posts that should show this `0` are the posts that the script turns to `0` and puts the signup quantity on the latest post. 

#### Relevant tickets
Relevant to [this](https://www.pivotaltracker.com/n/projects/2019429/stories/154347334) pivotal card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.