### PR TITLE
removes cache:clear from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,7 @@
     "warmup": [
       "@php artisan gateway:key",
       "@php artisan route:cache",
-      "@php artisan config:cache",
-      "@php artisan cache:clear"
+      "@php artisan config:cache"
     ]
   },
   "config": {


### PR DESCRIPTION
#### What's this PR do?
Removes `"@php artisan cache:clear"` from `composer.json` file. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
We don't need to do this every deploy - just needed to make sure #679 didn't break anything! Removing per @DFurnes 's [suggestion](https://github.com/DoSomething/rogue/pull/684#issuecomment-383659004).

#### Relevant tickets
Fixes #684 
#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
