### PR TITLE
154979852 Turn off image editing

### DIFF
--- a/app/Console/Commands/EditImagesCommand.php
+++ b/app/Console/Commands/EditImagesCommand.php
@@ -49,7 +49,6 @@ class EditImagesCommand extends Command
 
                 try {
                     $editedImage = (string) Image::make($image)
-                        ->orientate()
                         ->fit(400)
                         ->encode('jpg', 75);
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -65,9 +65,6 @@ class PostRepository
     public function create(array $data, $signupId)
     {
         if (isset($data['file'])) {
-            // Auto-orient the photo by default based on exif data.
-            $image = Image::make($data['file'])->orientate();
-
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
         } else {
             $fileUrl = null;

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -286,9 +286,6 @@ class PostRepository
                 // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
                 ->rotate(-$cropValues['crop_rotate'])
                 ->crop($cropValues['crop_width'], $cropValues['crop_height'], $cropValues['crop_x'], $cropValues['crop_y']);
-        } else {
-            // Otherwise, try to rotate automatically by EXIF metadata.
-            $editedImage = $editedImage->orientate();
         }
 
         $editedImage = $editedImage->fit(400)

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -65,6 +65,9 @@ class PostRepository
     public function create(array $data, $signupId)
     {
         if (isset($data['file'])) {
+            // Auto-orient the photo by default based on exif data.
+            $image = Image::make($data['file']);
+
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
         } else {
             $fileUrl = null;

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -127,9 +127,11 @@ class PostRepository
             $signup->save();
         }
 
-        // Edit the image if there is one
-        if (isset($data['file'])) {
-            $this->crop($data, $post->id);
+        if (!config('features.glide')) {
+            // Edit the image if there is one
+            if (isset($data['file'])) {
+                $this->crop($data, $post->id);
+            }
         }
 
         return $post;

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -269,7 +269,6 @@ class PostRepository
         return Post::with('signup', 'tags')->findOrFail($post->id);
     }
 
-
     /**
      * Crop an image
      *
@@ -285,6 +284,6 @@ class PostRepository
         // use default crop (400x400)
         $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
 
-        return $this->aws->storeImageData((string)$editedImage, 'edited_' . $postId);
+        return $this->aws->storeImageData((string) $editedImage, 'edited_' . $postId);
     }
 }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -127,7 +127,7 @@ class PostRepository
             $signup->save();
         }
 
-        if (!config('features.glide')) {
+        if (! config('features.glide')) {
             // Edit the image if there is one
             if (isset($data['file'])) {
                 $this->crop($data, $post->id);

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -127,11 +127,9 @@ class PostRepository
             $signup->save();
         }
 
-        if (! config('features.glide')) {
-            // Edit the image if there is one
-            if (isset($data['file'])) {
-                $this->crop($data, $post->id);
-            }
+        // Edit the image if there is one
+        if (isset($data['file'])) {
+            $this->crop($data, $post->id);
         }
 
         return $post;

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -269,8 +269,11 @@ class PostRepository
         return Post::with('signup', 'tags')->findOrFail($post->id);
     }
 
+
     /**
      * Crop an image
+     *
+     * @TODO - remove when glide is permanent.
      *
      * @param  int $signupId
      * @return url|null
@@ -279,19 +282,8 @@ class PostRepository
     {
         $editedImage = Image::make($data['file']);
 
-        // If glide is off and we have crop values, use those for editing.
-        $cropValues = array_only($data, $this->cropProperties);
-
-        if (!config('features.glide') && count($cropValues) > 0) {
-            $editedImage = $editedImage
-                // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
-                ->rotate(-$cropValues['crop_rotate'])
-                ->crop($cropValues['crop_width'], $cropValues['crop_height'], $cropValues['crop_x'], $cropValues['crop_y'])
-                ->encode('jpg', 75);
-        // Otherwise, use default crop (400x400).
-        } else {
-            $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
-        }
+        // use default crop (400x400)
+        $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
 
         return $this->aws->storeImageData((string)$editedImage, 'edited_' . $postId);
     }

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -253,9 +253,6 @@ class PostRepository
                 // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
                 ->rotate(-$cropValues['crop_rotate'])
                 ->crop($cropValues['crop_width'], $cropValues['crop_height'], $cropValues['crop_x'], $cropValues['crop_y']);
-        } else {
-            // Otherwise, try to rotate automatically by EXIF metadata.
-            $editedImage = $editedImage->orientate();
         }
 
         $editedImage = $editedImage->fit(400)

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -109,11 +109,9 @@ class PostRepository
 
         $post->save();
 
-        if (! config('features.glide')) {
-            // Edit the image if there is one
-            if (isset($data['file'])) {
-                $this->crop($data, $post->id);
-            }
+        // Edit the image if there is one
+        if (isset($data['file'])) {
+            $this->crop($data, $post->id);
         }
 
         // Update the signup's total quantity.
@@ -245,15 +243,6 @@ class PostRepository
     protected function crop($data, $postId)
     {
         $editedImage = Image::make($data['file']);
-
-        // If we have crop values, then use 'em.
-        $cropValues = array_only($data, $this->cropProperties);
-        if (count($cropValues) > 0) {
-            $editedImage = $editedImage
-                // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
-                ->rotate(-$cropValues['crop_rotate'])
-                ->crop($cropValues['crop_width'], $cropValues['crop_height'], $cropValues['crop_x'], $cropValues['crop_y']);
-        }
 
         $editedImage = $editedImage->fit(400)
             ->encode('jpg', 75);

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -67,6 +67,9 @@ class PostRepository
     public function create(array $data, $signupId, $authenticatedUserRole = null)
     {
         if (isset($data['file'])) {
+            // Auto-orient the photo by default based on exif data.
+            $image = Image::make($data['file']);
+
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
         } else {
             $fileUrl = null;

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -67,9 +67,6 @@ class PostRepository
     public function create(array $data, $signupId, $authenticatedUserRole = null)
     {
         if (isset($data['file'])) {
-            // Auto-orient the photo by default based on exif data.
-            $image = Image::make($data['file'])->orientate();
-
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
         } else {
             $fileUrl = null;

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -237,6 +237,8 @@ class PostRepository
     /**
      * Crop an image
      *
+     * @TODO - remove when glide is permanent.
+     *
      * @param  int $signupId
      * @return url|null
      */
@@ -244,9 +246,20 @@ class PostRepository
     {
         $editedImage = Image::make($data['file']);
 
-        $editedImage = $editedImage->fit(400)
-            ->encode('jpg', 75);
+        // If glide is off and we have crop values, use those for editing.
+        $cropValues = array_only($data, $this->cropProperties);
 
-        return $this->aws->storeImageData((string) $editedImage, 'edited_' . $postId);
+        if (! config('features.glide') && count($cropValues) > 0) {
+            $editedImage = $editedImage
+                // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
+                ->rotate(-$cropValues['crop_rotate'])
+                ->crop($cropValues['crop_width'], $cropValues['crop_height'], $cropValues['crop_x'], $cropValues['crop_y'])
+                ->encode('jpg', 75);
+        // Otherwise, use default crop (400x400).
+        } else {
+            $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
+        }
+
+        return $this->aws->storeImageData((string)$editedImage, 'edited_' . $postId);
     }
 }

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -109,9 +109,11 @@ class PostRepository
 
         $post->save();
 
-        // Edit the image if there is one
-        if (isset($data['file'])) {
-            $this->crop($data, $post->id);
+        if (! config('features.glide')) {
+            // Edit the image if there is one
+            if (isset($data['file'])) {
+                $this->crop($data, $post->id);
+            }
         }
 
         // Update the signup's total quantity.

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -246,19 +246,8 @@ class PostRepository
     {
         $editedImage = Image::make($data['file']);
 
-        // If glide is off and we have crop values, use those for editing.
-        $cropValues = array_only($data, $this->cropProperties);
-
-        if (! config('features.glide') && count($cropValues) > 0) {
-            $editedImage = $editedImage
-                // Intervention Image rotates images counter-clockwise, but we get values assuming clockwise rotation, so we negate it to rotate clockwise.
-                ->rotate(-$cropValues['crop_rotate'])
-                ->crop($cropValues['crop_width'], $cropValues['crop_height'], $cropValues['crop_x'], $cropValues['crop_y'])
-                ->encode('jpg', 75);
-        // Otherwise, use default crop (400x400).
-        } else {
-            $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
-        }
+        // use default crop (400x400)
+        $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
 
         return $this->aws->storeImageData((string)$editedImage, 'edited_' . $postId);
     }

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -249,6 +249,6 @@ class PostRepository
         // use default crop (400x400)
         $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
 
-        return $this->aws->storeImageData((string)$editedImage, 'edited_' . $postId);
+        return $this->aws->storeImageData((string) $editedImage, 'edited_' . $postId);
     }
 }


### PR DESCRIPTION
#### What's this PR do?

Moves the cropping we do under the glide feature flag so that, if glide is on, we don't do it.

The hope is that this won't cause any weird issues with images being oriented or cropped incorrectly. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Detailed background on this issue: https://github.com/orgs/DoSomething/teams/team-bleed/discussions/16

#### Relevant tickets
addresses https://www.pivotaltracker.com/story/show/154979852

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.