### PR TITLE
Update import signups command to use for RRR imports

### DIFF
--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -74,7 +74,7 @@ class ImportSignupsCommand extends Command
                     'campaign_id' => $missing_signup['campaign_node_id'],
                     'campaign_run_id' => $missing_signup['campaign_run_id'],
                     'source' => 'sms',
-                    'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp']: Carbon::now(),
+                    'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp'] : Carbon::now(),
                 ]);
 
                 if ($signup->id % $logfreq == 0) {

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -7,6 +7,8 @@ use League\Csv\Reader;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Illuminate\Console\Command;
+use Rogue\Jobs\SendSignupToBlink;
+use Rogue\Jobs\SendSignupToQuasar;
 
 class ImportSignupsCommand extends Command
 {

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -78,6 +78,10 @@ class ImportSignupsCommand extends Command
                 if ($signup->id % $logfreq == 0) {
                     info('rogue:signupimport: Created signup ' . $signup->id);
                 }
+
+                // Business Logic
+                SendSignupToQuasar::dispatch($signup);
+                SendSignupToBlink::dispatch($signup);
             } else {
                 if ($existing_signup->id % $logfreq == 0) {
                     info('rogue:signupimport: Signup ' . $existing_signup->id . ' already exists! Moving on.');

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Console\Commands;
 
+use Carbon\Carbon;
 use League\Csv\Reader;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
@@ -71,7 +72,7 @@ class ImportSignupsCommand extends Command
                     'campaign_id' => $missing_signup['campaign_node_id'],
                     'campaign_run_id' => $missing_signup['campaign_run_id'],
                     'source' => 'sms',
-                    'created_at' => $missing_signup['signup_created_at_timestamp'],
+                    'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp']: Carbon::now(),
                 ]);
 
                 if ($signup->id % $logfreq == 0) {

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -73,7 +73,7 @@ class ImportSignupsCommand extends Command
                     'northstar_id' => $missing_signup['northstar_id'],
                     'campaign_id' => $missing_signup['campaign_node_id'],
                     'campaign_run_id' => $missing_signup['campaign_run_id'],
-                    'source' => 'sms',
+                    'source' => 'phoenix-next',
                     'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp'] : Carbon::now(),
                 ]);
 

--- a/app/Jobs/SendSignupToBlink.php
+++ b/app/Jobs/SendSignupToBlink.php
@@ -40,6 +40,7 @@ class SendSignupToBlink implements ShouldQueue
     {
         $payload = $this->signup->toBlinkPayload();
 
+        // @TODO: update other places we call this to not check for config('features.blink')
         $shouldSend = config('features.blink');
         if ($shouldSend) {
             $blink->userSignup($payload);

--- a/app/Jobs/SendSignupToBlink.php
+++ b/app/Jobs/SendSignupToBlink.php
@@ -40,7 +40,14 @@ class SendSignupToBlink implements ShouldQueue
     {
         $payload = $this->signup->toBlinkPayload();
 
-        $blink->userSignup($payload);
-        logger()->info('Signup ' . $payload['id'] . ' sent to Blink');
+        $shouldSend = config('features.blink');
+        if ($shouldSend) {
+            $blink->userSignup($payload);
+            logger()->info('Signup ' . $payload['id'] . ' sent to Blink');
+        }
+
+        // Log
+        $verb = $shouldSend ? 'sent' : 'would have been sent';
+        info('Signup ' . $payload['id'] . ' ' . $verb . ' to Customer.io');
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -60,16 +60,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.52.34",
+            "version": "3.52.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "c414752f2f88a036958438a3d973475c6786a387"
+                "reference": "f1d453c2c090ef7a8d4887c7d121bdd0cb7b7613"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c414752f2f88a036958438a3d973475c6786a387",
-                "reference": "c414752f2f88a036958438a3d973475c6786a387",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f1d453c2c090ef7a8d4887c7d121bdd0cb7b7613",
+                "reference": "f1d453c2c090ef7a8d4887c7d121bdd0cb7b7613",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +136,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-03-27T19:13:06+00:00"
+            "time": "2018-03-29T22:20:51+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -1519,16 +1519,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.5.39",
+            "version": "v5.5.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "a21ef7e51df831a7c38d24dcf8c4774ee0847526"
+                "reference": "d724ce0aa61bbd9adf658215eec484f5dd6711d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/a21ef7e51df831a7c38d24dcf8c4774ee0847526",
-                "reference": "a21ef7e51df831a7c38d24dcf8c4774ee0847526",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/d724ce0aa61bbd9adf658215eec484f5dd6711d6",
+                "reference": "d724ce0aa61bbd9adf658215eec484f5dd6711d6",
                 "shasum": ""
             },
             "require": {
@@ -1536,7 +1536,7 @@
                 "erusev/parsedown": "~1.7",
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
-                "league/flysystem": "~1.0",
+                "league/flysystem": "^1.0.8",
                 "monolog/monolog": "~1.12",
                 "mtdowling/cron-expression": "~1.0",
                 "nesbot/carbon": "^1.24.1",
@@ -1649,7 +1649,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2018-03-09T17:24:53+00:00"
+            "time": "2018-03-30T13:29:30+00:00"
         },
         {
             "name": "laravel/tinker",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,6 +37,6 @@
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_DATABASE" value="rogue_test"/>
         <env name="DS_ENABLE_GLIDE" value="true"/>
-        <env name="DS_ENABLE_BLINK" value="true"/>
+        <env name="DS_ENABLE_BLINK" value="false"/>
     </php>
 </phpunit>

--- a/tests/Console/ImportSignupsCommandTest.php
+++ b/tests/Console/ImportSignupsCommandTest.php
@@ -21,7 +21,7 @@ class ImportSignupsCommandTest extends TestCase
             'northstar_id' => '56e83a07469c64d8578b5ed4',
             'campaign_id' => '362',
             'campaign_run_id' => '2341',
-            'source' => 'sms',
+            'source' => 'phoenix-next',
             'created_at' => '2014-03-13 21:39:01',
         ]);
 
@@ -29,7 +29,7 @@ class ImportSignupsCommandTest extends TestCase
             'northstar_id' => '5589c9bb469c6475138b81f0',
             'campaign_id' => '1144',
             'campaign_run_id' => '5066',
-            'source' => 'sms',
+            'source' => 'phoenix-next',
             'created_at' => '2013-11-06 23:32:03',
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
- Added business logic into `ImportSignupsCommand` which happens after we create a signup (`SendSignupToQuasar`, `SendSignupToBlink`)
- updated `SendSignupToBlink` to be local dev friendly (you are able to hit it regardless of if you are sending to Blink and it will log accordingly, so you can be sure it is getting hit at the right times)
- `ImportSignupsCommand` no longer requires a `created_at` and will use `now()` if one is not given
- updated our test `.env` to not send to Blink
- lock file is updated because I had to run `composer update`
- updated script to use source `phoenix-next` instead of `sms`

#### How should this be reviewed?
Is the update to our test `.env` okay? 

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/156354146)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
