### PR TITLE
Re-adds text helper back in and re-names 

### DIFF
--- a/resources/assets/components/Post/__snapshots__/test.js.snap
+++ b/resources/assets/components/Post/__snapshots__/test.js.snap
@@ -11,7 +11,7 @@ exports[`it renders correctly 1`] = `
       className="post__image"
     >
       <img
-        src={undefined}
+        src={null}
       />
     </div>
     <div
@@ -21,7 +21,7 @@ exports[`it renders correctly 1`] = `
         className="admin-tools__links"
       >
         <a
-          href={undefined}
+          href={null}
           target="_blank"
         >
           Original Photo

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { remove, map, clone } from 'lodash';
-import { getImageUrlFromPost, getEditedImageUrl } from '../../helpers';
+import { getImageUrlFromPost, getEditedImageUrl, displayCaption } from '../../helpers';
 
 import './post.scss';
 
@@ -55,6 +55,7 @@ class Post extends React.Component {
 
   render() {
     const post = this.props.post;
+    const caption = displayCaption(post);
     const user = this.props.user ? this.props.user : null;
     const signup = this.props.signup;
     const campaign = this.props.campaign;
@@ -108,7 +109,7 @@ class Post extends React.Component {
               : null}
 
             <div className="container -padded">
-              <TextBlock title={textOrCaption} content={post.media.text} />
+              <TextBlock title={textOrCaption} content={displayCaption(post)} />
             </div>
 
             <div className="container">

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { remove, map, clone } from 'lodash';
-import { getImageUrlFromPost, getEditedImageUrl, displayCaption } from '../../helpers';
+import { getImageUrlFromPost, getEditedImageUrl, displayPostText } from '../../helpers';
 
 import './post.scss';
 
@@ -55,7 +55,6 @@ class Post extends React.Component {
 
   render() {
     const post = this.props.post;
-    const caption = displayCaption(post);
     const user = this.props.user ? this.props.user : null;
     const signup = this.props.signup;
     const campaign = this.props.campaign;
@@ -109,7 +108,7 @@ class Post extends React.Component {
               : null}
 
             <div className="container -padded">
-              <TextBlock title={textOrCaption} content={displayCaption(post)} />
+              <TextBlock title={textOrCaption} content={displayPostText(post)} />
             </div>
 
             <div className="container">

--- a/resources/assets/components/Post/test.js
+++ b/resources/assets/components/Post/test.js
@@ -6,9 +6,7 @@ import Post from './index';
 test('it renders correctly', () => {
   const post = {
     id: 123,
-    media: {
-      text: 'Here is my awesome caption!',
-    },
+    text: 'Here is my awesome caption!',
     status: 'pending',
     tags: [],
     type: 'photo',

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -74,12 +74,12 @@ export function displayCityState(city, state) {
 }
 
 /**
- * Returns a readable caption string.
+ * Returns a readable Post text string.
  *
  * @param {Array} post
- * @return {String|null} caption string.
+ * @return {String|null} text string.
  */
-export function displayCaption(post) {
+export function displayPostText(post) {
   if (post.text) {
     return post.text;
   } else if (post.media) {

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -74,6 +74,22 @@ export function displayCityState(city, state) {
 }
 
 /**
+ * Returns a readable caption string.
+ *
+ * @param {Array} post
+ * @return {String|null} caption string.
+ */
+export function displayCaption(post) {
+  if (post.text) {
+    return post.text;
+  } else if (post.media) {
+    return post.media.text;
+  }
+
+  return null;
+}
+
+/**
  * Process file (provided as an ArrayBuffer) depending
  * on its type.
  *


### PR DESCRIPTION
#### What's this PR do?
- Re-adds `displayCaption` helper method back in that was removed from #686 
  - I realized we actually do need this because this is how we display on the signup page! 
- Renames the `displayCaption` helper method to `displayPostText` so it is more reflective of the data schema. 
- Updates Jest test. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156813946) Pivotal card (for real this time!)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
