### PR TITLE
Allow sending posts/signups to Quasar without logging

### DIFF
--- a/app/Console/Commands/SendToQuasar.php
+++ b/app/Console/Commands/SendToQuasar.php
@@ -16,6 +16,7 @@ class SendToQuasar extends Command
      * @var string
      */
     protected $signature = 'rogue:quasar
+                            {logFreq=1}
                             {start=0000-00-00 : Include all signups and posts updated on or after this day. Format: YYYY-MM-DD}
                             {end? : Include signups and posts updated up to but not including this day. Format: YYYY-MM-DD}';
 
@@ -45,6 +46,7 @@ class SendToQuasar extends Command
     {
         info('rogue:quasar - Starting to send to Quasar');
 
+        $logFreq = $this->argument('logFreq');
         $start = $this->argument('start');
         $end = $this->argument('end');
 
@@ -55,9 +57,14 @@ class SendToQuasar extends Command
             $signups = $signups->where('updated_at', '<=', $end);
         }
 
-        $signups->chunkById(1000, function ($signups) {
+        $signups->chunkById(1000, function ($signups) use ($logFreq) {
             foreach ($signups as $signup) {
-                SendSignupToQuasar::dispatch($signup);
+                if ($signup->id % $logFreq === 0) {
+                    $log = true;
+                } else {
+                    $log = false;
+                }
+                SendSignupToQuasar::dispatch($signup, $log);
             }
         });
 
@@ -68,9 +75,14 @@ class SendToQuasar extends Command
             $posts = $posts->where('updated_at', '<=', $end);
         }
 
-        $posts->chunkById(1000, function ($posts) {
+        $posts->chunkById(1000, function ($posts) use ($logFreq) {
             foreach ($posts as $post) {
-                SendPostToQuasar::dispatch($post);
+                if ($post->id % $logFreq === 0) {
+                    $log = true;
+                } else {
+                    $log = false;
+                }
+                SendPostToQuasar::dispatch($post, $log);
             }
         });
 

--- a/app/Console/Commands/SendToQuasar.php
+++ b/app/Console/Commands/SendToQuasar.php
@@ -16,9 +16,9 @@ class SendToQuasar extends Command
      * @var string
      */
     protected $signature = 'rogue:quasar
-                            {logFreq=1}
                             {start=0000-00-00 : Include all signups and posts updated on or after this day. Format: YYYY-MM-DD}
-                            {end? : Include signups and posts updated up to but not including this day. Format: YYYY-MM-DD}';
+                            {end? : Include signups and posts updated up to but not including this day. Format: YYYY-MM-DD}
+                            {--logFreq=1 : How often we should log that a Post or Signup has been sent to Quasar. Logging happens every logFreq posts/signups.}';
 
     /**
      * The console command description.
@@ -46,9 +46,9 @@ class SendToQuasar extends Command
     {
         info('rogue:quasar - Starting to send to Quasar');
 
-        $logFreq = $this->argument('logFreq');
         $start = $this->argument('start');
         $end = $this->argument('end');
+        $logFreq = $this->option('logFreq');
 
         // Send Signups
         $signups = Signup::where('updated_at', '>=', $start);

--- a/app/Console/Commands/SendToQuasar.php
+++ b/app/Console/Commands/SendToQuasar.php
@@ -59,12 +59,8 @@ class SendToQuasar extends Command
 
         $signups->chunkById(1000, function ($signups) use ($logFreq) {
             foreach ($signups as $signup) {
-                if ($signup->id % $logFreq === 0) {
-                    $log = true;
-                } else {
-                    $log = false;
-                }
-                SendSignupToQuasar::dispatch($signup, $log);
+                $shouldWriteToLog = ($signup->id % $logFreq === 0);
+                SendSignupToQuasar::dispatch($signup, $shouldWriteToLog);
             }
         });
 
@@ -77,12 +73,8 @@ class SendToQuasar extends Command
 
         $posts->chunkById(1000, function ($posts) use ($logFreq) {
             foreach ($posts as $post) {
-                if ($post->id % $logFreq === 0) {
-                    $log = true;
-                } else {
-                    $log = false;
-                }
-                SendPostToQuasar::dispatch($post, $log);
+                $shouldWriteToLog = ($post->id % $logFreq === 0);
+                SendPostToQuasar::dispatch($post, $shouldWriteToLog);
             }
         });
 

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -23,7 +23,7 @@ class SendPostToQuasar implements ShouldQueue
     /**
      * Whether or not to log that this Post was sent to Quasar.
      *
-     * @var boolean
+     * @var bool
      */
     protected $log;
 

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -21,13 +21,21 @@ class SendPostToQuasar implements ShouldQueue
     protected $post;
 
     /**
+     * Whether or not to log that this Post was sent to Quasar.
+     *
+     * @var boolean
+     */
+    protected $log;
+
+    /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(Post $post)
+    public function __construct(Post $post, $log = true)
     {
         $this->post = $post;
+        $this->log = $log;
     }
 
     /**
@@ -47,8 +55,10 @@ class SendPostToQuasar implements ShouldQueue
         }
 
         // Log
-        $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
-        info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
+        if ($this->log) {
+            $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+            info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
+        }
     }
 
     /**

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -21,13 +21,21 @@ class SendSignupToQuasar implements ShouldQueue
     protected $signup;
 
     /**
+     * Whether or not to log that this Signup was sent to Quasar.
+     *
+     * @var boolean
+     */
+    protected $log;
+
+    /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(Signup $signup)
+    public function __construct(Signup $signup, $log = true)
     {
         $this->signup = $signup;
+        $this->log = $log;
     }
 
     /**
@@ -47,8 +55,10 @@ class SendSignupToQuasar implements ShouldQueue
         }
 
         // Log
-        $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
-        info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
+        if ($this->log) {
+            $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+            info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
+        }
     }
 
     /**

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -23,7 +23,7 @@ class SendSignupToQuasar implements ShouldQueue
     /**
      * Whether or not to log that this Signup was sent to Quasar.
      *
-     * @var boolean
+     * @var bool
      */
     protected $log;
 


### PR DESCRIPTION
🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥  
#### What's this PR do?
- `SendPostToQuasar` and `SendSignupToQuasar` now accept a parameter to suppress logging (if nothing is passed, they still log)
- `SendToQuasar` command now takes in an option (defaults to 1) for how often we should log that a Post or Signup has been sent to Quasar (aka how often we should NOT suppress logging)

#### How should this be reviewed?
Will this keeps the logging to a reasonable volume when running this command over all Posts and Signups?

#### Any background context you want to provide?
Without a change like this, we would way overflow our logs.

#### Relevant tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/155196205)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
