### PR TITLE
Send reviews to Customer.io

### DIFF
--- a/app/Jobs/SendReviewedPostToCIO.php
+++ b/app/Jobs/SendReviewedPostToCIO.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rogue\Jobs;
+
+use Rogue\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SendReviewedPostToCIO implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The post to send to Customer.io.
+     *
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Post $post)
+    {
+        $this->post = $post;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Format the payload
+        $payload = $this->post->toBlinkPayload();
+
+        // Send to Quasar
+        $shouldSendToCIO = config('features.blink');
+        if ($shouldSendToCIO) {
+            gateway('blink')->post('v1/events/user-signup-post-review', $payload);
+        }
+
+        // Log
+        $verb = $shouldSendToCIO ? 'sent' : 'would have been sent';
+        info('Review of post ' . $this->post->id . ' ' . $verb . ' to Customer.io');
+    }
+}

--- a/app/Jobs/SendReviewedPostToCustomerIo.php
+++ b/app/Jobs/SendReviewedPostToCustomerIo.php
@@ -9,7 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class SendReviewedPostToCIO implements ShouldQueue
+class SendReviewedPostToCustomerIo implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -42,6 +42,7 @@ class SendReviewedPostToCIO implements ShouldQueue
 
         // Send to Quasar
         $shouldSendToCIO = config('features.blink');
+
         if ($shouldSendToCIO) {
             gateway('blink')->post('v1/events/user-signup-post-review', $payload);
         }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -6,6 +6,7 @@ use Rogue\Models\Post;
 use Rogue\Jobs\SendPostToBlink;
 use Rogue\Jobs\SendPostToQuasar;
 use Rogue\Jobs\SendSignupToQuasar;
+use Rogue\Jobs\SendReviewedPostToCIO;
 use Rogue\Repositories\PostRepository;
 use Rogue\Jobs\SendDeletedPostToQuasar;
 
@@ -70,6 +71,7 @@ class PostService
         $reviewedPost = $this->repository->reviews($data);
 
         SendPostToQuasar::dispatch($reviewedPost);
+        SendReviewedPostToCIO::dispatch($reviewedPost);
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -6,9 +6,9 @@ use Rogue\Models\Post;
 use Rogue\Jobs\SendPostToBlink;
 use Rogue\Jobs\SendPostToQuasar;
 use Rogue\Jobs\SendSignupToQuasar;
-use Rogue\Jobs\SendReviewedPostToCIO;
 use Rogue\Repositories\PostRepository;
 use Rogue\Jobs\SendDeletedPostToQuasar;
