### PR TITLE
Force delete test records

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ If you ever have any questions about working in Rogue, please reach out to the #
 
 ### Getting Started
 
-To get started with development, follow the [installation](./development/installation.md) and [contributing](./development/contributing.md) documentation.
+To get started with development, follow the [installation](https://github.com/DoSomething/rogue/blob/master/docs/development/installation.md) and [contributing](https://github.com/DoSomething/rogue/blob/master/docs/development/contributing.md) documentation.
 
-To get started using the API, see our [API Documentation](./endpoints)
+To get started using the API, see our [API Documentation](https://github.com/DoSomething/rogue/tree/master/docs/endpoints)
 
 ### Security Vulnerabilities
 

--- a/app/Console/Commands/ForceDeleteTestRecords.php
+++ b/app/Console/Commands/ForceDeleteTestRecords.php
@@ -51,7 +51,7 @@ class ForceDeleteTestRecords extends Command
             $runscopePost->forceDelete();
         }
 
-        $this->info('All Runscope and Ghost Inspector Signups deleted.');
+        $this->info('All Runscope signups and posts deleted.');
 
         // Force delete all signups created by Ghost Inspector tests, identified by 'why_participated.'
         $ghostInspectorSignups = Signup::where('why_participated', 'Why! I love to test! Team Bleed for the win! Tongue Cat forever!')->get();
@@ -59,12 +59,12 @@ class ForceDeleteTestRecords extends Command
             $ghostInspectorSignup->forceDelete();
         }
 
-        // Force delete all psots created by Ghost Inspector tests, identified by
+        // Force delete all posts created by Ghost Inspector tests, identified by caption.
         $ghostInspectorPosts = Post::where('text', 'Caption! I love to test! Team Bleed for the win! Tongue Cat forever!')->get();
         foreach ($ghostInspectorPosts as $ghostInspectorPost) {
             $ghostInspectorPost->forceDelete();
         }
 
-        $this->info('All Runscope and Ghost Inspector Posts deleted.');
+        $this->info('All Ghost Inspector signups and posts deleted.');
     }
 }

--- a/app/Console/Commands/ForceDeleteTestRecords.php
+++ b/app/Console/Commands/ForceDeleteTestRecords.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+use Illuminate\Console\Command;
+
+class ForceDeleteTestRecords extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:forceDeleteTestRecords';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Force deletes signups and posts made in Runscope and Ghost Inspector tests';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Force delete all signups created by Runscope, identified by source.
+        $runscopeSignups = Signup::where('source', 'runscope')->orWhere('source', 'runscope-oauth')->get();
+        foreach ($runscopeSignups as $runscopeSignup) {
+            $runscopeSignup->forceDelete();
+        }
+
+        // Force delete all posts created by Runscope, identified by source.
+        $runscopePosts = Post::where('source', 'runscope')->orWhere('source', 'runscope-oauth')->get();
+        foreach ($runscopePosts as $runscopePost) {
+            $runscopePost->forceDelete();
+        }
+
+        $this->info('All Runscope and Ghost Inspector Signups deleted.');
+
+        // Force delete all signups created by Ghost Inspector tests, identified by 'why_participated.'
+        $ghostInspectorSignups = Signup::where('why_participated', 'Why! I love to test! Team Bleed for the win! Tongue Cat forever!')->get();
+        foreach ($ghostInspectorSignups as $ghostInspectorSignup) {
+            $ghostInspectorSignup->forceDelete();
+        }
+
+        // Force delete all psots created by Ghost Inspector tests, identified by
+        $ghostInspectorPosts = Post::where('text', 'Caption! I love to test! Team Bleed for the win! Tongue Cat forever!')->get();
+        foreach ($ghostInspectorPosts as $ghostInspectorPost) {
+            $ghostInspectorPost->forceDelete();
+        }
+
+        $this->info('All Runscope and Ghost Inspector Posts deleted.');
+    }
+}

--- a/app/Console/Commands/ForceDeleteTestRecords.php
+++ b/app/Console/Commands/ForceDeleteTestRecords.php
@@ -48,10 +48,10 @@ class ForceDeleteTestRecords extends Command
         $this->info('All Runscope signups and posts deleted.');
 
         // Force delete all signups created by Ghost Inspector tests, identified by 'why_participated.'
-        Signup::where('why_participated', 'Why! I love to test! Team Bleed for the win! Tongue Cat forever!')->forceDelete();
+        Signup::where('why_participated', 'why_participated_ghost_test')->forceDelete();
 
         // Force delete all posts created by Ghost Inspector tests, identified by caption.
-        Post::where('text', 'Caption! I love to test! Team Bleed for the win! Tongue Cat forever!')->forceDelete();
+        Post::where('text', 'caption_ghost_test')->forceDelete();
 
         $this->info('All Ghost Inspector signups and posts deleted.');
     }

