### PR TITLE
Throttle /images route

### DIFF
--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -33,6 +33,8 @@ class ImagesController extends Controller
         $this->filesystem = $filesystem;
         $this->aws = $aws;
         $this->fastly = $fastly;
+
+        $this->middleware('throttle:15');
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,5 +62,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \Rogue\Http\Middleware\RedirectIfAuthenticated::class,
         'role' => \Rogue\Http\Middleware\CheckRole::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -36,7 +36,7 @@
         <env name="STORAGE_DRIVER" value="public"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_DATABASE" value="rogue_test"/>
-        <env name="DS_ENABLE_GLIDE" value="false"/>
+        <env name="DS_ENABLE_GLIDE" value="true"/>
         <env name="DS_ENABLE_BLINK" value="true"/>
     </php>
 </phpunit>

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -15,24 +15,23 @@ class ImagesTest extends TestCase
     public function testImagesThrottle()
     {
         // Make a post to view
-        $post = factory(Post::class)->create();
+        $posts = factory(Post::class, 10)->create();
 
         // View the post 15 times (using 3 different versions)
         for ($i = 0; $i < 5; $i++) {
-            $response = $this->getJson('images/' . $post->id);
-            $response->assertStatus(200);
+            $response = $this->getJson('images/' . $posts->random()->id)->assertSuccessful(200);
         }
         for ($i = 5; $i < 10; $i++) {
-            $response = $this->getJson('images/' . $post->id . '?w=500&h=500&fit=crop');
+            $response = $this->getJson('images/' . $posts->random()->id . '?w=500&h=500&fit=crop');
             $response->assertStatus(200);
         }
         for ($i = 10; $i < 15; $i++) {
-            $response = $this->getJson('images/' . $post->id . '?w=250&h=400&fit=crop&filt=sepia');
+            $response = $this->getJson('images/' . $posts->random()->id . '?w=250&h=400&fit=crop&filt=sepia');
             $response->assertStatus(200);
         }
 
         // Get a "Too Many Attempts" response when viewing the post a 16th time
-        $response = $this->getJson('images/' . $post->id);
+        $response = $this->getJson('images/' . $posts->random()->id);
         $response->assertStatus(429);
     }
 }

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Http;
+
+use Tests\TestCase;
+use Rogue\Models\Post;
+
+class ImagesTest extends TestCase
+{
+    /**
+     * Test for endpoint throttling.
+     *
+     * @return void
+     */
+    public function testImagesThrottle()
+    {
+        // Make a post to view
+        $post = factory(Post::class)->create();
+
+        // View the post 15 times (using 3 different versions)
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->getJson('images/' . $post->id);
+            $response->assertStatus(200);
+        }
+        for ($i = 5; $i < 10; $i++) {
+            $response = $this->getJson('images/' . $post->id . '?w=500&h=500&fit=crop');
+            $response->assertStatus(200);
+        }
+        for ($i = 10; $i < 15; $i++) {
+            $response = $this->getJson('images/' . $post->id . '?w=250&h=400&fit=crop&filt=sepia');
+            $response->assertStatus(200);
+        }
+
+        // Get a "Too Many Attempts" response when viewing the post a 16th time
+        $response = $this->getJson('images/' . $post->id);
+        $response->assertStatus(429);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
- Added throttling (at 15 requests/minute) to the `/images` route
- Added a test to make sure that a user gets a `Too Many Attempts` response after 15 images

#### How should this be reviewed?
👀  Is there anything else we should be testing for? Do we need to test with more than one image?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/155853452)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.