### PR TITLE
Command re-send posts and signups to Quasar

### DIFF
--- a/app/Console/Commands/SendToQuasar.php
+++ b/app/Console/Commands/SendToQuasar.php
@@ -56,7 +56,7 @@ class SendToQuasar extends Command
         }
 
         $signups->chunkById(1000, function ($signups) {
-            foreach($signups as $signup) {
+            foreach ($signups as $signup) {
                 SendSignupToQuasar::dispatch($signup);
             }
         });
@@ -69,7 +69,7 @@ class SendToQuasar extends Command
         }
 
         $posts->chunkById(1000, function ($posts) {
-            foreach($posts as $post) {
+            foreach ($posts as $post) {
                 SendPostToQuasar::dispatch($post);
             }
         });

--- a/app/Console/Commands/SendToQuasar.php
+++ b/app/Console/Commands/SendToQuasar.php
@@ -15,7 +15,9 @@ class SendToQuasar extends Command
      *
      * @var string
      */
-    protected $signature = 'rogue:quasar {start=0000-00-00} {end?}';
+    protected $signature = 'rogue:quasar
+                            {start=0000-00-00 : Include all signups and posts updated on or after this day. Format: YYYY-MM-DD}
+                            {end? : Include signups and posts updated up to but not including this day. Format: YYYY-MM-DD}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/SendToQuasar.php
+++ b/app/Console/Commands/SendToQuasar.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class SendToQuasar extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:quasar';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the given items to Quasar.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends ConsoleKernel
         Commands\TagPosts::class,
         Commands\UpdateSignup::class,
         Commands\ReviewSignup::class,
+        Commands\SendToQuasar::class,
     ];
 
     /**

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -56,7 +56,8 @@ class SendPostToQuasar implements ShouldQueue
      *
      * @return int
      */
-    public function getPostId() {
+    public function getPostId()
+    {
         return $this->post->id;
     }
 }

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -50,4 +50,13 @@ class SendPostToQuasar implements ShouldQueue
         $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
         info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
     }
+
+    /**
+     * Get the id of the post we are sending to Quasar
+     *
+     * @return int
+     */
+    public function getPostId() {
+        return $this->post->id;
+    }
 }

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -56,7 +56,8 @@ class SendSignupToQuasar implements ShouldQueue
      *
      * @return int
      */
-    public function getSignupId() {
+    public function getSignupId()
+    {
         return $this->signup->id;
     }
 }

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -50,4 +50,13 @@ class SendSignupToQuasar implements ShouldQueue
         $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
         info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
     }
+
+    /**
+     * Get the id of the signup we are sending to Quasar
+     *
+     * @return int
+     */
+    public function getSignupId() {
+        return $this->signup->id;
+    }
 }

