### PR TITLE
Add  as a valid status for voter reg posts

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -67,7 +67,7 @@ class PostRequest extends Request
                 $rule = 'in:pending,accepted,rejected';
                 break;
             case 'voter-reg':
-                $rule = 'in:register-form,register-OVR,confirmed,ineligible,uncertain';
+                $rule = 'in:pending,register-form,register-OVR,confirmed,ineligible,uncertain';
                 break;
             default:
                 $rule = 'in:pending,accepted,rejected';


### PR DESCRIPTION
#### What's this PR do?

when ingesting `voter-reg` posts we translate the statuses provided by TurboVote into 5 different statuses that we care about at DoSomething. There are cases where there is a turbovote status that we do not know about or maybe it is even not given to us. In those cases, we just want to send `pending`. 

This updates the validation around the statuses we allow for `voter-reg` posts so that we can send this status to rogue with a voter registration post. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?

relates to this issue in [chompy](https://github.com/DoSomething/chompy/issues/12)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
