### PR TITLE
Updates v3/tags endpoint to toggle and updates front end to use this endpoint

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -63,24 +63,4 @@ class TagsController extends ApiController
 
         return $this->item($updatedPost);
     }
-
-    /**
-     * Remove a tag from a post.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @param  Post $post
-     * @return \Illuminate\Http\Response
-     */
-    // public function destroy(Request $request, Post $post)
-    // {
-    //     $request->validate([
-    //         'tag_name' => 'required|string',
-    //     ]);
-
-    //     $post = $this->post->find($post->id);
-
-    //     $untaggedPost = $this->post->untag($post, $request->tag_name);
-
-    //     return $this->item($untaggedPost);
-    // }
 }

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -57,7 +57,7 @@ class TagsController extends ApiController
         // If the post already has the tag, remove it. Otherwise, add the tag to the post.
         if ($post->tagNames()->contains($request->tag_name)) {
             $updatedPost = $this->post->untag($post, $request->tag_name);
-         } else {
+        } else {
             $updatedPost = $this->post->tag($post, $request->tag_name);
         }
 

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -40,7 +40,7 @@ class TagsController extends ApiController
     }
 
     /**
-     * Store a newly created resource in storage.
+     * Updates a post's tags when added or deleted.
      *
      * @param  \Illuminate\Http\Request $request
      * @param  Post $post
@@ -54,9 +54,14 @@ class TagsController extends ApiController
 
         $post = $this->post->find($post->id);
 
-        $taggedPost = $this->post->tag($post, $request->tag_name);
+        // If the post already has the tag, remove it. Otherwise, add the tag to the post.
+        if ($post->tagNames()->contains($request->tag_name)) {
+            $updatedPost = $this->post->untag($post, $request->tag_name);
+         } else {
+            $updatedPost = $this->post->tag($post, $request->tag_name);
+        }
 
-        return $this->item($taggedPost);
+        return $this->item($updatedPost);
     }
 
     /**
@@ -66,16 +71,16 @@ class TagsController extends ApiController
      * @param  Post $post
      * @return \Illuminate\Http\Response
      */
