### PR TITLE
Re-naming `caption` to `text`

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -147,7 +147,7 @@ class PostsController extends ApiController
     public function update(Request $request, Post $post)
     {
         $validatedRequest = $request->validate([
-            'caption' => 'nullable|string|max:140',
+            'text' => 'nullable|string|max:140',
             'quantity' => 'nullable|integer',
         ]);
 

--- a/app/Http/Requests/Three/PostRequest.php
+++ b/app/Http/Requests/Three/PostRequest.php
@@ -30,7 +30,7 @@ class PostRequest extends Request
             'type' => 'required|string|in:photo,voter-reg',
             'action' => 'required|string',
             'why_participated' => 'nullable|string',
-            'caption' => 'required|nullable|string|max:140',
+            'text' => 'required|nullable|string|max:140',
             'quantity' => 'nullable|integer',
             'file' => 'image|dimensions:min_width=400,min_height=400',
             'status' => 'in:pending,accepted,rejected',

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -42,7 +42,7 @@ class PostTransformer extends TransformerAbstract
             'media' => [
                 'url' => $post->getMediaUrl(),
                 'original_image_url' => $post->url . '?time='. Carbon::now()->timestamp,
-                'caption' => $post->caption,
+                'caption' => $post->text,
             ],
             'tags' => $post->tagSlugs(),
             'reactions' => [

--- a/app/Http/Transformers/ReportbackTransformer.php
+++ b/app/Http/Transformers/ReportbackTransformer.php
@@ -20,7 +20,7 @@ class ReportbackTransformer extends TransformerAbstract
         $result = [
             'id' => (string) $post->id,
             'status' => $post->status,
-            'caption' => $post->caption,
+            'caption' => $post->text,
             'uri' => url(config('services.phoenix.uri') . '/api/v1/reportback-items/'.$post->id, ['absolute' => true]),
             'media' => [
                 'uri' => $post->getMediaUrl(),

--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -41,7 +41,7 @@ class PostTransformer extends TransformerAbstract
             'media' => [
                 'url' => $post->getMediaUrl(),
                 'original_image_url' => $post->url . '?time='. Carbon::now()->timestamp,
-                'caption' => $post->caption,
+                'text' => $post->text,
             ],
             'quantity' => $post->quantity,
             'reactions' => [

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -170,6 +170,7 @@ class Post extends Model
             'action' => $this->action,
             'url' => $this->getMediaUrl(),
             'caption' => $this->text,
+            'text' => $this->text,
             'status' => $this->status,
             'remote_addr' => $this->remote_addr,
             'source' => $this->source,
@@ -203,6 +204,7 @@ class Post extends Model
             'media' => [
                 'url' => $this->getMediaUrl(),
                 'caption' => $this->text,
+                'text' => $this->text,
             ],
             'tags' => $this->tagSlugs(),
             'status' => $this->status,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -30,7 +30,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'details', 'quantity', 'url', 'caption', 'status', 'source', 'source_details', 'remote_addr'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'remote_addr'];
 
     /**
      * Attributes that can be queried when filtering.
@@ -169,7 +169,7 @@ class Post extends Model
             'type' => $this->type,
             'action' => $this->action,
             'url' => $this->getMediaUrl(),
-            'caption' => $this->caption,
+            'caption' => $this->text,
             'status' => $this->status,
             'remote_addr' => $this->remote_addr,
             'source' => $this->source,
@@ -202,7 +202,7 @@ class Post extends Model
             // @NOTE - Remove if we get rid of rotation.
             'media' => [
                 'url' => $this->getMediaUrl(),
-                'caption' => $this->caption,
+                'caption' => $this->text,
             ],
             'tags' => $this->tagSlugs(),
             'status' => $this->status,

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -81,7 +81,7 @@ class PostRepository
             'northstar_id' => $data['northstar_id'],
             'campaign_id' => $signup->campaign_id,
             'url' => $fileUrl,
-            'caption' => $data['caption'],
+            'text' => $data['caption'],
             'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => isset($data['source']) ? $data['source'] : null,
             'remote_addr' => isset($data['remote_addr']) ? $data['remote_addr'] : null,

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -86,7 +86,7 @@ class PostRepository
             'type' => isset($data['type']) ? $data['type'] : 'photo',
             'action' => isset($data['action']) ? $data['action'] : null,
             'url' => $fileUrl,
-            'caption' => isset($data['caption']) ? $data['caption'] : null,
+            'text' => isset($data['text']) ? $data['text'] : null,
             'status' => 'pending',
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -28,7 +28,7 @@ $factory->define(Post::class, function (Generator $faker) {
             return factory(Signup::class)->create()->id;
         },
         'url' => $url,
-        'caption' => $faker->sentence(),
+        'text' => $faker->sentence(),
         'source' => $faker->randomElement(['phoenix-oauth', 'phoenix-next']),
         'remote_addr' => $faker->ipv4,
         'status' => 'pending',

--- a/database/migrations/2018_03_12_202842_rename_caption_to_text_in_posts_table.php
+++ b/database/migrations/2018_03_12_202842_rename_caption_to_text_in_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameCaptionToTextInPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->renameColumn('caption', 'text');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->renameColumn('text', 'caption');
+        });
+    }
+}

--- a/documentation/endpoints/v3/posts.md
+++ b/documentation/endpoints/v3/posts.md
@@ -50,7 +50,7 @@ Example Response:
             "northstar_id": "5594429fa59dbfc9578b48f4",
             "media": {
                 "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_2984.jpeg",
-                "caption": null
+                "text": null
             },
             "quantity": "12",
             "tags": [],
@@ -70,7 +70,7 @@ Example Response:
             "northstar_id": "5575e568a59dbf3b7a8b4572",
             "media": {
                 "url": "https://s3.amazonaws.com/ds-rogue-qa/uploads/reportback-items/edited_3655.jpeg",
-                "caption": "Perhaps you CAN be of some assistance, Bill"
+                "text": "Perhaps you CAN be of some assistance, Bill"
             },
             "quantity": "12",
             "tags": [],
@@ -120,7 +120,7 @@ Example Response:
     "media": {
       "url": "http://localhost/storage/uploads/reportback-items/edited_332.jpeg?time=1509129880",
       "original_image_url": "http://localhost/storage/uploads/reportback-items/289-923df5957838355206574f72d5520f0f-1509115822.jpeg?time=1509129880",
-      "caption": "fe"
+      "text": "fe"
     },
     "quantity": "12",
     "tags": [],
@@ -156,8 +156,8 @@ POST /api/v3/posts
     The number of reportback nouns verbed. Can be `null`.
   - **why_participated**: (string).
     The reason why the user participated.
-  - **caption**: (string).
-    Corresponding caption for the post.
+  - **text**: (string).
+    Corresponding text for the post (could be photo caption or other words).
   - **status**: (string).
     Option to set status upon creation if admin uploads post for user.
   - **file**: (file) required for photo posts.
@@ -178,7 +178,7 @@ Example Response:
     "media": {
       "url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/edited_214.jpeg",
       "original_image_url": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/128-482cab927f6529c7f5e5c4bfd2594186-1501090354.jpeg",
-      "caption": "Captioning captions",
+      "text": "Captioning captions",
     },
     "quantity": "12",
     "status": "pending",
@@ -211,15 +211,15 @@ Example Response:
 PATCH /api/v3/posts/:post_id
 ```
 
-  - **caption**: (string)
-    The caption of the post.
+  - **text**: (string)
+    The text of the post.
   - **quantity**: (int)
     The quantity of items in the post.
 
 Example request body:
 ```
 [
-  "caption" => "Here is a brand new caption"
+  "text" => "Here is a brand new caption"
   "quantity" => "7"
 ]
 ```
@@ -234,7 +234,7 @@ Example response:
       "media": {
           "url": "http://localhost/storage/uploads/reportback-items/edited_332.jpeg?time=1509379493",
           "original_image_url": "http://localhost/storage/uploads/reportback-items/289-923df5957838355206574f72d5520f0f-1509115822.jpeg?time=1509379493",
-          "caption": "Here is a brand new caption"
+          "text": "Here is a brand new caption"
       },
       "quantity": "7",
       "tags": [],

--- a/tests/Http/Three/PostTest.php
+++ b/tests/Http/Three/PostTest.php
@@ -23,7 +23,7 @@ class PostTest extends TestCase
         $campaignId = $this->faker->randomNumber(4);
         $campaignRunId = $this->faker->randomNumber(4);
         $quantity = $this->faker->numberBetween(10, 1000);
-        $caption = $this->faker->sentence;
+        $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API calls.
@@ -39,7 +39,7 @@ class PostTest extends TestCase
             'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
-            'caption'          => $caption,
+            'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
@@ -55,7 +55,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'tags' => [],
@@ -98,7 +98,7 @@ class PostTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
-        $caption = $this->faker->sentence;
+        $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
@@ -113,7 +113,7 @@ class PostTest extends TestCase
             'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
-            'caption'          => $caption,
+            'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
@@ -129,7 +129,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'tags' => [],
@@ -167,7 +167,7 @@ class PostTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
-        $caption = $this->faker->sentence;
+        $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
@@ -182,7 +182,7 @@ class PostTest extends TestCase
             'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
-            'caption'          => $caption,
+            'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
@@ -198,7 +198,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'tags' => [],
@@ -228,7 +228,7 @@ class PostTest extends TestCase
 
         // Create a second post without why_participated.
         $secondQuantity = $this->faker->numberBetween(10, 1000);
-        $secondCaption = $this->faker->sentence;
+        $secondText = $this->faker->sentence;
         $secondDetails = ['source-detail' => 'broadcast-333', 'other' => 'other'];
 
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
@@ -238,7 +238,7 @@ class PostTest extends TestCase
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $secondQuantity,
-            'caption'          => $secondCaption,
+            'text'             => $secondText,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($secondDetails),
         ]);
@@ -254,7 +254,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'tags' => [],
@@ -294,7 +294,7 @@ class PostTest extends TestCase
     public function testCreatingAPostWithNullAsQuantity()
     {
         $signup = factory(Signup::class)->create();
-        $caption = $this->faker->sentence;
+        $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
@@ -308,7 +308,7 @@ class PostTest extends TestCase
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => null,
-            'caption'          => $caption,
+            'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
@@ -324,7 +324,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'tags' => [],
@@ -361,7 +361,7 @@ class PostTest extends TestCase
     public function testCreatingAPostWithoutQuantityParam()
     {
         $signup = factory(Signup::class)->create();
-        $caption = $this->faker->sentence;
+        $text = $this->faker->sentence;
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -373,7 +373,7 @@ class PostTest extends TestCase
             'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
-            'caption'          => $caption,
+            'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
         ]);
 
@@ -388,7 +388,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'tags' => [],
@@ -426,7 +426,7 @@ class PostTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
-        $caption = $this->faker->sentence;
+        $text = $this->faker->sentence;
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -440,7 +440,7 @@ class PostTest extends TestCase
             'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
-            'caption'          => $caption,
+            'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
         ]);
 
@@ -474,7 +474,7 @@ class PostTest extends TestCase
                     'media' => [
                         'url',
                         'original_image_url',
-                        'caption',
+                        'text',
                     ],
                     'quantity',
                     'reactions' => [
@@ -526,7 +526,7 @@ class PostTest extends TestCase
                     'media' => [
                         'url',
                         'original_image_url',
-                        'caption',
+                        'text',
                     ],
                     'quantity',
                     'reactions' => [
@@ -594,7 +594,7 @@ class PostTest extends TestCase
                     'media' => [
                         'url',
                         'original_image_url',
-                        'caption',
+                        'text',
                     ],
                     'quantity',
                     'reactions' => [
@@ -657,7 +657,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'reactions' => [
@@ -700,7 +700,7 @@ class PostTest extends TestCase
                 'media' => [
                     'url',
                     'original_image_url',
-                    'caption',
+                    'text',
                 ],
                 'quantity',
                 'reactions' => [
@@ -735,14 +735,14 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
-            'caption' => 'new caption',
+            'text' => 'new caption',
             'quantity' => 8,
         ]);
 
         $response->assertStatus(200);
 
-        // Make sure that the posts's new status and caption gets persisted in the database.
-        $this->assertEquals($post->fresh()->caption, 'new caption');
+        // Make sure that the posts's new status and text gets persisted in the database.
+        $this->assertEquals($post->fresh()->text, 'new caption');
         $this->assertEquals($post->fresh()->quantity, 8);
 
         // Make sure the signup's quantity gets updated.
@@ -761,14 +761,14 @@ class PostTest extends TestCase
 
         $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
             'quantity' => 'this is words not a number!',
-            'caption' => 'This must be longer than 140 characters to break the validation rules so here I will create a caption that is longer than 140 characters to test.',
+            'text' => 'This must be longer than 140 characters to break the validation rules so here I will create a caption that is longer than 140 characters to test.',
         ]);
 
         $response->assertStatus(422);
 
         $json = $response->json();
         $this->assertEquals('The quantity must be an integer.', $json['errors']['quantity'][0]);
-        $this->assertEquals('The caption may not be greater than 140 characters.', $json['errors']['caption'][0]);
+        $this->assertEquals('The text may not be greater than 140 characters.', $json['errors']['text'][0]);
     }
 
     /**
@@ -783,7 +783,7 @@ class PostTest extends TestCase
 
         $response = $this->withAccessToken($user->id)->patchJson('api/v3/posts/' . $post->id, [
             'status' => 'accepted',
-            'caption' => 'new caption',
+            'text' => 'new caption',
         ]);
 
         $response->assertStatus(403);


### PR DESCRIPTION
#### What's this PR do?
- Rename `caption` column in `posts` table to `text`
- `v3` now uses `text` instead of `caption` everywhere
- `v2` still takes in and validates `caption`, but saves to and retrieves from the `text` attribute on the post
- adds additional `text` field to Blink (c.io) and Quasar payloads (still sends `caption` too)

#### How should this be reviewed?
Tests passing? Test updates look good? `v2` still works?

#### Any background context you want to provide?
Words aren't always a caption.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/155822916)

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.