### PR TITLE
Limit queue retries

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: composer warmup && vendor/bin/heroku-php-nginx -C nginx.conf public/
 
 release: php artisan migrate --force
 
-queue: php artisan queue:work --sleep=5
+queue: php artisan queue:work --tries=3 --sleep=5


### PR DESCRIPTION
#### What's this PR do?

Updates the Procfile so that we limit failing jobs to only try 3 times at most before moving it into the `faild_jobs` table and moving on. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

This has been causing our logs to clog. See thread here: https://dosomething.slack.com/archives/C0YGXUE01/p1524058904000801

#### Relevant tickets

🐛 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
