### PR TITLE
Cleans up tests and makes sure AsOwner tests are always passing 

### DIFF
--- a/tests/Console/ImportSignupsCommandTest.php
+++ b/tests/Console/ImportSignupsCommandTest.php
@@ -11,7 +11,7 @@ class ImportSignupsCommandTest extends TestCase
     public function testImportingSignupsWithNoDuplicates()
     {
         // Timestamp right before running the script
-        $start_time = Carbon::now();
+        $start_time = $this->mockTime(Carbon::now());
 
         // Run the signup import command
         $this->artisan('rogue:signupimport', ['path' => 'tests/Console/example-signups.csv']);
@@ -37,14 +37,9 @@ class ImportSignupsCommandTest extends TestCase
         $all_signups = Signup::all();
         $this->assertTrue($all_signups->count() == 2);
 
-        // The below is failing and we're not sure why!
-        // @TODO: come back and investigate!
-
-        $this->markTestIncomplete();
-
         // Make sure the 'updated_at' timestamps are not backdated
-        // foreach ($all_signups as $signup) {
-        //     $this->assertTrue($signup->updated_at->gte($start_time));
-        // }
+        foreach ($all_signups as $signup) {
+            $this->assertTrue($signup->updated_at->gte($start_time));
+        }
     }
 }

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -599,7 +599,7 @@ class PostTest extends TestCase
         $rejectedPosts = factory(Post::class, 'rejected', 3)->create();
 
         $northstarId = $this->faker->northstar_id;
