### PR TITLE
v3 posts index to not return posts tagged "Hide In Gallery" by default

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -71,15 +71,16 @@ class PostsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)
-            ->orderBy('created_at', 'desc')
-            // by default, do not return posts hidden from the gallery
-            ->withoutTag('hide-in-gallery');
+            ->orderBy('created_at', 'desc');
 
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Post::$indexes);
 
         // Only allow admins or staff to see un-approved posts from other users.
         $query = $query->whereVisible();
+
+        // Only return posts tagged "Hide In Gallery" if staff user or if is owner of the post.
+        $query = $query->withHiddenPosts();
 
         // If tag param is passed, only return posts that have that tag.
         if (array_has($filters, 'tag')) {

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -71,7 +71,9 @@ class PostsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(Post::class)
-            ->orderBy('created_at', 'desc');
+            ->orderBy('created_at', 'desc')
+            // by default, do not return posts hidden from the gallery
+            ->withoutTag('hide-in-gallery');
 
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Post::$indexes);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -338,4 +338,19 @@ class Post extends Model
                          ->orWhere('northstar_id', auth()->id());
         }
     }
+
+    /**
+     * Scope a query to only return posts tagged as "Hide In Gallery" if a user is an admin, staff, or is owner of post.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithHiddenPosts($query)
+    {
+        if ((! token()->exists()) || (! in_array(token()->role, ['admin', 'staff']))) {
+            return $query->whereDoesntHave('tags', function ($query) {
+                $query->where('tag_slug', 'hidden-in-gallery');
+            })
+                ->orWhere('northstar_id', auth()->id());
+        }
+    }
 }

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -7,7 +7,7 @@ All `v3 /posts` endpoints require the `activity` scope. `Create`/`update`/`delet
 GET /api/v3/posts
 ```
 
-Posts are returned in reverse chronological order.
+Posts are returned in reverse chronological order. By default, posts that are tagged "Hide In Gallery" are not returned.
 
 Only admins and post owners will have `tags`, `source`, and `remote_addr` returned in the response.
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -7,9 +7,9 @@ All `v3 /posts` endpoints require the `activity` scope. `Create`/`update`/`delet
 GET /api/v3/posts
 ```
 
-Posts are returned in reverse chronological order. By default, posts that are tagged "Hide In Gallery" are not returned.
+Posts are returned in reverse chronological order.
 
-Only admins and post owners will have `tags`, `source`, and `remote_addr` returned in the response.
+Only admins and post owners will have `tags`, `source`, `remote_addr`, and hidden posts (posts that are tagged 'Hide In Gallery') returned in the response.
 
 Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 


### PR DESCRIPTION
#### What's this PR do?
- Updates `/v3/posts` index to not return posts tagged "Hide In Gallery" by default

#### How should this be reviewed?
👀 
- Hit this endpoint
- No posts that are tagged "Hide In Gallery" should be returned! 

#### Any background context you want to provide?
The You've Got The Power gallery was showing posts that were tagged "Hide In Gallery" because it is using the `v3` endpoint and it hasn't been updated to not include these! 

Update [this](https://www.pivotaltracker.com/n/projects/2019429/stories/157411893) Pivotal Card. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