--- a/tests/Console/SendToQuasarCommandTest.php
+++ b/tests/Console/SendToQuasarCommandTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Console;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+use Rogue\Jobs\SendPostToQuasar;
+use Rogue\Jobs\SendSignupToQuasar;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+class SendToQuasarCommandTest extends TestCase
+{
+    public function testSendingWithNoArguments()
+    {
+        Bus::fake();
+
+        $this->mockTime('8/3/2017 14:00:00');
+        factory(Signup::class, 2)->create();
+        factory(Post::class, 2)->create();
+
+        $this->mockTime('2/4/2018 12:00:00');
+        factory(Signup::class, 2)->create();
+        factory(Post::class, 2)->create();
+
+        $this->artisan('rogue:quasar');
+
+        foreach(Signup::all() as $signup) {
+            Bus::assertDispatched(SendSignupToQuasar::class, function ($job) use ($signup) {
+                return $job->getSignupId() === $signup->id;
+            });
+        }
+
+        foreach(Post::all() as $post) {
+            Bus::assertDispatched(SendPostToQuasar::class, function ($job) use ($post) {
+                return $job->getPostId() === $post->id;
+            });
+        }
+    }
+
+    public function testSendingWithStartArgument()
+    {
+        Bus::fake();
+
+        // Create some signups and posts
+        $this->mockTime('8/3/2017 14:00:00');
+        $signupsNotSent = factory(Signup::class, 2)->create();
+        $postsNotSent = factory(Post::class, 2)->create();
+
+        $this->mockTime('2/4/2018 12:00:00');
+        $signupsToSend = factory(Signup::class, 2)->create();
+        $postsToSend = factory(Post::class, 2)->create();
+
+        // Call the command
+        $this->artisan('rogue:quasar', ['start' => '2018-02-04']);
+
+        // Make sure that posts and signups that should have been sent were
+        foreach($signupsToSend as $signup) {
+            Bus::assertDispatched(SendSignupToQuasar::class, function ($job) use ($signup, $signupsNotSent) {
+                return $job->getSignupId() === $signup->id;
+            });
+        }
+
+        foreach($postsToSend as $post) {
+            Bus::assertDispatched(SendPostToQuasar::class, function ($job) use ($post) {
+                return $job->getPostId() === $post->id;
+            });
+        }
+
+        // Make sure that posts and signups that should NOT have been sent weren't
+        foreach($signupsNotSent as $signup) {
+            Bus::assertNotDispatched(SendSignupToQuasar::class, function ($job) use ($signup) {
+                return $job->getSignupId() === $signup->id;
+            });
+        }
+
+       foreach($postsNotSent as $post) {
+            Bus::assertNotDispatched(SendPostToQuasar::class, function ($job) use ($post) {
+                return $job->getPostId() === $post->id;
+            });
+        }
+    }
+
+    public function testSendingWithStartAndEndArguments()
+    {
+        Bus::fake();
+
+        // Create some signups and posts
+        $this->mockTime('8/3/2017 14:00:00');
+        $signupsNotSent = factory(Signup::class, 2)->create();
+        $postsNotSent = factory(Post::class, 2)->create();
+
+        $this->mockTime('2/4/2018 12:00:00');
+        $oldSignupsToSend = factory(Signup::class, 2)->create();
+        $oldPostsToSend = factory(Post::class, 2)->create();
+
+        $this->mockTime('5/18/2018 09:00:00');
+        $newSignupsToSend= factory(Signup::class, 2)->create();
+        $newPostsToSend = factory(Post::class, 2)->create();
+
+        $signupsToSend = $oldSignupsToSend->merge($newSignupsToSend);
+        $postsToSend = $oldPostsToSend->merge($newPostsToSend);
+
+        // Call the command
+        $this->artisan('rogue:quasar', ['start' => '2018-02-04', 'end' => '2018-05-19']);
+
+        // Make sure that posts and signups that should have been sent were
+        foreach($signupsToSend as $signup) {
+            Bus::assertDispatched(SendSignupToQuasar::class, function ($job) use ($signup, $signupsNotSent) {
+                return $job->getSignupId() === $signup->id;
+            });
+        }
+
+        foreach($postsToSend as $post) {
+            Bus::assertDispatched(SendPostToQuasar::class, function ($job) use ($post) {
+                return $job->getPostId() === $post->id;
+            });
+        }
+
+        // Make sure that posts and signups that should NOT have been sent weren't
+        foreach($signupsNotSent as $signup) {
+            Bus::assertNotDispatched(SendSignupToQuasar::class, function ($job) use ($signup) {
+                return $job->getSignupId() === $signup->id;
+            });
+        }
+
+       foreach($postsNotSent as $post) {
+            Bus::assertNotDispatched(SendPostToQuasar::class, function ($job) use ($post) {
+                return $job->getPostId() === $post->id;
+            });
+        }
+    }
+}

--- a/tests/Console/SendToQuasarCommandTest.php
+++ b/tests/Console/SendToQuasarCommandTest.php
@@ -124,7 +124,7 @@ class SendToQuasarCommandTest extends TestCase
             });
         }
 
-       foreach ($postsNotSent as $post) {
+        foreach ($postsNotSent as $post) {
             Bus::assertNotDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });

--- a/tests/Console/SendToQuasarCommandTest.php
+++ b/tests/Console/SendToQuasarCommandTest.php
@@ -74,7 +74,7 @@ class SendToQuasarCommandTest extends TestCase
             });
         }
 
-       foreach ($postsNotSent as $post) {
+        foreach ($postsNotSent as $post) {
             Bus::assertNotDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });

--- a/tests/Console/SendToQuasarCommandTest.php
+++ b/tests/Console/SendToQuasarCommandTest.php
@@ -2,15 +2,12 @@
 
 namespace Tests\Console;
 
