### PR TITLE
Allow client with correct scopes to store posts with NS ID and Status

### DIFF
--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -104,17 +104,18 @@ class PostsController extends ApiController
      */
     public function store(PostRequest $request)
     {
-        $northstarId = getNorthstarId($request);
+        return 'store';
+        // $northstarId = getNorthstarId($request);
 
-        $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
+        // $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
 
-        if (! $signup) {
-            $signup = $this->signups->create($request->all(), $northstarId);
-        }
+        // if (! $signup) {
+        //     $signup = $this->signups->create($request->all(), $northstarId);
+        // }
 
-        $post = $this->posts->create($request->all(), $signup->id);
+        // $post = $this->posts->create($request->all(), $signup->id);
 
-        return $this->item($post, 201, [], null, 'signup');
+        // return $this->item($post, 201, [], null, 'signup');
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -104,19 +104,17 @@ class PostsController extends ApiController
      */
     public function store(PostRequest $request)
     {
-        dd('make sure requests are coming in');
-        // return 'store';
-        // $northstarId = getNorthstarId($request);
+        $northstarId = getNorthstarId($request);
 
-        // $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
 
-        // if (! $signup) {
-        //     $signup = $this->signups->create($request->all(), $northstarId);
-        // }
+        if (! $signup) {
+            $signup = $this->signups->create($request->all(), $northstarId);
+        }
 
-        // $post = $this->posts->create($request->all(), $signup->id);
+        $post = $this->posts->create($request->all(), $signup->id);
 
-        // return $this->item($post, 201, [], null, 'signup');
+        return $this->item($post, 201, [], null, 'signup');
     }
 
     /**

--- a/app/Http/Controllers/Three/PostsController.php
+++ b/app/Http/Controllers/Three/PostsController.php
@@ -104,7 +104,8 @@ class PostsController extends ApiController
      */
     public function store(PostRequest $request)
     {
-        return 'store';
+        dd('make sure requests are coming in');
+        // return 'store';
         // $northstarId = getNorthstarId($request);
 
         // $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -87,7 +87,7 @@ class PostRepository
             'action' => isset($data['action']) ? $data['action'] : null,
             'url' => $fileUrl,
             'text' => isset($data['text']) ? $data['text'] : null,
-            'status' => 'pending',
+            'status' => isset($data['status']) ? $data['status'] : null,
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
@@ -95,17 +95,17 @@ class PostRepository
         ]);
 
         // If we are explicitly passed an authenticated user, use their role, otherwise grab it from the session.
-        $authenticatedUserRole = ! $authenticatedUserRole ? auth()->user()->role : $authenticatedUserRole;
+        // $authenticatedUserRole = ! $authenticatedUserRole ? auth()->user()->role : $authenticatedUserRole;
 
-        // Admin users may provide a status when uploading a post.
-        if (isset($data['status']) && $authenticatedUserRole === 'admin') {
-            $post->status = $data['status'];
-        }
+        // // Admin users may provide a status when uploading a post.
+        // if (isset($data['status']) && $authenticatedUserRole === 'admin') {
+        //     $post->status = $data['status'];
+        // }
 
-        // Admin users may provide a source when uploading a post.
-        if (isset($data['source']) && $authenticatedUserRole === 'admin') {
-            $post->source = $data['source'];
-        }
+        // // Admin users may provide a source when uploading a post.
+        // if (isset($data['source']) && $authenticatedUserRole === 'admin') {
+        //     $post->source = $data['source'];
+        // }
 
         $post->save();
 

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -97,7 +97,7 @@ class PostRepository
         $isAdmin = isset($data['status']) && isset(auth()->user()->role) && auth()->user()->role === 'admin';
         $hasAdminScope = in_array('admin', token()->scopes());
 
-        // Admin users may provide a status when uploading a post.
+        // Admin users may provide a source and status when uploading a post.
         if ($isAdmin || $hasAdminScope) {
             $post->status = isset($data['status']) ? $data['status'] : 'pending';
             $post->source = isset($data['source']) ? $data['source'] : token()->client();

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -95,17 +95,17 @@ class PostRepository
         ]);
 
         // If we are explicitly passed an authenticated user, use their role, otherwise grab it from the session.
-        // $authenticatedUserRole = ! $authenticatedUserRole ? auth()->user()->role : $authenticatedUserRole;
+        $authenticatedUserRole = ! $authenticatedUserRole ? auth()->user()->role : $authenticatedUserRole;
 
-        // // Admin users may provide a status when uploading a post.
-        // if (isset($data['status']) && $authenticatedUserRole === 'admin') {
-        //     $post->status = $data['status'];
-        // }
+        // Admin users may provide a status when uploading a post.
+        if (isset($data['status']) && $authenticatedUserRole === 'admin') {
+            $post->status = $data['status'];
+        }
 
