### PR TITLE
Fix reaction counts & boolean on `v3/posts/:id` route.

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -71,7 +71,6 @@ class PostsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)
-            ->withCount('reactions')
             ->with('tags')
             ->orderBy('created_at', 'desc');
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -71,7 +71,6 @@ class PostsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)
-            ->with('tags')
             ->orderBy('created_at', 'desc');
 
         $filters = $request->query('filter');

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -77,13 +77,6 @@ class PostsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Post::$indexes);
 
-        // If a user made the request, return whether or not they liked each post.
-        if (auth()->check()) {
-            $query = $query->with(['reactions' => function ($query) {
-                $query->where('northstar_id', '=', auth()->id());
-            }]);
-        }
-
         // Only allow admins or staff to see un-approved posts from other users.
         $query = $query->whereVisible();
 

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -48,7 +48,7 @@ class PostTransformer extends TransformerAbstract
             'quantity' => $post->quantity,
             'reactions' => [
                 'reacted' => $reacted,
-                'total' => isset($post->reactions_count) ? $post->reactions_count : null,
+                'total' => $post->reactions_count,
             ],
             'status' => $post->status,
             'created_at' => $post->created_at->toIso8601String(),

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -26,11 +26,6 @@ class PostTransformer extends TransformerAbstract
      */
     public function transform(Post $post)
     {
-        $reacted = false;
-        if ($post->relationLoaded('reactions')) {
-            $reacted = $post->reactions->isNotEmpty();
-        }
-
         $response = [
             'id' => $post->id,
             'signup_id' => $post->signup_id,
@@ -47,7 +42,7 @@ class PostTransformer extends TransformerAbstract
             ],
             'quantity' => $post->quantity,
             'reactions' => [
-                'reacted' => $reacted,
+                'reacted' => ! empty($post->reaction),
                 'total' => $post->reactions_count,
             ],
             'status' => $post->status,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -19,6 +19,13 @@ class Post extends Model
     protected $dates = ['deleted_at'];
 
     /**
+     * The relationship counts that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withCount = ['reactions'];
+
+    /**
      * All of the relationships to be touched.
      *
      * @var array

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -22,7 +22,7 @@ class Post extends Model
      * Always load a user's own reaction,
      * if they're logged-in.
      */
-    protected $with = ['reaction'];
+    protected $with = ['reaction', 'tags'];
 
     /**
      * The relationship counts that should be eager loaded on every query.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -19,6 +19,12 @@ class Post extends Model
     protected $dates = ['deleted_at'];
 
     /**
+     * Always load a user's own reaction,
+     * if they're logged-in.
+     */
+    protected $with = ['reaction'];
+
+    /**
      * The relationship counts that should be eager loaded on every query.
      *
      * @var array
@@ -79,6 +85,16 @@ class Post extends Model
     public function reactions()
     {
         return $this->hasMany(Reaction::class);
+    }
+
+    /**
+     * Get the reactions associated with this post
+     * for the given user ID.
+     */
+    public function reaction()
+    {
+        return $this->hasOne(Reaction::class)
+            ->where('northstar_id', auth()->id());
     }
 
     /**

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use Rogue\Models\Post;
 use Rogue\Models\User;
 use Rogue\Models\Signup;
+use Rogue\Models\Reaction;
 use DoSomething\Gateway\Blink;
 use Illuminate\Http\UploadedFile;
 
@@ -785,6 +786,35 @@ class PostTest extends TestCase
 
         $json = $response->json();
         $this->assertEquals($post->id, $json['data']['id']);
+    }
+
+    /**
+     * Test for retrieving a specific post with reactions.
+     *
+     * GET /api/v3/post/:post_id
+     * @return void
+     */
+    public function testPostShowWithReactions()
+    {
+        $viewer = $this->randomUserId();
+        $post = factory(Post::class, 'accepted')->create();
+
+        // Create two reactions for this post!
+        Reaction::withTrashed()->firstOrCreate(['northstar_id' => $viewer, 'post_id' => $post->id]);
+        Reaction::withTrashed()->firstOrCreate(['northstar_id' => 'someone_else_lol', 'post_id' => $post->id]);
+
+        $response = $this->withAccessToken($viewer, 'user')->getJson('api/v3/posts/' . $post->id);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'id' => $post->id,
+                'reactions' => [
+                    'reacted' => true,
+                    'total' => 2,
+                ],
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
We were previously only loading the `reacted` and `reaction_count` properties on the [post index](https://github.com/DoSomething/rogue/blob/b0af355ddb2e29c126a71aa5d55a13bceda7453c/app/Http/Controllers/PostsController.php#L64-L97), which means the same posts ran through `PostTransformer` on `posts/{postId}` (or anywhere else) would appear to have no reactions. 🙅‍♂️ 

This pull request updates the `Post` model to always eager-load the `reaction_count` property on posts, and adds an (also eager-loaded) `reaction` has-one relationship to get the current user's reaction if it exists. This simplifies logic in that index method a bit & makes everything consistent!

#### How should this be reviewed?
I added a failing test in f207c79, which [shows how the response is incorrect](https://app.wercker.com/dosomething/rogue/runs/build/5ac3b6783ada9c00016a3a9f?step=5ac3b6b696f3f30001371e43).

I then fixed `reactions.total` in 4566058 and `reactions.reacted` in 7f418b7, and a little bonus fix to make sure we always load `tags` in `4c6c04f`.

#### Any background context you want to provide?
This was blocking my work on using the v3 APIs to power the new Phoenix Next galleries.

#### Relevant tickets
[#155944555](https://www.pivotaltracker.com/story/show/155944555)