### PR TITLE
Tag posts command

### DIFF
--- a/app/Console/Commands/TagPosts.php
+++ b/app/Console/Commands/TagPosts.php
@@ -47,6 +47,7 @@ class TagPosts extends Command
         if ($posts) {
             foreach ($posts as $post) {
                 $this->info('Tagging post_id: '.$post->id.' as '.$tag->tag_slug);
+                // @TODO - Send to quasar when tagged.
                 $post->tag($tag->tag_name);
             }
         }

--- a/app/Console/Commands/TagPosts.php
+++ b/app/Console/Commands/TagPosts.php
@@ -2,8 +2,8 @@
 
 namespace Rogue\Console\Commands;
 
-use Rogue\Models\Post;
 use Rogue\Models\Tag;
+use Rogue\Models\Post;
 use Illuminate\Console\Command;
 
 class TagPosts extends Command
@@ -44,8 +44,7 @@ class TagPosts extends Command
         $posts = Post::find($postIds);
         $tag = Tag::findOrFail($this->option('tag'));
 
-        foreach ($posts as $post)
-        {
+        foreach ($posts as $post) {
             $post->tag($tag->tag_name);
         }
     }

--- a/app/Console/Commands/TagPosts.php
+++ b/app/Console/Commands/TagPosts.php
@@ -13,7 +13,7 @@ class TagPosts extends Command
      *
      * @var string
      */
-    protected $signature = 'rogue:tagposts {post* : The ids of the posts to update, separate by spaces} {--tag=}';
+    protected $signature = 'rogue:tagposts {--tag=: The id of the tag to use.} {--posts=: Comma-separated list of the post_ids to update.}';
 
     /**
      * The console command description.
@@ -39,13 +39,16 @@ class TagPosts extends Command
      */
     public function handle()
     {
-        $postIds = $this->argument('post');
-
+        $postIds = explode(',', $this->option('posts'));
         $posts = Post::find($postIds);
+
         $tag = Tag::findOrFail($this->option('tag'));
 
-        foreach ($posts as $post) {
-            $post->tag($tag->tag_name);
+        if ($posts) {
+            foreach ($posts as $post) {
+                $this->info('Tagging post_id: '.$post->id.' as '.$tag->tag_slug);
+                $post->tag($tag->tag_name);
+            }
         }
     }
 }

--- a/app/Console/Commands/TagPosts.php
+++ b/app/Console/Commands/TagPosts.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Post;
+use Rogue\Models\Tag;
+use Illuminate\Console\Command;
+
+class TagPosts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:tagposts {post* : The ids of the posts to update, separate by spaces} {--tag=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Tag a set of posts with the given tag id';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $postIds = $this->argument('post');
+
+        $posts = Post::find($postIds);
+        $tag = Tag::findOrFail($this->option('tag'));
+
+        foreach ($posts as $post)
+        {
+            $post->tag($tag->tag_name);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends ConsoleKernel
         Commands\PostCleanup::class,
         Commands\MakeDefaultURLsNull::class,
         Commands\MakeSourceSms::class,
+        Commands\TagPosts::class,
     ];
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Adds a command that lets you programatically tag a group of posts. 

To run the command: 
`php artisan rogue:tagposts --tag=1 --posts=1,3,6`

which would tag posts 1, 3, and 6 as `hide-in-gallery`

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

So we can quickly tag some posts for a campaign when we need to. 

#### Relevant tickets

Needed to fix some posts on prod. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.