-        // // Admin users may provide a source when uploading a post.
-        // if (isset($data['source']) && $authenticatedUserRole === 'admin') {
-        //     $post->source = $data['source'];
-        // }
+        // Admin users may provide a source when uploading a post.
+        if (isset($data['source']) && $authenticatedUserRole === 'admin') {
+            $post->source = $data['source'];
+        }
 
         $post->save();
 

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -87,23 +87,20 @@ class PostRepository
             'action' => isset($data['action']) ? $data['action'] : null,
             'url' => $fileUrl,
             'text' => isset($data['text']) ? $data['text'] : null,
-            'status' => isset($data['status']) ? $data['status'] : null,
+            'status' => isset($data['status']) ? $data['status'] : 'pending',
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
             'remote_addr' => request()->ip(),
         ]);
 
-        // If we are explicitly passed an authenticated user, use their role, otherwise grab it from the session.
-        $authenticatedUserRole = ! $authenticatedUserRole ? auth()->user()->role : $authenticatedUserRole;
-
         // Admin users may provide a status when uploading a post.
-        if (isset($data['status']) && $authenticatedUserRole === 'admin') {
+        if (isset($data['status']) && isset(auth()->user()->role) && auth()->user()->role === 'admin') {
             $post->status = $data['status'];
         }
 
         // Admin users may provide a source when uploading a post.
-        if (isset($data['source']) && $authenticatedUserRole === 'admin') {
+        if (isset($data['source']) && isset(auth()->user()->role) && auth()->user()->role === 'admin') {
             $post->source = $data['source'];
         }
 

--- a/app/Repositories/Three/PostRepository.php
+++ b/app/Repositories/Three/PostRepository.php
@@ -87,21 +87,20 @@ class PostRepository
             'action' => isset($data['action']) ? $data['action'] : null,
             'url' => $fileUrl,
             'text' => isset($data['text']) ? $data['text'] : null,
-            'status' => isset($data['status']) ? $data['status'] : 'pending',
+            'status' => 'pending',
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
             'remote_addr' => request()->ip(),
         ]);
 
-        // Admin users may provide a status when uploading a post.
-        if (isset($data['status']) && isset(auth()->user()->role) && auth()->user()->role === 'admin') {
-            $post->status = $data['status'];
-        }
+        $isAdmin = isset($data['status']) && isset(auth()->user()->role) && auth()->user()->role === 'admin';
+        $hasAdminScope = in_array('admin', token()->scopes());
 
-        // Admin users may provide a source when uploading a post.
-        if (isset($data['source']) && isset(auth()->user()->role) && auth()->user()->role === 'admin') {
-            $post->source = $data['source'];
+        // Admin users may provide a status when uploading a post.
+        if ($isAdmin || $hasAdminScope) {
+            $post->status = isset($data['status']) ? $data['status'] : 'pending';
+            $post->source = isset($data['source']) ? $data['source'] : token()->client();
         }
 
         $post->save();

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -84,7 +84,7 @@ function getAgeFromBirthdate($birthdate)
  */
 function getNorthstarId($request)
 {
-    if (token()->role() === 'admin') {
+    if (token()->role() === 'admin' || in_array('admin', token()->scopes())) {
         return isset($request['northstar_id']) ? $request['northstar_id'] : auth()->id();
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -84,6 +84,9 @@ function getAgeFromBirthdate($birthdate)
  */
 function getNorthstarId($request)
 {
+    info('debug');
+    info($request);
+    info(auth());
     if (token()->role() === 'admin') {
         return isset($request['northstar_id']) ? $request['northstar_id'] : auth()->id();
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -84,9 +84,6 @@ function getAgeFromBirthdate($birthdate)
  */
 function getNorthstarId($request)
 {
-    info('debug');
-    info($request);
-    info(auth());
     if (token()->role() === 'admin') {
         return isset($request['northstar_id']) ? $request['northstar_id'] : auth()->id();
     }


### PR DESCRIPTION
While working on [Chompy](https://github.com/DoSomething/chompy) I noticed that when we made a post request to Rogue from Chompy it wasn't creating posts/signups with the correct NS ID. 

This was because we were using the NS ID of the authenticated user. 

In the case of Chompy, we are authenticated as the application, chompy, and we are create posts/signups on _behalf_ of the user in the CSV. 

So this PR updates the helper to grab NS ID from the authenticated user to also check if it is a client submitting the post and if it has the correct scope that allows it to store posts with a custom status.

