### PR TITLE
Update status validation to allow for new voter-reg statuses

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -31,7 +31,7 @@ class PostRequest extends Request
             'text' => 'nullable|string|max:256',
             'quantity' => 'nullable|integer',
             'file' => 'image|dimensions:min_width=400,min_height=400',
-            'status' => 'in:pending,accepted,rejected',
+            'status' => 'in:pending,accepted,rejected,register-form,register-OVR,confirmed,ineligible,uncertain',
             'details'=> 'json',
         ];
     }


### PR DESCRIPTION
#### What's this PR do?
We are adding 5 new statuses that can be applied to `voter-reg` posts. 

This updates the validation rule on the post `status` field so that we can pass them via the API

I think there might be a way to lock down the validation even more. Like if `type=voter-reg`, validate it one way. If `type=photo` validate it another way. But this is a first pass.

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

https://github.com/DoSomething/chompy/wiki/TurboVote-Imports#status-translation-rules

#### Relevant tickets

Addresses a need for our importer app to send TurboVote statuses to rogue. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
