### PR TITLE
checks if both post and signup exist before sending to quasar/blink

### DIFF
--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -39,7 +39,7 @@ class SendPostToCustomerIo implements ShouldQueue
     public function handle(Blink $blink)
     {
         // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
-        if ($this->post) {
+        if ($this->post && $this->post->signup) {
             $payload = $this->post->toBlinkPayload();
 
             $blink->userSignupPost($payload);

--- a/app/Jobs/SendPostToQuasar.php
+++ b/app/Jobs/SendPostToQuasar.php
@@ -46,7 +46,7 @@ class SendPostToQuasar implements ShouldQueue
     public function handle()
     {
         // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
-        if ($this->post) {
+        if ($this->post && $this->post->signup) {
             // Format the payload
             $payload = $this->post->toQuasarPayload();
 


### PR DESCRIPTION
#### What's this PR do?
Checks if both post and signup exist before sending post to quasar/blink

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
We're still seeing errors with the Runscope tests! We think it is because the timing is off with the queue and the signup has been deleted before the job fires. This is an extra sanity check to make sure both the post and signup exist before trying to fire jobs.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
