### PR TITLE
adds max width and max height to Post Request

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -34,7 +34,7 @@ class PostRequest extends Request
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',
             'quantity' => 'nullable|integer',
-            'file' => 'image|dimensions:min_width=400,min_height=400',
+            'file' => 'image|dimensions:min_width=400,min_height=400,max_width=5000,max_height_3500',
             'status' => $this->getStatusRules($this->type),
             'details'=> 'json',
         ];

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -34,7 +34,7 @@ class PostRequest extends Request
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',
             'quantity' => 'nullable|integer',
-            'file' => 'image|dimensions:min_width=400,min_height=400,max_width=5000,max_height_3500',
+            'file' => 'image|dimensions:min_width=400,min_height=400,max_width=5000,max_height_4000',
             'status' => $this->getStatusRules($this->type),
             'details'=> 'json',
         ];


### PR DESCRIPTION
#### What's this PR do?
- Adds `max_width` and `max_height` to Post Request. 
  - We were seeing a lot of errors in Papertrail saying these images didn't exist when they actually do. 
  - All these images were fairly large - we are thinking if we limit them to be smaller then this won't break anymore. 
  - More context [here](https://github.com/orgs/DoSomething/teams/team-bleed/discussions/27). 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/157050126) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
