### PR TITLE
Make 'type' and 'action' fields public.

### DIFF
--- a/app/Http/Transformers/Three/PostTransformer.php
+++ b/app/Http/Transformers/Three/PostTransformer.php
@@ -34,6 +34,8 @@ class PostTransformer extends TransformerAbstract
         $response = [
             'id' => $post->id,
             'signup_id' => $post->signup_id,
+            'type' => $post->type,
+            'action' => $post->action,
             'northstar_id' => $post->northstar_id,
             // Add cache-busting query string to urls to make sure we get the
             // most recent version of the image.
@@ -58,8 +60,6 @@ class PostTransformer extends TransformerAbstract
             $response['source'] = $post->source;
             $response['source_details'] = $post->source_details;
             $response['remote_addr'] = $post->remote_addr;
-            $response['type'] = $post->type;
-            $response['action'] = $post->action;
             $response['details'] = $post->details;
         }
 


### PR DESCRIPTION
#### What's this PR do?
We need these `type` and `action` fields to be able to decide how to display a post (e.g. "show this as a photo" vs. "show this as a text block"). In the future, we may also separate different actions into different galleries.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
These are needed in order to display content correctly to users.

#### Relevant tickets
[#155944555](https://www.pivotaltracker.com/story/show/155944555)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.