-use Carbon\Carbon;
 use Tests\TestCase;
 use Rogue\Models\Post;
 use Rogue\Models\Signup;
 use Rogue\Jobs\SendPostToQuasar;
 use Rogue\Jobs\SendSignupToQuasar;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class SendToQuasarCommandTest extends TestCase
 {
@@ -28,13 +25,13 @@ class SendToQuasarCommandTest extends TestCase
 
         $this->artisan('rogue:quasar');
 
-        foreach(Signup::all() as $signup) {
+        foreach (Signup::all() as $signup) {
             Bus::assertDispatched(SendSignupToQuasar::class, function ($job) use ($signup) {
                 return $job->getSignupId() === $signup->id;
             });
         }
 
-        foreach(Post::all() as $post) {
+        foreach (Post::all() as $post) {
             Bus::assertDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });
@@ -58,26 +55,26 @@ class SendToQuasarCommandTest extends TestCase
         $this->artisan('rogue:quasar', ['start' => '2018-02-04']);
 
         // Make sure that posts and signups that should have been sent were
-        foreach($signupsToSend as $signup) {
+        foreach ($signupsToSend as $signup) {
             Bus::assertDispatched(SendSignupToQuasar::class, function ($job) use ($signup, $signupsNotSent) {
                 return $job->getSignupId() === $signup->id;
             });
         }
 
-        foreach($postsToSend as $post) {
+        foreach ($postsToSend as $post) {
             Bus::assertDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });
         }
 
         // Make sure that posts and signups that should NOT have been sent weren't
-        foreach($signupsNotSent as $signup) {
+        foreach ($signupsNotSent as $signup) {
             Bus::assertNotDispatched(SendSignupToQuasar::class, function ($job) use ($signup) {
                 return $job->getSignupId() === $signup->id;
             });
         }
 
-       foreach($postsNotSent as $post) {
+       foreach ($postsNotSent as $post) {
             Bus::assertNotDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });
@@ -98,7 +95,7 @@ class SendToQuasarCommandTest extends TestCase
         $oldPostsToSend = factory(Post::class, 2)->create();
 
         $this->mockTime('5/18/2018 09:00:00');
-        $newSignupsToSend= factory(Signup::class, 2)->create();
+        $newSignupsToSend = factory(Signup::class, 2)->create();
         $newPostsToSend = factory(Post::class, 2)->create();
 
         $signupsToSend = $oldSignupsToSend->merge($newSignupsToSend);
@@ -108,26 +105,26 @@ class SendToQuasarCommandTest extends TestCase
         $this->artisan('rogue:quasar', ['start' => '2018-02-04', 'end' => '2018-05-19']);
 
         // Make sure that posts and signups that should have been sent were
-        foreach($signupsToSend as $signup) {
+        foreach ($signupsToSend as $signup) {
             Bus::assertDispatched(SendSignupToQuasar::class, function ($job) use ($signup, $signupsNotSent) {
                 return $job->getSignupId() === $signup->id;
             });
         }
 
-        foreach($postsToSend as $post) {
+        foreach ($postsToSend as $post) {
             Bus::assertDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });
         }
 
         // Make sure that posts and signups that should NOT have been sent weren't
-        foreach($signupsNotSent as $signup) {
+        foreach ($signupsNotSent as $signup) {
             Bus::assertNotDispatched(SendSignupToQuasar::class, function ($job) use ($signup) {
                 return $job->getSignupId() === $signup->id;
             });
         }
 
-       foreach($postsNotSent as $post) {
+       foreach ($postsNotSent as $post) {
             Bus::assertNotDispatched(SendPostToQuasar::class, function ($job) use ($post) {
                 return $job->getPostId() === $post->id;
             });


### PR DESCRIPTION
#### What's this PR do?
- New command to send posts and signups within a given date range (or all, if none given) to Quasar
    - Dates are based on the `updated_at` timestamps on the posts and signups
- Adds 3 tests for each scenario that the command can be run with (no arguments, start date given, and start and end date both given)

#### How should this be reviewed?
Does using `updated_at` make sense? Is it okay to assume we always want to send both posts and signups?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/155196205)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
