### PR TITLE
Rotation bug on Rogue Admin

### DIFF
--- a/resources/assets/components/Post/__snapshots__/test.js.snap
+++ b/resources/assets/components/Post/__snapshots__/test.js.snap
@@ -26,13 +26,6 @@ exports[`it renders correctly 1`] = `
         >
           Original Photo
         </a>
-        <br />
-        <a
-          href={null}
-          target="_blank"
-        >
-          Edited Photo
-        </a>
       </div>
     </div>
   </div>

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -66,13 +66,11 @@ class Post extends React.Component {
         {/* Post Images */}
         <div className="container__block -third images">
           <div className="post__image">
-            <img src={getImageUrlFromPost(post, 'edited')} />
+            <img src={getImageUrlFromPost(post, 'original')} />
           </div>
           <div className="admin-tools">
             <div className="admin-tools__links">
               <a href={getImageUrlFromPost(post, 'original')} target="_blank">Original Photo</a>
-              <br />
-              <a href={getImageUrlFromPost(post, 'edited')} target="_blank">Edited Photo</a>
             </div>
             {this.props.rotate ?
               <div className="admin-tools__rotate">

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -44,8 +44,8 @@ class PostGroup extends React.Component {
               deletePost={this.props.deletePost}
               showSiblings={false}
               campaign={this.props.campaign}
-              showQuantity
               rotate={this.props.rotate}
+              showQuantity
             />))
             :
             <Empty header={`This user has no ${this.props.groupType} posts`} />
@@ -431,6 +431,7 @@ Signup.propTypes = {
   signup_id: PropTypes.number.isRequired,
   user: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   campaign: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  rotate: PropTypes.func.isRequired,
 };
 
 export default Signup;

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -45,6 +45,7 @@ class PostGroup extends React.Component {
               showSiblings={false}
               campaign={this.props.campaign}
               showQuantity
+              rotate={this.props.rotate}
             />))
             :
             <Empty header={`This user has no ${this.props.groupType} posts`} />

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -215,10 +215,9 @@ const reviewComponent = (Component, data) => {
       return response.then((json) => {
         this.setState((prevState) => {
           const newState = {...prevState};
-
           // Add a cache-busting string to the end of the image url
           // so that it changes and triggers a re-render.
-          newState.posts[postId].media.url = json.url;
+          newState.posts[postId].media.url = json.url + '?time=' + Date.now();
 
           return newState;
         });

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -217,7 +217,7 @@ const reviewComponent = (Component, data) => {
           const newState = {...prevState};
           // Add a cache-busting string to the end of the image url
           // so that it changes and triggers a re-render.
-          newState.posts[postId].media.url = json.url + '?time=' + Date.now();
+          newState.posts[postId].media.original_image_url = json.original_image_url + '?time=' + Date.now();
 
           return newState;
         });

--- a/resources/views/signups/show.blade.php
+++ b/resources/views/signups/show.blade.php
@@ -4,7 +4,7 @@
     @include('layouts.header', ['header' => $campaign['title'], 'subtitle' => ''])
 
     <div class="container -padded">
-        <div class="wrapper" data-container="Signup">
+        <div class="wrapper" data-container="Signup" data-reviewing="true">
             Loading...
         </div>
     </div>


### PR DESCRIPTION
#### What's this PR do?
- Fixes rotation bug on campaign inbox page (more details in [this card](https://www.pivotaltracker.com/n/projects/2019429/stories/155955162))
- Adds rotation feature on signup page (`/signups/:signup_id`)
- Removes any reference to `edited url` because it is no longer being used with Glide on. 

#### How should this be reviewed?
- Rotate an image.
- The image should rotate on the front end. 
- Click the "Original Photo" link - this should also be updated to the new rotation.
- Refresh the page and the new rotation should be on the image. 

#### Any background context you want to provide?
@sbsmith86 and I saw some weirdness - we're not sure why all the reviewing was showing up _except_ for the rotation button without this fix 👻 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/155955162) Pivotal Card except for the `503` error @ngjo - I couldn't recreate this on my local! I think we can merge this and then see if it is still an error after?

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.