### PR TITLE
if there is no campaign id, handles error gracefully

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -78,7 +78,6 @@ class CampaignService
             $this->cache->store($id, $campaign['data'], 1440);
 
             $campaign = $campaign['data'];
-            // dd($campaign);
         }
 
         return $campaign;

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -55,14 +55,30 @@ class CampaignService
             // @TODO: change this to grab from Phoenix when Phoenix returns all info. we need!
             $campaign = $this->ashes->getCampaign($id);
 
+            // Handle cases where the ID was not found.
             if (empty($campaign['data']['id'])) {
-                info('missing_campaign_data', compact('id', 'campaign'));
+                $placeholder = [
+                    'id' => $id,
+                    'title' => 'Unknown Campaign (' . $id . ')',
+                    'staff_pick' => false,
+                    'causes' => [
+                        'primary' => [
+                            'name' => null,
+                        ],
+                    ],
+                    'uri' => null,
+                ];
+
+                $this->cache->store($id, $placeholder, 1440);
+
+                return $placeholder;
             }
 
             // Cache campaign for a day.
-            $this->cache->store($campaign['data']['id'], $campaign['data'], 1440);
+            $this->cache->store($id, $campaign['data'], 1440);
 
             $campaign = $campaign['data'];
+            // dd($campaign);
         }
 
         return $campaign;


### PR DESCRIPTION
#### What's this PR do?
- If there is no `campaign_id`, mock campaign array we would get from Ashes to handle error gracefully and prevent entire page from crashing. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This is related to #700 when we saw an error in production where `/campaigns` was throwing a `500` error. This was because there was a signup record with no `campaign_id` and caused the page to crash. If this happens in the future, we want to handle this error in a more graceful manner.

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/157673595) Pivotal card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
