### PR TITLE
v3/signups/:signup_id?include=posts bug

### DIFF
--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -119,11 +119,6 @@ class SignupsController extends ApiController
      */
     public function show(Request $request, Signup $signup)
     {
-        // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
-        if ($request->query('include') === 'posts') {
-            $signup = Signup::with('visiblePosts')->find($signup->id);
-        }
-
         return $this->item($signup, 200, [], $this->transformer, $request->query('include'));
     }
 

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -121,8 +121,7 @@ class SignupsController extends ApiController
     {
         // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
         if ($request->query('include') === 'posts') {
-            $signups = Signup::withVisiblePosts()->get();
-            $signup = $signups->keyBy('id')[$signup->id];
+            $signup = Signup::with('posts')->find($signup->id);
         }
 
         return $this->item($signup, 200, [], $this->transformer, $request->query('include'));

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -121,7 +121,8 @@ class SignupsController extends ApiController
     {
         // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
         if ($request->query('include') === 'posts') {
-            $signup = Signup::withVisiblePosts()->first();
+            $signups = Signup::withVisiblePosts()->get();
+            $signup = $signups->keyBy('id')[$signup->id];
         }
 
         return $this->item($signup, 200, [], $this->transformer, $request->query('include'));

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -121,7 +121,7 @@ class SignupsController extends ApiController
     {
         // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
         if ($request->query('include') === 'posts') {
-            $signup = Signup::with('posts')->find($signup->id);
+            $signup = Signup::with('visiblePosts')->find($signup->id);
         }
 
         return $this->item($signup, 200, [], $this->transformer, $request->query('include'));

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -52,7 +52,8 @@ class SignupTransformer extends TransformerAbstract
      */
     public function includePosts(Signup $signup)
     {
-        $post = $signup->posts;
+        // Only allow an admin or the user who owns the signup to see the signup's unapproved posts.
+        $post = $signup->visiblePosts;
 
         return $this->collection($post, new PostTransformer);
     }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -61,6 +61,16 @@ class Signup extends Model
      */
     public function posts()
     {
+        return $this->hasMany(Post::class)->with('tags');
+    }
+
+    /**
+     * Get the visible posts associated with this signup.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function visiblePosts()
+    {
         if (! is_staff_user()) {
             return $this->hasMany(Post::class)->where('status', '=', 'accepted')
                                               ->orWhere('northstar_id', auth()->id())

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -61,6 +61,12 @@ class Signup extends Model
      */
     public function posts()
     {
+        if (! is_staff_user()) {
+            return $this->hasMany(Post::class)->where('status', '=', 'accepted')
+                                              ->orWhere('northstar_id', auth()->id())
+                                              ->with('tags');
+        }
+
         return $this->hasMany(Post::class)->with('tags');
     }
 

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -422,7 +422,7 @@ class Signup extends React.Component {
             </div>
 
             <div className="container__row">
-              <button className="button delete -tertiary" onClick={e => this.deleteSignup(signup.signup_id, e)}>Delete Signup</button>
+              <button className="button delete -tertiary" onClick={e => this.deleteSignup(signup.id, e)}>Delete Signup</button>
             </div>
 
             <MetaInformation

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -309,6 +309,68 @@ class SignupTest extends TestCase
     }
 
     /**
+     * Test for signup show with included pending post info. as non-admin/non-owner.
+     * Only admins/owners should be able to see pending/rejected posts.
+     *
+     * GET /api/v3/signups/:signup_id?include=posts
+     * @return void
+     */
+    public function testSignupShowWithIncludedPostsAsNonAdminNonOwner()
+    {
+        $post = factory(Post::class)->create();
+        $signup = $post->signup;
+
+        // Test with annoymous user that no posts are returned.
+        $response = $this->getJson('api/v3/signups/' . $signup->id . '?include=posts');
+        $response->assertStatus(200);
+        $decodedResponse = $response->decodeResponseJson();
+
+        $this->assertEquals(true, empty($decodedResponse['data']['posts']['data']));
+    }
+
+    /**
+     * Test for signup show with included pending post info. as admin
+     * Only admins/owners should be able to see pending/rejected posts.
+     *
+     * GET /api/v3/signups/:signup_id?include=posts
+     * @return void
+     */
+    public function testSignupShowWithIncludedPostsAsAdmin()
+    {
+        $post = factory(Post::class)->create();
+        $signup = $post->signup;
+
+        // Test with admin that posts are returned.
+        $response = $this->withAdminAccessToken()->getJson('api/v3/signups/' . $signup->id . '?include=posts');
+        $response->assertStatus(200);
+        $decodedResponse = $response->decodeResponseJson();
+
+        $this->assertEquals(false, empty($decodedResponse['data']['posts']['data']));
+        $this->assertEquals($signup->id, $decodedResponse['data']['posts']['data'][0]['signup_id']);
+    }
+
+    /**
+     * Test for signup show with included pending post info. as owner
+     * Only admins/owners should be able to see pending/rejected posts.
+     *
+     * GET /api/v3/signups/:signup_id?include=posts
+     * @return void
+     */
+    public function testSignupShowWithIncludedPostsAsOwner()
+    {
+        $post = factory(Post::class)->create();
+        $signup = $post->signup;
+
+        // Test with admin that posts are returned.
+        $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/signups/' . $signup->id . '?include=posts');
+        $response->assertStatus(200);
+        $decodedResponse = $response->decodeResponseJson();
+
+        $this->assertEquals(false, empty($decodedResponse['data']['posts']['data']));
+        $this->assertEquals($signup->id, $decodedResponse['data']['posts']['data'][0]['signup_id']);
+    }
+
+    /**
      * Test for signup index with included user info. as admin.
      * Only admins/owners should be able to see all user info.
      *


### PR DESCRIPTION
#### What's this PR do?
- This PR fixes the bug when you hit `/v3/signup/:signup_id?include=posts`, it returns the incorrect signup (without the `?include=posts`, everything works fine).
  - This is because `withVisiblePosts()` returns a collection and it was grabbing the first post from this collection and always returning that instead of the one specified in the endpoint! 
  - This fix explicitly grabs the correct signup from the collection. 
- Also adds tests to make sure this is returning properly!
- Also fixes bug @aaronschachter pointed out that was introduced in #688 that deleting signup no longer works (we were sending `signup.signup_id` instead of `signup.id` which was changed when we changed to using v3 endpoint).

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/157064679) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
