### PR TITLE
Update signup field command

### DIFF
--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -23,13 +23,22 @@ class UpdateSignup extends Command
     protected $description = 'Update a target field on a set of signups contrained by the provided parameters';
 
     /**
+     * The signup service instance.
+     *
+     * @var Rogue\Services\Three\SignupService
+     */
+    protected $signups;
+
+    /**
      * Create a new command instance.
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(SignupService $signups)
     {
         parent::__construct();
+
+        $this->signups = $signups;
     }
 
     /**
@@ -40,5 +49,6 @@ class UpdateSignup extends Command
     public function handle()
     {
         // dd($this->option('target'), $this->option('campaign'), $this->option('campaign_run'), $this->option('date'));
+        dd(get_class($this->signups));
     }
 }

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -83,13 +83,11 @@ class UpdateSignup extends Command
 
         if ($signups->isNotEmpty()) {
             foreach ($signups as $signup) {
-                $this->info('Updating '.$targetField.' for signup '.$signup->id);
-
                 $this->signups->update($signup, [$targetField => $targetValue]);
             }
         } else {
             $this->error('No signups found with that criteria.');
-            $return;
+            return;
         }
     }
 }

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Signup;
+use Illuminate\Console\Command;
+use Rogue\Services\Three\SignupService;
+
+class UpdateSignup extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:updatesignups {--target= : The name of the field to update} {--campaign= : The campaign_id to search for signups under} {--campaign_run= : The campaign_run_id to search for signups under} {--date= : Will be used to search for signups greater than the provided value}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update a target field on a set of signups contrained by the provided parameters';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // dd($this->option('target'), $this->option('campaign'), $this->option('campaign_run'), $this->option('date'));
+    }
+}

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -53,11 +53,13 @@ class UpdateSignup extends Command
 
         if (! $targetField) {
             $this->error('No target field specified.');
+
             return;
         }
 
         if (! $targetValue) {
             $this->error('No target value specified.');
+
             return;
         }
 

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -87,6 +87,7 @@ class UpdateSignup extends Command
             }
         } else {
             $this->error('No signups found with that criteria.');
+
             return;
         }
     }

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -56,7 +56,7 @@ class UpdateSignup extends Command
             return;
         }
 
-        if (!$targetValue) {
+        if (! $targetValue) {
             $this->error('No target value specified.');
             return;
         }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends ConsoleKernel
         Commands\MakeDefaultURLsNull::class,
         Commands\MakeSourceSms::class,
         Commands\TagPosts::class,
+        Commands\UpdateSignup::class,
     ];
 
     /**


### PR DESCRIPTION
#### What's this PR do?

Adds a command to update a target field/value on the signup record given a set of query contraints.

Here is an example for updating `campaign_run_id` to `8044` for all signups where `campagin_run_id = 7669` (currently) and that were created after 3/1/18 

`php artisan rogue:updatesignup --target=campaign_run_id --campaign_run=7669 -targetValue=8044 --date=2018-03-01`

#### How should this be reviewed?

:eyes:

#### Any background context you want to provide?
This is a command to help with a specific use case outlined in this [slack thread](https://dosomething.slack.com/archives/C2BLZGBPH/p1520264003000003)

I tried to make it flexible if we need it for other things, but this should at least take care of this use case and we can flush it out if more requests like this come in. 

Also this moves through the `SignupService` so it will send the signup update to quasar. 

#### Relevant tickets
Fixes 🐛 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.