### PR TITLE
v3/posts quantity bug

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 preset: laravel
 
-linting: true
-
 disabled:
  - concat_without_spaces
  - no_useless_return

--- a/app/Repositories/Legacy/Two/PostRepository.php
+++ b/app/Repositories/Legacy/Two/PostRepository.php
@@ -97,7 +97,10 @@ class PostRepository
 
             // If the quantity difference is negative than we recieved an incremental submission
             // and should just add that to the post.
-            if ($quantityDiff < 0) {
+            // If the quantity difference equals zero and this is the first post,
+            // the post and signup were created at the same time -
+            // store this quantity on both the post and signup.
+            if ($quantityDiff < 0 || ($quantityDiff === 0 && $signup->posts_count === 0)) {
                 $quantityDiff = $data['quantity'];
             } elseif ($quantityDiff === 0 && $signup->posts_count > 0) {
                 // If the quantity difference equals zero, and this is not the first post,


### PR DESCRIPTION
#### What's this PR do?
- We were seeing a bug that if a post and signup were created at the same time, the quantities were saved as `0` both on the post and the signup. 
- This PR fixes that bug - it adds the missing check if the difference between the new quantity (coming in as the request) and the signup quantity is `0` and this is the first post, set the post and the signup's quantity to `0`. Before it was not check this and thus set the quantities as `0` (the difference). 
  - When the signup is first created, the quantity is correctly set as `2`. However, that gets overriden and set to `0` [here](https://github.com/DoSomething/rogue/blob/master/app/Repositories/Legacy/Two/PostRepository.php#L127) when it re-sets the signup's quantity to a sum of the posts' quantities. In this case, since it thought the post's quantity was `0`, it summed that one quantity and set the signup's quantity to `0`.  

#### How should this be reviewed?
👀 
- Does this logic make sense? 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156817767) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
