### PR TITLE
Caption bug on all pages and updates Signup component to use v3/signups instead of v2/activity

### DIFF
--- a/app/Http/Controllers/Legacy/Web/SignupsController.php
+++ b/app/Http/Controllers/Legacy/Web/SignupsController.php
@@ -55,7 +55,7 @@ class SignupsController extends Controller
                 'signup_id' => $signup->id,
                 // @TODO - We could probably grab campaign and user info from API as well.
                 'campaign' => $campaign,
-                'user' => $user->toArray(),
+                // 'user' => $user->toArray(),
             ]);
     }
 }

--- a/app/Http/Controllers/Legacy/Web/SignupsController.php
+++ b/app/Http/Controllers/Legacy/Web/SignupsController.php
@@ -55,7 +55,7 @@ class SignupsController extends Controller
                 'signup_id' => $signup->id,
                 // @TODO - We could probably grab campaign and user info from API as well.
                 'campaign' => $campaign,
-                // 'user' => $user->toArray(),
+                'user' => $user->toArray(),
             ]);
     }
 }

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { remove, map, clone } from 'lodash';
-import { getImageUrlFromPost, getEditedImageUrl, displayPostText } from '../../helpers';
+import { getImageUrlFromPost, getEditedImageUrl } from '../../helpers';
 
 import './post.scss';
 
@@ -108,7 +108,7 @@ class Post extends React.Component {
               : null}
 
             <div className="container -padded">
-              <TextBlock title={textOrCaption} content={displayPostText(post)} />
+              <TextBlock title={textOrCaption} content={post.media.text} />
             </div>
 
             <div className="container">

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -112,10 +112,10 @@ class Signup extends React.Component {
    */
   getSignupAndPosts(id) {
     this.api.get(`api/v3/signups/${id}`, {
-        include: 'posts',
+      include: 'posts',
     }).then(json => this.setState({
-        signup: json.data,
-        posts: keyBy(json.data.posts.data, 'id'),
+      signup: json.data,
+      posts: keyBy(json.data.posts.data, 'id'),
     }));
   }
 
@@ -429,7 +429,7 @@ class Signup extends React.Component {
               title="Meta"
               details={{
                 'Signup ID': signup.id,
-                // 'Northstar ID': user.id,
+                'Northstar ID': user.id,
                 'Signup Source': signup.source,
                 'Created At': new Date(signup.created_at).toDateString(),
               }}

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -111,10 +111,11 @@ class Signup extends React.Component {
    * @return {Object}
    */
   getSignupAndPosts(id) {
-    this.api.get(`api/v3/signups/${id}?include=posts`)
-      .then(json => this.setState({
+    this.api.get(`api/v3/signups/${id}`, {
+        include: 'posts',
+    }).then(json => this.setState({
         signup: json.data,
-        posts: keyBy(json.data[0].posts.data, 'id'),
+        posts: keyBy(json.data.posts.data, 'id'),
     }));
   }
 
@@ -368,7 +369,7 @@ class Signup extends React.Component {
     const signup = this.state.signup;
     const campaign = this.props.campaign;
     const posts = this.state.posts;
-    console.log(this.state);
+
     if (! this.state.signup) {
       return <Empty header={`This signup has been deleted`} />;
     }
@@ -427,9 +428,9 @@ class Signup extends React.Component {
             <MetaInformation
               title="Meta"
               details={{
-                'Signup ID': signup.signup_id,
+                'Signup ID': signup.id,
                 // 'Northstar ID': user.id,
-                'Signup Source': signup.signup_source,
+                'Signup Source': signup.source,
                 'Created At': new Date(signup.created_at).toDateString(),
               }}
             />

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -101,23 +101,20 @@ class Signup extends React.Component {
   }
 
   componentDidMount() {
-    this.getUserActivity(this.props.signup_id);
+    this.getSignupAndPosts(this.props.signup_id);
   }
 
   /**
-   * Gets the user activity for the specified user and update state.
+   * Gets the signup and posts and update state.
    *
    * @param {String} id
    * @return {Object}
    */
-  getUserActivity(id) {
-    this.api.get('api/v2/activity', {
-      filter: {
-        id,
-      },
-    }).then(json => this.setState({
-      signup: json.data[0],
-      posts: keyBy(json.data[0].posts.data, 'id'),
+  getSignupAndPosts(id) {
+    this.api.get(`api/v3/signups/${id}?include=posts`)
+      .then(json => this.setState({
+        signup: json.data,
+        posts: keyBy(json.data[0].posts.data, 'id'),
     }));
   }
 
@@ -371,7 +368,7 @@ class Signup extends React.Component {
     const signup = this.state.signup;
     const campaign = this.props.campaign;
     const posts = this.state.posts;
-
+    console.log(this.state);
     if (! this.state.signup) {
       return <Empty header={`This signup has been deleted`} />;
     }
@@ -431,7 +428,7 @@ class Signup extends React.Component {
               title="Meta"
               details={{
                 'Signup ID': signup.signup_id,
-                'Northstar ID': user.id,
+                // 'Northstar ID': user.id,
                 'Signup Source': signup.signup_source,
                 'Created At': new Date(signup.created_at).toDateString(),
               }}

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -74,22 +74,6 @@ export function displayCityState(city, state) {
 }
 
 /**
- * Returns a readable Post text string.
- *
- * @param {Array} post
- * @return {String|null} text string.
- */
-export function displayPostText(post) {
-  if (post.text) {
-    return post.text;
-  } else if (post.media) {
-    return post.media.text;
-  }
-
-  return null;
-}
-
-/**
  * Process file (provided as an ArrayBuffer) depending
  * on its type.
  *


### PR DESCRIPTION
#### What's this PR do?
- This fixes the [caption bug](https://www.pivotaltracker.com/n/projects/2019429/stories/156813946) once and for all! 
- Turns out, we really don't need the helper method (sorry I lied in #687 !) - removed this again! 
- The caption/text still wasn't showing up on the `/signup/:signup_id` page. 
  - This is because we were using the `v2/activity` endpoint to grab the signup and its posts and the v2 post transformer returns [caption instead of text](https://github.com/DoSomething/rogue/blob/master/app/Http/Transformers/Legacy/Two/PostTransformer.php#L47).
  - This PR updates that to use `v3/signups` instead of `v2/activity`, that [returns text instead of caption](https://github.com/DoSomething/rogue/blob/master/app/Http/Transformers/PostTransformer.php#L41) and what the Post component expects when rendering the post's text.
 
#### How should this be reviewed?
👀 

#### Relevant tickets
I swear this now fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156813946) Pivotal card. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