-    public function destroy(Request $request, Post $post)
-    {
-        $request->validate([
-            'tag_name' => 'required|string',
-        ]);
+    // public function destroy(Request $request, Post $post)
+    // {
+    //     $request->validate([
+    //         'tag_name' => 'required|string',
+    //     ]);
 
-        $post = $this->post->find($post->id);
+    //     $post = $this->post->find($post->id);
 
-        $untaggedPost = $this->post->untag($post, $request->tag_name);
+    //     $untaggedPost = $this->post->untag($post, $request->tag_name);
 
-        return $this->item($untaggedPost);
-    }
+    //     return $this->item($untaggedPost);
+    // }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -60,16 +60,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.55.10",
+            "version": "3.55.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "88247c9eedb1083781847e09508b7daf28c90149"
+                "reference": "5177cbe73c96d25ff759e406ac81b8e25557482c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/88247c9eedb1083781847e09508b7daf28c90149",
-                "reference": "88247c9eedb1083781847e09508b7daf28c90149",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5177cbe73c96d25ff759e406ac81b8e25557482c",
+                "reference": "5177cbe73c96d25ff759e406ac81b8e25557482c",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +136,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-05-10T02:27:29+00:00"
+            "time": "2018-05-10T23:23:00+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -793,16 +793,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.14.6",
+            "version": "v1.14.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "58c68e3746fc4fb93f08bbd711f0cd97cd978b8f"
+                "reference": "75386ce29795188b3eb4b276f21f216290c1eff0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/58c68e3746fc4fb93f08bbd711f0cd97cd978b8f",
-                "reference": "58c68e3746fc4fb93f08bbd711f0cd97cd978b8f",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/75386ce29795188b3eb4b276f21f216290c1eff0",
+                "reference": "75386ce29795188b3eb4b276f21f216290c1eff0",
                 "shasum": ""
             },
             "require": {
@@ -850,7 +850,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2018-03-28T17:18:05+00:00"
+            "time": "2018-05-14T18:51:22+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -33,5 +33,4 @@ Endpoint                                       | Functionality
 #### Tags
 Endpoint                                       | Functionality
 ---------------------------------------------- | --------------------------------------------------------
-`POST /api/v3/posts/:post_id/tags`             | [Tag a Post](tags.md#tag-a-post)
-`DELETE /api/v3/posts/:post_id/tags`           | [Delete a Tag from a Post](tags.md#delete-a-tag-from-a-post)
+`POST /api/v3/posts/:post_id/tags`             | [Tag or Untag a Post](tags.md#tag-or-untag-a-post)

--- a/docs/endpoints/tags.md
+++ b/docs/endpoints/tags.md
@@ -1,7 +1,7 @@
 ## Tags
 All `v3 /posts/{post}/tags` endpoints require the `activity` scope. `Create`/`update`/`delete` endpoints also require the `write` scope.
 
-## Tag a Post
+## Tag or untag a Post
 
 ```
 POST /api/v3/posts/:post_id/tags
@@ -35,41 +35,6 @@ Example Response:
         "remote_addr": "142.55.196.64",
         "created_at": "2018-01-26T16:25:16+00:00",
         "updated_at": "2018-01-26T21:17:39+00:00"
-    }
-}
-```
-
-## Delete a Tag From a Post
-```
-DELETE /api/v3/posts/:post_id/tags
-```
-  - **tag_name**: (int|string) required.
-    The tag you want to delete from the post
-
-Example Response:
-
-```
-{
-    "data": {
-        "id": 2,
-        "signup_id": 1,
-        "northstar_id": "561563f9a59dbfbe378b4567",
-        "media": {
-            "url": "http://rogue.test/images/2",
-            "original_image_url": "http://rogue.test/storage/uploads/reportback-items/76154-6dba2dea32f35e93c6ec7c70e1f3ceab-1517245151.jpeg?time=1517262927",
-            "caption": "Dolores vitae amet animi eos libero porro."
-        },
-        "quantity": 41,
-        "tags": [],
-        "reactions": {
-            "reacted": false,
-            "total": null
-        },
-        "status": "pending",
-        "source": "phoenix-next",
-        "remote_addr": "50.59.121.68",
-        "created_at": "2018-01-29T16:59:11+00:00",
-        "updated_at": "2018-01-29T21:55:27+00:00"
     }
 }
 ```

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -61,7 +61,7 @@ class Post extends React.Component {
     const quantity = post.quantity != null ? post.quantity : 0;
     const containerSize = post.type === 'photo' ? '-third' : '-half';
     const textOrCaption = post.type === 'photo' ? 'Photo Caption' : 'Text';
-
+    console.log(post.media.text);
     return (
       <div className="post container__row">
         {/* Post Images */}

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -61,7 +61,7 @@ class Post extends React.Component {
     const quantity = post.quantity != null ? post.quantity : 0;
     const containerSize = post.type === 'photo' ? '-third' : '-half';
     const textOrCaption = post.type === 'photo' ? 'Photo Caption' : 'Text';
-    console.log(post.media.text);
+
     return (
       <div className="post container__row">
         {/* Post Images */}

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -193,14 +193,13 @@ class Signup extends React.Component {
   }
 
   // Tag a post.
-  updateTag(postId, tag, requestMethod) {
-    const fields = {
-      post_id: postId,
+  updateTag(postId, tag) {
+    const field = {
       tag_name: tag,
     };
 
     // Check to see if we are creating or deleting this tag.
-    const response = requestMethod === 'POST' ? this.api.post(`api/v3/posts/${postId}/tags`, fields) : this.api.delete(`api/v3/posts/${postId}/tags`, fields);
+    const response = this.api.post(`api/v3/posts/${postId}/tags`, field);
 
     return response.then((result) => {
       this.setState((previousState) => {

--- a/resources/assets/components/Tags/index.js
+++ b/resources/assets/components/Tags/index.js
@@ -23,9 +23,7 @@ class Tag extends React.Component {
 
     this.setState({ sending: true });
 
-    const requestMethod = isActive ? 'DELETE' : 'POST';
-
-    this.props.isClicked(post, label, requestMethod)
+    this.props.isClicked(post, label)
       .then(() => {
         this.setState({ sending: false });
       });

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -127,7 +127,6 @@ const reviewComponent = (Component, data) => {
     // Tag a post.
     updateTag(postId, tag) {
       const field = {
-        // post_id: postId,
         tag_name: tag,
       };
 

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -126,12 +126,12 @@ const reviewComponent = (Component, data) => {
 
     // Tag a post.
     updateTag(postId, tag) {
-      const fields = {
-        post_id: postId,
+      const field = {
+        // post_id: postId,
         tag_name: tag,
       };
 
-      let response = this.api.post('tags', fields);
+      let response = this.api.post(`api/v3/posts/${postId}/tags`, field);
 
       return response.then((result) => {
         this.setState((previousState) => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -75,5 +75,5 @@ $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function (
 
     // tag
     $this->post('posts/{post}/tags', 'TagsController@store');
-    $this->delete('posts/{post}/tags', 'TagsController@destroy');
+    // $this->delete('posts/{post}/tags', 'TagsController@destroy');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -75,5 +75,4 @@ $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function (
 
     // tag
     $this->post('posts/{post}/tags', 'TagsController@store');
-    // $this->delete('posts/{post}/tags', 'TagsController@destroy');
 });


### PR DESCRIPTION
#### What's this PR do?
- Updates `v3/tags` endpoint to toggle (instead of having a separate `POST /v3/posts/{post}/tags` and `DELETE /v3/posts/{post}/tags` endpoints.
- Updates front end to use `v3/tags` endpoint instead of `tags` endpoint.
- Fixes bug where post's text/caption disappears when tagging. 

#### How should this be reviewed?
- All tests should pass! 

#### Relevant tickets
Fixes these Pivotal cards: 
- [When you apply any tag it seems, the caption disappears](https://www.pivotaltracker.com/n/projects/2019429/stories/157204400)
- [Update v3 tags endpoint to function more like a toggle (similar to v3 reactions)](https://www.pivotaltracker.com/n/projects/2019429/stories/156656870)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
