### PR TITLE
Add 'type' and 'action' to Post indexes.

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -53,7 +53,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'status'];
+    public static $indexes = ['id', 'signup_id', 'campaign_id', 'action', 'northstar_id', 'status'];
 
     /**
      * Each post has events.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -53,7 +53,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'action', 'northstar_id', 'status'];
+    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'northstar_id', 'status'];
 
     /**
      * Each post has events.


### PR DESCRIPTION
#### What's this PR do?
We want to query a user's posts by `type` and `action` for the submission gallery on You've Got The Power (so we can show separate galleries for a user's text and photo submissions). This pull request adds those columns to the `Post` model's `$indexes` array so they can be filtered.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Both columns are already indexed in the database.

#### Relevant tickets
[#155866191](https://www.pivotaltracker.com/story/show/155866191)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md