-        $secondNorthstarId = $this->faker->northstar_id;
+        $secondNorthstarId = '59ea1c1ca0bfad5e90139dcz';
 
         foreach ($posts as $post) {
             $post->northstar_id = $northstarId;

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -599,7 +599,6 @@ class PostTest extends TestCase
         $rejectedPosts = factory(Post::class, 'rejected', 3)->create();
 
         $northstarId = $this->faker->northstar_id;
-        $secondNorthstarId = '59ea1c1ca0bfad5e90139dcz';
 
         foreach ($posts as $post) {
             $post->northstar_id = $northstarId;
@@ -607,7 +606,7 @@ class PostTest extends TestCase
         }
 
         foreach ($rejectedPosts as $rejectedPost) {
-            $rejectedPost->northstar_id = $secondNorthstarId;
+            $rejectedPost->northstar_id = '59ea1c1ca0bfad5e90139dcz';
             $rejectedPost->save();
         }
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -599,6 +599,7 @@ class PostTest extends TestCase
         $rejectedPosts = factory(Post::class, 'rejected', 3)->create();
 
         $northstarId = $this->faker->northstar_id;
+        $secondNorthstarId = $this->faker->northstar_id;
 
         foreach ($posts as $post) {
             $post->northstar_id = $northstarId;
@@ -606,12 +607,11 @@ class PostTest extends TestCase
         }
 
         foreach ($rejectedPosts as $rejectedPost) {
-            $rejectedPost->northstar_id = $this->faker->northstar_id;
+            $rejectedPost->northstar_id = $secondNorthstarId;
             $rejectedPost->save();
         }
 
         $response = $this->withAccessToken($northstarId)->getJson('api/v3/posts');
-
         $response->assertStatus(200);
         $response->assertJsonCount(2, 'data');
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -33,7 +33,7 @@ class PostTest extends TestCase
             ->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($northstarId, 'user')->json('POST', 'api/v3/posts', [
+        $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,
             'campaign_run_id'  => $campaignRunId,
             'type'             => 'photo',
@@ -106,7 +106,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -206,7 +206,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -263,7 +263,7 @@ class PostTest extends TestCase
         $secondText = $this->faker->sentence;
         $secondDetails = ['source-detail' => 'broadcast-333', 'other' => 'other'];
 
-        $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -399,7 +399,7 @@ class PostTest extends TestCase
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
         // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/posts', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'campaign_run_id'  => $signup->campaign_run_id,
@@ -610,7 +610,7 @@ class PostTest extends TestCase
             $rejectedPost->save();
         }
 
-        $response = $this->withAccessToken($northstarId, 'user')->getJson('api/v3/posts');
+        $response = $this->withAccessToken($northstarId)->getJson('api/v3/posts');
 
         $response->assertStatus(200);
         $response->assertJsonCount(2, 'data');
@@ -711,7 +711,7 @@ class PostTest extends TestCase
     public function testPostShowAsAdmin()
     {
         $post = factory(Post::class)->create();
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->getJson('api/v3/posts/' . $post->id);
+        $response = $this->withAdminAccessToken()->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -754,7 +754,7 @@ class PostTest extends TestCase
     public function testPostShowAsOwner()
     {
         $post = factory(Post::class)->create();
-        $response = $this->withAccessToken($post->northstar_id, 'user')->getJson('api/v3/posts/' . $post->id);
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -830,7 +830,7 @@ class PostTest extends TestCase
 
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->patchJson('api/v3/posts/' . $post->id, [
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
             'text' => 'new caption',
             'quantity' => 8,
         ]);
@@ -877,7 +877,7 @@ class PostTest extends TestCase
     {
         $post = factory(Post::class)->create();
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->patchJson('api/v3/posts/' . $post->id, [
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
             'quantity' => 'this is words not a number!',
             'text' => 'This must be longer than 140 characters to break the validation rules so here I will create a caption that is longer than 140 characters to test.',
         ]);
@@ -899,7 +899,7 @@ class PostTest extends TestCase
         $user = factory(User::class)->create();
         $post = factory(Post::class)->create();
 
-        $response = $this->withAccessToken($user->id, 'user')->patchJson('api/v3/posts/' . $post->id, [
+        $response = $this->withAccessToken($user->id)->patchJson('api/v3/posts/' . $post->id, [
             'status' => 'accepted',
             'text' => 'new caption',
         ]);
@@ -923,7 +923,7 @@ class PostTest extends TestCase
         // Mock time of when the post is soft deleted.
         $this->mockTime('8/3/2017 14:00:00');
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->deleteJson('api/v3/posts/' . $post->id);
+        $response = $this->withAdminAccessToken()->deleteJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
 
@@ -969,7 +969,7 @@ class PostTest extends TestCase
     {
         $post = factory(Post::class)->create();
 
-        $response = $this->withAccessToken($post->northstar_id, 'user')->getJson('api/v3/posts/' . $post->id);
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
 
@@ -1005,7 +1005,7 @@ class PostTest extends TestCase
     {
         $post = factory(Post::class)->create();
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->getJson('api/v3/posts/' . $post->id);
+        $response = $this->withAdminAccessToken()->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
 

--- a/tests/Http/ReactionTest.php
+++ b/tests/Http/ReactionTest.php
@@ -25,7 +25,7 @@ class ReactionTest extends TestCase
         $northstarId = $this->faker->uuid;
 
         // Create a reaction.
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/post/' . $post->id . '/reactions', [
+        $response = $this->withAdminAccessToken()->postJson('api/v3/post/' . $post->id . '/reactions', [
             'northstar_id' => $northstarId,
         ]);
 
@@ -39,7 +39,7 @@ class ReactionTest extends TestCase
         ]);
 
         // React (unlike) again to the same post with the same user.
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/post/' . $post->id . '/reactions', [
+        $response = $this->withAdminAccessToken()->postJson('api/v3/post/' . $post->id . '/reactions', [
             'northstar_id' => $northstarId,
         ]);
 
@@ -88,7 +88,7 @@ class ReactionTest extends TestCase
         $post = factory(Post::class)->create();
 
         // Create a reaction.
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/post/' . $post->id . '/reactions', [
+        $response = $this->withAdminAccessToken()->postJson('api/v3/post/' . $post->id . '/reactions', [
             'northstar_id' => $this->faker->uuid,
         ]);
 
@@ -101,7 +101,7 @@ class ReactionTest extends TestCase
         ]);
 
         // A second user reacts to the same post..
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/post/' . $post->id . '/reactions', [
+        $response = $this->withAdminAccessToken()->postJson('api/v3/post/' . $post->id . '/reactions', [
             'northstar_id' => $this->faker->uuid,
         ]);
 

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -317,17 +317,15 @@ class SignupTest extends TestCase
      */
     public function testSignupIndexWithIncludedUserAsAdmin()
     {
-        // @TODO: revisit with this card: https://www.pivotaltracker.com/n/projects/2019429/stories/155479565
-        $this->markTestIncomplete();
-        // $post = factory(Post::class)->create();
-        // $signup = $post->signup;
+        $post = factory(Post::class)->create();
+        $signup = $post->signup;
 
-        // // Test with admin that entire user is returned.
-        // $response = $this->withAdminAccessToken()->getJson('api/v3/signups' . '?include=user');
-        // $response->assertStatus(200);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Test with admin that entire user is returned.
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups' . '?include=user');
+        $response->assertStatus(200);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $this->assertEquals(false, empty($decodedResponse['data'][0]['user']['data']['birthdate']));
+        $this->assertEquals(false, empty($decodedResponse['data'][0]['user']['data']['birthdate']));
     }
 
     /**
@@ -339,17 +337,15 @@ class SignupTest extends TestCase
      */
     public function testSignupIndexWithIncludedUserAsOwner()
     {
-        // @TODO: revisit with this card: https://www.pivotaltracker.com/n/projects/2019429/stories/155479565
-        $this->markTestIncomplete();
-        // $post = factory(Post::class)->create();
-        // $signup = $post->signup;
+        $post = factory(Post::class)->create();
+        $signup = $post->signup;
 
-        // // Test with admin that entire user is returned.
-        // $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups' . '?include=user');
-        // $response->assertStatus(200);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Test with admin that entire user is returned.
+        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups' . '?include=user');
+        $response->assertStatus(200);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $this->assertEquals(false, empty($decodedResponse['data'][0]['user']['data']['birthdate']));
+        $this->assertEquals(false, empty($decodedResponse['data'][0]['user']['data']['birthdate']));
     }
 
     /**
@@ -361,17 +357,15 @@ class SignupTest extends TestCase
      */
     public function testSignupIndexWithIncludedUserAsNonAdminNonOwner()
     {
-        // @TODO: revisit with this card: https://www.pivotaltracker.com/n/projects/2019429/stories/155479565
-        $this->markTestIncomplete();
-        // $post = factory(Post::class)->create();
-        // $signup = $post->signup;
+        $post = factory(Post::class)->create();
+        $signup = $post->signup;
 
-        // // Test with annoymous user that only a user's first name is returned.
-        // $response = $this->getJson('api/v3/signups' . '?include=user');
-        // $response->assertStatus(200);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Test with annoymous user that only a user's first name is returned.
+        $response = $this->getJson('api/v3/signups' . '?include=user');
+        $response->assertStatus(200);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $this->assertEquals(true, empty($decodedResponse['data'][0]['user']['data']['birthdate']));
+        $this->assertEquals(true, empty($decodedResponse['data'][0]['user']['data']['birthdate']));
     }
 
     /**
@@ -387,74 +381,72 @@ class SignupTest extends TestCase
      */
     public function testSignupsIndexAsAdminWithFilters()
     {
-        // @TODO: revisit with this card: https://www.pivotaltracker.com/n/projects/2019429/stories/155479565
-        $this->markTestIncomplete();
-        // $northstarId = $this->faker->northstar_id;
-        // $campaignId = str_random(22);
-        // $campaignRunId = $this->faker->randomNumber(4);
+        $northstarId = $this->faker->northstar_id;
+        $campaignId = str_random(22);
+        $campaignRunId = $this->faker->randomNumber(4);
 
-        // // Create two signups
-        // factory(Signup::class, 2)->create([
-        //    'northstar_id' => $northstarId,
-        //    'campaign_id' => $campaignId,
-        //    'campaign_run_id' => $campaignRunId,
-        // ]);
+        // Create two signups
+        factory(Signup::class, 2)->create([
+           'northstar_id' => $northstarId,
+           'campaign_id' => $campaignId,
+           'campaign_run_id' => $campaignRunId,
+        ]);
 
-        // // Create three more signups with different northstar_id, campaign_id, and campaign_run_id
-        // $secondNorthstarId = $this->faker->northstar_id;
-        // $secondCampaignId = str_random(22);
-        // $secondCampaignRunId = $this->faker->randomNumber(4);
+        // Create three more signups with different northstar_id, campaign_id, and campaign_run_id
+        $secondNorthstarId = $this->faker->northstar_id;
+        $secondCampaignId = str_random(22);
+        $secondCampaignRunId = $this->faker->randomNumber(4);
 
-        // factory(Signup::class, 3)->create([
-        //    'northstar_id' => $secondNorthstarId,
-        //    'campaign_id' => $secondCampaignId,
-        //    'campaign_run_id' => $secondCampaignRunId,
-        // ]);
+        factory(Signup::class, 3)->create([
+           'northstar_id' => $secondNorthstarId,
+           'campaign_id' => $secondCampaignId,
+           'campaign_run_id' => $secondCampaignRunId,
+        ]);
 
-        // // Filter by northstar_id
-        // $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[northstar_id]=' . $northstarId);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Filter by northstar_id
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[northstar_id]=' . $northstarId);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $response->assertStatus(200);
+        $response->assertStatus(200);
 
-        // // Assert only 2 signups are returned
-        // $this->assertEquals(2, $decodedResponse['meta']['cursor']['count']);
+        // Assert only 2 signups are returned
+        $this->assertEquals(2, $decodedResponse['meta']['cursor']['count']);
 
-        // // Filter by campaign_id
-        // $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_id]=' . $secondCampaignId);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Filter by campaign_id
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_id]=' . $secondCampaignId);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $response->assertStatus(200);
+        $response->assertStatus(200);
 
-        // // Assert only 3 signups are returned
-        // $this->assertEquals(3, $decodedResponse['meta']['cursor']['count']);
+        // Assert only 3 signups are returned
+        $this->assertEquals(3, $decodedResponse['meta']['cursor']['count']);
 
-        // // Filter by campaign_run_id
-        // $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_run_id]=' . $campaignRunId);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Filter by campaign_run_id
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_run_id]=' . $campaignRunId);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $response->assertStatus(200);
+        $response->assertStatus(200);
 
-        // // Assert only 2 signups are returned
-        // $this->assertEquals(2, $decodedResponse['meta']['cursor']['count']);
+        // Assert only 2 signups are returned
+        $this->assertEquals(2, $decodedResponse['meta']['cursor']['count']);
 
-        // // Filter by campaign_run_id and northstar_id
-        // $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_run_id]=' . $campaignRunId . '&filter[northstar_id]=' . $northstarId);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Filter by campaign_run_id and northstar_id
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_run_id]=' . $campaignRunId . '&filter[northstar_id]=' . $northstarId);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $response->assertStatus(200);
+        $response->assertStatus(200);
 
-        // // Assert only 2 signups are returned
-        // $this->assertEquals(2, $decodedResponse['meta']['cursor']['count']);
+        // Assert only 2 signups are returned
+        $this->assertEquals(2, $decodedResponse['meta']['cursor']['count']);
 
-        // // Filter by multiple campaign_run_id
-        // $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_run_id]=' . $campaignRunId . ',' . $secondCampaignRunId);
-        // $decodedResponse = $response->decodeResponseJson();
+        // Filter by multiple campaign_run_id
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?filter[campaign_run_id]=' . $campaignRunId . ',' . $secondCampaignRunId);
+        $decodedResponse = $response->decodeResponseJson();
 
-        // $response->assertStatus(200);
+        $response->assertStatus(200);
 
-        // // Assert all signups are returned
-        // $this->assertEquals(5, $decodedResponse['meta']['cursor']['count']);
+        // Assert all signups are returned
+        $this->assertEquals(5, $decodedResponse['meta']['cursor']['count']);
     }
 
     /**

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -281,7 +281,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that posts are returned.
-        $response = $this->withAdminAccessToken()->getJson('api/v3/signups' . '?include=posts');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?include=posts');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -301,7 +301,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that posts are returned.
-        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/signups' . '?include=posts');
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/signups?include=posts');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -321,7 +321,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that entire user is returned.
-        $response = $this->withAdminAccessToken()->getJson('api/v3/signups' . '?include=user');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?include=user');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -341,7 +341,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that entire user is returned.
-        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups' . '?include=user');
+        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups?include=user');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -361,7 +361,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with annoymous user that only a user's first name is returned.
-        $response = $this->getJson('api/v3/signups' . '?include=user');
+        $response = $this->getJson('api/v3/signups?include=user');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -25,7 +25,7 @@ class SignupTest extends TestCase
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
 
-        $response = $this->withAccessToken($northstarId, 'user')->postJson('api/v3/signups', [
+        $response = $this->withAccessToken($northstarId)->postJson('api/v3/signups', [
             'campaign_id' => $campaignId,
             'campaign_run_id' => $campaignRunId,
             'details' => 'affiliate-messaging',
@@ -93,7 +93,7 @@ class SignupTest extends TestCase
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
 
-        $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/signups', [
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/signups', [
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'source' => 'the-fox-den',
@@ -177,7 +177,7 @@ class SignupTest extends TestCase
     {
         factory(Signup::class, 10)->create();
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin', ['activity'])->getJson('api/v3/signups');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups');
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -220,7 +220,7 @@ class SignupTest extends TestCase
            'northstar_id' => $northstarId,
         ]);
 
-        $response = $this->withAccessToken($northstarId, 'user')->getJson('api/v3/signups');
+        $response = $this->withAccessToken($northstarId)->getJson('api/v3/signups');
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data' => [
@@ -281,7 +281,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that posts are returned.
-        $response = $this->withAccessToken($this->randomUserId(), 'admin', ['activity'])->getJson('api/v3/signups' . '?include=posts');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups' . '?include=posts');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -301,7 +301,7 @@ class SignupTest extends TestCase
         $signup = $post->signup;
 
         // Test with admin that posts are returned.
-        $response = $this->withAccessToken($post->northstar_id, 'user', ['activity'])->getJson('api/v3/signups' . '?include=posts');
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/signups' . '?include=posts');
         $response->assertStatus(200);
         $decodedResponse = $response->decodeResponseJson();
 
@@ -477,7 +477,7 @@ class SignupTest extends TestCase
         }
 
         // Order results by descending quantity
-        $response = $this->withAccessToken($this->randomUserId(), 'admin', ['activity'])->getJson('api/v3/signups?orderBy=quantity,desc');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderBy=quantity,desc');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
@@ -487,7 +487,7 @@ class SignupTest extends TestCase
         $this->assertEquals(4, $decodedResponse['data'][1]['quantity']);
 
         // Order results by ascending quantity
-        $response = $this->withAccessToken($this->randomUserId(), 'admin', ['activity'])->getJson('api/v3/signups?orderBy=quantity,asc');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups?orderBy=quantity,asc');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
@@ -531,7 +531,7 @@ class SignupTest extends TestCase
     public function testSignupShowAsAdmin()
     {
         $signup = factory(Signup::class)->create();
-        $response = $this->withAccessToken($this->randomUserId(), 'admin', ['activity'])->getJson('api/v3/signups/' . $signup->id);
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups/' . $signup->id);
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -559,7 +559,7 @@ class SignupTest extends TestCase
     public function testSignupShowAsOwner()
     {
         $signup = factory(Signup::class)->create();
-        $response = $this->withAccessToken($signup->northstar_id, 'user', ['activity'])->getJson('api/v3/signups/' . $signup->id);
+        $response = $this->withAccessToken($signup->northstar_id)->getJson('api/v3/signups/' . $signup->id);
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -590,7 +590,7 @@ class SignupTest extends TestCase
         // Mock time of when the signup is soft deleted.
         $this->mockTime('8/3/2017 14:00:00');
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->deleteJson('api/v3/signups/' . $signup->id);
+        $response = $this->withAdminAccessToken()->deleteJson('api/v3/signups/' . $signup->id);
 
         $response->assertStatus(200);
 
@@ -637,7 +637,7 @@ class SignupTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->patchJson('api/v3/signups/' . $signup->id, [
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/signups/' . $signup->id, [
             'why_participated'  => 'new why participated',
         ]);
 
@@ -675,7 +675,7 @@ class SignupTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->patchJson('api/v3/signups/' . $signup->id);
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/signups/' . $signup->id);
 
         $response->assertStatus(422);
     }
@@ -690,7 +690,7 @@ class SignupTest extends TestCase
         $user = factory(User::class)->create();
         $signup = factory(Signup::class)->create();
 
-        $response = $this->withAccessToken($user->id, 'user')->patchJson('api/v3/signups/' . $signup->id, [
+        $response = $this->withAccessToken($user->id)->patchJson('api/v3/signups/' . $signup->id, [
             'why_participated' => 'new why participated',
         ]);
 
@@ -725,7 +725,7 @@ class SignupTest extends TestCase
         $secondSignup->quantity = $secondSignup->getQuantity();
         $secondSignup->save();
 
-        $response = $this->withAccessToken($this->randomUserId(), 'user', ['activity'])->getJson('api/v3/signups');
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups');
 
         $response->assertStatus(200);
         $response->assertJson([

--- a/tests/Http/TagsTest.php
+++ b/tests/Http/TagsTest.php
@@ -21,7 +21,7 @@ class TagsTest extends TestCase
         $post = factory(Post::class)->create();
 
         // Apply the tag to the post
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/posts/' . $post->id . '/tags', [
+        $response = $this->withAdminAccessToken()->postJson('api/v3/posts/' . $post->id . '/tags', [
             'tag_name' => 'Good Photo',
         ]);
 
@@ -88,13 +88,13 @@ class TagsTest extends TestCase
 
         $post = factory(Post::class)->create();
 
-        $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/posts/' . $post->id . '/tags', [
+        $this->withAdminAccessToken()->postJson('api/v3/posts/' . $post->id . '/tags', [
              'tag_name' => 'Good Photo',
          ]);
 
         $this->assertContains('Good Photo', $post->tagNames());
 
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->deleteJson('api/v3/posts/' . $post->id . '/tags', [
+        $response = $this->withAdminAccessToken()->deleteJson('api/v3/posts/' . $post->id . '/tags', [
             'tag_name' => 'Good Photo',
         ]);
 
@@ -165,7 +165,7 @@ class TagsTest extends TestCase
 
         $post = factory(Post::class)->create();
 
-        $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/posts/' . $post->id . '/tags', [
+        $this->withAdminAccessToken()->postJson('api/v3/posts/' . $post->id . '/tags', [
              'tag_name' => 'Good Photo',
          ]);
 
@@ -178,7 +178,7 @@ class TagsTest extends TestCase
         $this->assertContains('Tag To Delete', $post->tagNames());
 
         // Send request to remove "Tag To Delete" tag
-        $response = $this->withAccessToken($this->randomUserId(), 'admin')->deleteJson('api/v3/posts/' . $post->id . '/tags', [
+        $response = $this->withAdminAccessToken()->deleteJson('api/v3/posts/' . $post->id . '/tags', [
             'tag_name' => 'Tag To Delete',
         ]);
 
@@ -203,7 +203,7 @@ class TagsTest extends TestCase
         // Later, apply the tag to the post
         $this->mockTime('10/21/2017 13:05:00');
 
-        $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/posts/' . $post->id . '/tags', [
+        $this->withAdminAccessToken()->postJson('api/v3/posts/' . $post->id . '/tags', [
             'tag_name' => 'Good Photo',
         ]);
 
@@ -221,7 +221,7 @@ class TagsTest extends TestCase
         $posts = factory(Post::class, 20)->create();
 
         // Later, apply the tag to the post
-        $this->withAccessToken($this->randomUserId(), 'admin')->postJson('api/v3/posts/' . $posts->first()->id . '/tags', [
+        $this->withAdminAccessToken()->postJson('api/v3/posts/' . $posts->first()->id . '/tags', [
             'tag_name' => 'get-outta-here',
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
- Cleans up Signup, Post, Reaction, and Tags Tests to use `withAdminAccessToken()` where possible and deletes unneccessary params in some `withAccessToken()` cases. 
- Comments back in incomplete Signup Tests that are now passing (this was a wercker config issue)!
- Explicitly sets rejected posts' to a new `northstar_id` variable to get `testPostsIndexAsOwner` tests to pass every time
- Fixes the `testImportingSignupsWithNoDuplicates` test

#### How should this be reviewed?
- All tests should pass! 

#### Any background context you want to provide?
- Wercker was using [`rogue-qa-client`](https://aurora-qa.dosomething.org/clients/rogue-qa-client) in [Aurora](https://aurora-qa.dosomething.org/clients). This for some reason isn't allowing us to update this client and it is stuck on Authorization code grant instead of Machine (Client Credentials grant). Other clients aren't updating as expected either and just redirect to https://aurora-qa.dosomething.org/users when pressing "Save" Card to explore [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156516089) here!

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/155479565) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