+use Rogue\Jobs\SendReviewedPostToCustomerIo;
 
 class PostService
 {
@@ -71,7 +71,7 @@ class PostService
         $reviewedPost = $this->repository->reviews($data);
 
         SendPostToQuasar::dispatch($reviewedPost);
-        SendReviewedPostToCIO::dispatch($reviewedPost);
+        SendReviewedPostToCustomerIo::dispatch($reviewedPost);
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -5,8 +5,8 @@ namespace Rogue\Services\Three;
 use Rogue\Models\Post;
 use Rogue\Jobs\SendPostToBlink;
 use Rogue\Jobs\SendPostToQuasar;
-use Rogue\Jobs\SendReviewedPostToCIO;
 use Rogue\Jobs\SendDeletedPostToQuasar;
+use Rogue\Jobs\SendReviewedPostToCustomerIo;
 use Rogue\Repositories\Three\PostRepository;
 
 class PostService
@@ -96,7 +96,7 @@ class PostService
         $post = $this->repository->reviews($post, $data, $comment);
 
         SendPostToQuasar::dispatch($post);
-        SendReviewedPostToCIO::dispatch($post);
+        SendReviewedPostToCustomerIo::dispatch($post);
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/app/Services/Three/PostService.php
+++ b/app/Services/Three/PostService.php
@@ -5,6 +5,7 @@ namespace Rogue\Services\Three;
 use Rogue\Models\Post;
 use Rogue\Jobs\SendPostToBlink;
 use Rogue\Jobs\SendPostToQuasar;
+use Rogue\Jobs\SendReviewedPostToCIO;
 use Rogue\Jobs\SendDeletedPostToQuasar;
 use Rogue\Repositories\Three\PostRepository;
 
@@ -95,6 +96,7 @@ class PostService
         $post = $this->repository->reviews($post, $data, $comment);
 
         SendPostToQuasar::dispatch($post);
+        SendReviewedPostToCIO::dispatch($post);
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use Rogue\Models\Post;
 use Rogue\Models\User;
 use Illuminate\Support\Facades\Bus;
-use Rogue\Jobs\SendReviewedPostToCIO;
+use Rogue\Jobs\SendReviewedPostToCustomerIo;
 
 class ReviewsTest extends TestCase
 {
@@ -32,7 +32,7 @@ class ReviewsTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        Bus::assertDispatched(SendReviewedPostToCIO::class);
+        Bus::assertDispatched(SendReviewedPostToCustomerIo::class);
 
         // Make sure the post status is updated & a review is created.
         $this->assertEquals('accepted', $post->fresh()->status);

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -5,6 +5,8 @@ namespace Tests\Http;
 use Tests\TestCase;
 use Rogue\Models\Post;
 use Rogue\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Rogue\Jobs\SendReviewedPostToCIO;
 
 class ReviewsTest extends TestCase
 {
@@ -16,6 +18,8 @@ class ReviewsTest extends TestCase
      */
     public function testUpdatingASingleReview()
     {
+        Bus::fake();
+
         $this->mockTime('8/3/2017 17:02:00');
 
         // Create a post.
@@ -28,6 +32,7 @@ class ReviewsTest extends TestCase
         ]);
 
         $response->assertStatus(201);
+        Bus::assertDispatched(SendReviewedPostToCIO::class);
 
         // Make sure the post status is updated & a review is created.
         $this->assertEquals('accepted', $post->fresh()->status);

--- a/tests/Http/Three/ReviewsTest.php
+++ b/tests/Http/Three/ReviewsTest.php
@@ -5,7 +5,7 @@ namespace Tests\Http\Three;
 use Tests\TestCase;
 use Rogue\Models\Post;
 use Illuminate\Support\Facades\Bus;
-use Rogue\Jobs\SendReviewedPostToCIO;
+use Rogue\Jobs\SendReviewedPostToCustomerIo;
 
 class ReviewsTest extends TestCase
 {
@@ -30,7 +30,7 @@ class ReviewsTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        Bus::assertDispatched(SendReviewedPostToCIO::class);
+        Bus::assertDispatched(SendReviewedPostToCustomerIo::class);
 
         // Make sure the post status is updated & a review is created.
         $this->assertEquals('accepted', $post->fresh()->status);

--- a/tests/Http/Three/ReviewsTest.php
+++ b/tests/Http/Three/ReviewsTest.php
@@ -4,6 +4,8 @@ namespace Tests\Http\Three;
 
 use Tests\TestCase;
 use Rogue\Models\Post;
+use Illuminate\Support\Facades\Bus;
+use Rogue\Jobs\SendReviewedPostToCIO;
 
 class ReviewsTest extends TestCase
 {
@@ -15,6 +17,8 @@ class ReviewsTest extends TestCase
      */
     public function testPostingASingleReview()
     {
+        Bus::fake();
+
         // Create a post.
         $northstarId = $this->faker->northstar_id;
         $post = factory(Post::class)->create();
@@ -26,6 +30,7 @@ class ReviewsTest extends TestCase
         ]);
 
         $response->assertStatus(201);
+        Bus::assertDispatched(SendReviewedPostToCIO::class);
 
         // Make sure the post status is updated & a review is created.
         $this->assertEquals('accepted', $post->fresh()->status);


### PR DESCRIPTION
#### What's this PR do?
- Added `SendReviewedPostToCIO.php` which works like our other jobs to send data along. It hits `v1/events/user-signup-post-review` in Blink and sends the same payload that we sent to Blink when a post is created.
- The job is dispatched in the `review` methods of both the original and the v3 `PostService`
- In the reviews tests, call `Bus::fake()` and `        Bus::assertDispatched(SendReviewedPostToCIO::class)` to make sure the job is getting dispatched (but don't actually call it)


#### How should this be reviewed?
All the tests are passing, but are there other tests where the job should be getting dispatched?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/149862801)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.