### PR TITLE
checks to see if object exists before sending to quasar/blink

### DIFF
--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -40,10 +40,10 @@ class SendPostToCustomerIo implements ShouldQueue
     {
         // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
         if ($this->post) {
-          $payload = $this->post->toBlinkPayload();
+            $payload = $this->post->toBlinkPayload();
 
-          $blink->userSignupPost($payload);
-          logger()->info('Post ' . $payload['id'] . ' sent to Blink');
+            $blink->userSignupPost($payload);
+            logger()->info('Post ' . $payload['id'] . ' sent to Blink');
         }
     }
 }

--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -38,9 +38,12 @@ class SendPostToCustomerIo implements ShouldQueue
      */
     public function handle(Blink $blink)
     {
-        $payload = $this->post->toBlinkPayload();
+        // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
+        if ($this->post) {
+          $payload = $this->post->toBlinkPayload();
 
-        $blink->userSignupPost($payload);
-        logger()->info('Post ' . $payload['id'] . ' sent to Blink');
+          $blink->userSignupPost($payload);
+          logger()->info('Post ' . $payload['id'] . ' sent to Blink');
+        }
     }
 }

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -47,20 +47,20 @@ class SendPostToQuasar implements ShouldQueue
     {
         // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
         if ($this->post) {
-          // Format the payload
-          $payload = $this->post->toQuasarPayload();
+            // Format the payload
+            $payload = $this->post->toQuasarPayload();
 
-          // Send to Quasar
-          $shouldSendToQuasar = config('features.pushToQuasar');
-          if ($shouldSendToQuasar) {
-              gateway('blink')->post('v1/events/quasar-relay', $payload);
-          }
+            // Send to Quasar
+            $shouldSendToQuasar = config('features.pushToQuasar');
+            if ($shouldSendToQuasar) {
+                gateway('blink')->post('v1/events/quasar-relay', $payload);
+            }
 
-          // Log
-          if ($this->log) {
-              $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
-              info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
-          }
+            // Log
+            if ($this->log) {
+                $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+                info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
+            }
         }
     }
 

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -45,19 +45,22 @@ class SendPostToQuasar implements ShouldQueue
      */
     public function handle()
     {
-        // Format the payload
-        $payload = $this->post->toQuasarPayload();
+        // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
+        if ($this->post) {
+          // Format the payload
+          $payload = $this->post->toQuasarPayload();
 
-        // Send to Quasar
-        $shouldSendToQuasar = config('features.pushToQuasar');
-        if ($shouldSendToQuasar) {
-            gateway('blink')->post('v1/events/quasar-relay', $payload);
-        }
+          // Send to Quasar
+          $shouldSendToQuasar = config('features.pushToQuasar');
+          if ($shouldSendToQuasar) {
+              gateway('blink')->post('v1/events/quasar-relay', $payload);
+          }
 
-        // Log
-        if ($this->log) {
-            $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
-            info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
+          // Log
+          if ($this->log) {
+              $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+              info('Post ' . $this->post->id . ' ' . $verb . ' to Quasar');
+          }
         }
     }
 

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -38,16 +38,19 @@ class SendSignupToCustomerIo implements ShouldQueue
      */
     public function handle(Blink $blink)
     {
-        $payload = $this->signup->toBlinkPayload();
+        // Check if the signup still exists before sending (might have been deleted immediately if created in Runscope test).
+        if ($this->signup) {
+          $payload = $this->signup->toBlinkPayload();
 
-        // @TODO: update other places we call this to not check for config('features.blink')
-        $shouldSend = config('features.blink');
-        if ($shouldSend) {
-            $blink->userSignup($payload);
+          // @TODO: update other places we call this to not check for config('features.blink')
+          $shouldSend = config('features.blink');
+          if ($shouldSend) {
+              $blink->userSignup($payload);
+          }
+
+          // Log
+          $verb = $shouldSend ? 'sent' : 'would have been sent';
+          info('Signup ' . $payload['id'] . ' ' . $verb . ' to Customer.io');
         }
-
-        // Log
-        $verb = $shouldSend ? 'sent' : 'would have been sent';
-        info('Signup ' . $payload['id'] . ' ' . $verb . ' to Customer.io');
     }
 }

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -40,17 +40,17 @@ class SendSignupToCustomerIo implements ShouldQueue
     {
         // Check if the signup still exists before sending (might have been deleted immediately if created in Runscope test).
         if ($this->signup) {
-          $payload = $this->signup->toBlinkPayload();
+            $payload = $this->signup->toBlinkPayload();
 
-          // @TODO: update other places we call this to not check for config('features.blink')
-          $shouldSend = config('features.blink');
-          if ($shouldSend) {
-              $blink->userSignup($payload);
-          }
+            // @TODO: update other places we call this to not check for config('features.blink')
+            $shouldSend = config('features.blink');
+            if ($shouldSend) {
+                $blink->userSignup($payload);
+            }
 
-          // Log
-          $verb = $shouldSend ? 'sent' : 'would have been sent';
-          info('Signup ' . $payload['id'] . ' ' . $verb . ' to Customer.io');
+            // Log
+            $verb = $shouldSend ? 'sent' : 'would have been sent';
+            info('Signup ' . $payload['id'] . ' ' . $verb . ' to Customer.io');
         }
     }
 }

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -45,19 +45,22 @@ class SendSignupToQuasar implements ShouldQueue
      */
     public function handle()
     {
-        // Format payload
-        $payload = $this->signup->toQuasarPayload();
+        // Check if the signup still exists before sending (might have been deleted immediately if created in Runscope test).
+        if ($this->signup) {
+          // Format payload
+          $payload = $this->signup->toQuasarPayload();
 
-        // Send to Quasar
-        $shouldSendToQuasar = config('features.pushToQuasar');
-        if ($shouldSendToQuasar) {
-            gateway('blink')->post('v1/events/quasar-relay', $payload);
-        }
+          // Send to Quasar
+          $shouldSendToQuasar = config('features.pushToQuasar');
+          if ($shouldSendToQuasar) {
+              gateway('blink')->post('v1/events/quasar-relay', $payload);
+          }
 
-        // Log
-        if ($this->log) {
-            $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
-            info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
+          // Log
+          if ($this->log) {
+              $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+              info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
+          }
         }
     }
 

--- a/app/Jobs/SendSignupToQuasar.php
+++ b/app/Jobs/SendSignupToQuasar.php
@@ -47,20 +47,20 @@ class SendSignupToQuasar implements ShouldQueue
     {
         // Check if the signup still exists before sending (might have been deleted immediately if created in Runscope test).
         if ($this->signup) {
-          // Format payload
-          $payload = $this->signup->toQuasarPayload();
+            // Format payload
+            $payload = $this->signup->toQuasarPayload();
 
-          // Send to Quasar
-          $shouldSendToQuasar = config('features.pushToQuasar');
-          if ($shouldSendToQuasar) {
-              gateway('blink')->post('v1/events/quasar-relay', $payload);
-          }
+            // Send to Quasar
+            $shouldSendToQuasar = config('features.pushToQuasar');
+            if ($shouldSendToQuasar) {
+                gateway('blink')->post('v1/events/quasar-relay', $payload);
+            }
 
-          // Log
-          if ($this->log) {
-              $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
-              info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
-          }
+            // Log
+            if ($this->log) {
+                $verb = $shouldSendToQuasar ? 'sent' : 'would have been sent';
+                info('Signup ' . $this->signup->id . ' ' . $verb . ' to Quasar');
+            }
         }
     }
 


### PR DESCRIPTION
#### What's this PR do?
checks to see if object exists before sending to quasar/blink

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
We were seeing some errors in the logs that described runscope tests trying to send objects to quasar/blink that didn't exist. The tests automatically delete the records after creation and could do this before sending to the services. This PR adds a check to only send if the records still exists to avoid these errors. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