--- a/app/Console/Commands/ForceDeleteTestRecords.php
+++ b/app/Console/Commands/ForceDeleteTestRecords.php
@@ -40,30 +40,18 @@ class ForceDeleteTestRecords extends Command
     public function handle()
     {
         // Force delete all signups created by Runscope, identified by source.
-        $runscopeSignups = Signup::where('source', 'runscope')->orWhere('source', 'runscope-oauth')->get();
-        foreach ($runscopeSignups as $runscopeSignup) {
-            $runscopeSignup->forceDelete();
-        }
+        Signup::where('source', 'runscope')->orWhere('source', 'runscope-oauth')->forceDelete();
 
         // Force delete all posts created by Runscope, identified by source.
-        $runscopePosts = Post::where('source', 'runscope')->orWhere('source', 'runscope-oauth')->get();
-        foreach ($runscopePosts as $runscopePost) {
-            $runscopePost->forceDelete();
-        }
+        Post::where('source', 'runscope')->orWhere('source', 'runscope-oauth')->forceDelete();
 
         $this->info('All Runscope signups and posts deleted.');
 
         // Force delete all signups created by Ghost Inspector tests, identified by 'why_participated.'
-        $ghostInspectorSignups = Signup::where('why_participated', 'Why! I love to test! Team Bleed for the win! Tongue Cat forever!')->get();
-        foreach ($ghostInspectorSignups as $ghostInspectorSignup) {
-            $ghostInspectorSignup->forceDelete();
-        }
+        Signup::where('why_participated', 'Why! I love to test! Team Bleed for the win! Tongue Cat forever!')->forceDelete();
 
         // Force delete all posts created by Ghost Inspector tests, identified by caption.
-        $ghostInspectorPosts = Post::where('text', 'Caption! I love to test! Team Bleed for the win! Tongue Cat forever!')->get();
-        foreach ($ghostInspectorPosts as $ghostInspectorPost) {
-            $ghostInspectorPost->forceDelete();
-        }
+        Post::where('text', 'Caption! I love to test! Team Bleed for the win! Tongue Cat forever!')->forceDelete();
 
         $this->info('All Ghost Inspector signups and posts deleted.');
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -35,6 +35,6 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        //
+        $schedule->command(ForceDeleteTestRecords::class, ['--force'])->hourly();
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends ConsoleKernel
         Commands\UpdateSignup::class,
         Commands\ReviewSignup::class,
         Commands\SendToQuasar::class,
+        Commands\ForceDeleteTestRecords::class,
     ];
 
     /**

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -161,8 +161,8 @@ POST /api/v3/posts
     Corresponding text for the post (could be photo caption or other words). 256 max characters.
   - **status**: (string).
     Option to set status upon creation if admin uploads post for user.
-  - **file**: (file) required for photo posts.
-    File string to save of post image.
+  - **file**: (multipart/form-data) required for photo posts.
+    File to save of post image.
   - **details** (json).
     A JSON field to store extra details about a post.
   - **dont_send_to_blink** (boolean) optional.

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -10,6 +10,8 @@ POST /api/v3/signups
     The drupal node id of the campaign the user is signing up for.
   - **campaign_run_id**: (int) optional.
     The drupal campaign run node id of the campaign run the user is signing up for.
+  - **northstar_id**: (int) optional.
+    The northstar_id of the user who is signing up. Can be sent through from a client.
   - **why_participated**: (string) optional.
     The reason why the user participated.
   - **source**: (string) optional (for migration purposes, there are signups on prod with no source).

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -11,7 +11,7 @@ POST /api/v3/signups
   - **campaign_run_id**: (int) optional.
     The drupal campaign run node id of the campaign run the user is signing up for.
   - **northstar_id**: (int) optional.
-    The northstar_id of the user who is signing up. Can be sent through from a client.
+    The `northstar_id` of the user who the signup belongs to. This `northstar_id` will be used when acting `asClient`. Otherwise, if the request comes in acting `asUser`, it will ignore this and attribute the signup to the `northstar_id` from OAuth. 
   - **why_participated**: (string) optional.
     The reason why the user participated.
   - **source**: (string) optional (for migration purposes, there are signups on prod with no source).


### PR DESCRIPTION
#### What's this PR do?
- Force deletes test records created by Ghost Inspector and Runscope
  - Signups and Posts from runscope are found by `source` (either `runscope` or `runscope-oauth`). 
  - Signups from Ghost Inspector are found by `why_participated` (`Why! I love to test! Team Bleed for the win! Tongue Cat forever!`)
  - Posts from Ghost Inspector are found by `text` (`Caption! I love to test! Team Bleed for the win! Tongue Cat forever!`)
- Updates some documentation irrelevant to this but wanted to just sneak in here!

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
@sheyd re: [sending deleted events to the queue](https://dosomething.slack.com/archives/C6J24ADQW/p1523391687000195), since this is just working directly with the database and force deleting, I don't think it will actually send any notifications when this is deleted. Can you explain a little more to me what you need here so I can make sure I write this in?  

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156512296) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
