### PR TITLE
Remove detailed logging of POST api/v3/posts endpoint

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -98,7 +98,6 @@ class PostsController extends ApiController
      */
     public function store(PostRequest $request)
     {
-        info('PostController@store: Request Recieved', ['request' => $request->all()]);
         $northstarId = getNorthstarId($request);
 
         $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
@@ -106,11 +105,8 @@ class PostsController extends ApiController
         if (! $signup) {
             $signup = $this->signups->create($request->all(), $northstarId);
         }
-        info('PostController@store: Getting signup for post', ['signup' => $signup]);
 
         $post = $this->posts->create($request->all(), $signup->id);
-
-        info('PostController@store: Post created', ['post' => $post]);
 
         return $this->item($post, 201, [], null, 'signup');
     }

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -40,7 +40,6 @@ class PostManager
      */
     public function create($data, $signupId, $authenticatedUserRole = null)
     {
-        info('PostManager@create: Request Recieved', ['params' => func_get_args()]);
         $post = $this->repository->create($data, $signupId, $authenticatedUserRole);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -66,14 +66,11 @@ class PostRepository
      */
     public function create(array $data, $signupId, $authenticatedUserRole = null)
     {
-        info('PostRepository@create: Request Recieved', ['params' => func_get_args()]);
         if (isset($data['file'])) {
-            info('PostRepository@create: File found in request');
             // Auto-orient the photo by default based on exif data.
             $image = Image::make($data['file']);
-            info('PostRepository@create: Image made');
+
             $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
-            info('PostRepository@create: File stored', ['fileUrl' => $fileUrl]);
         } else {
             $fileUrl = null;
         }
@@ -96,13 +93,12 @@ class PostRepository
             'details' => isset($data['details']) ? $data['details'] : null,
             'remote_addr' => request()->ip(),
         ]);
-        info('PostRepository@create: post created', ['post' => $post]);
+
         $isAdmin = auth()->user() && auth()->user()->role === 'admin';
         $hasAdminScope = in_array('admin', token()->scopes());
 
         // Admin users may provide a source and status when uploading a post.
         if ($isAdmin || $hasAdminScope) {
-            info('PostRepository@create: admin user trying to set status or source');
             $post->status = isset($data['status']) ? $data['status'] : 'pending';
             $post->source = isset($data['source']) ? $data['source'] : token()->client();
         }
@@ -111,7 +107,6 @@ class PostRepository
 
         // Edit the image if there is one
         if (isset($data['file'])) {
-            info('PostRepository@create: Editing image file');
             $this->crop($data, $post->id);
         }
 

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -22,17 +22,13 @@ class AWS
      */
     public function storeImage($file, $filename)
     {
-        info('PostRepository@storeImage: Request Received ');
         if (is_string($file)) {
-            info('PostRepository@storeImage: File is given as a string', ['is_string($file)' => is_string($file)]);
             $data = $this->base64StringToDataString($file);
         } else {
-            info('PostRepository@storeImage: File is not given as a string');
             $data = file_get_contents($file->getPathname());
         }
 
         $extension = $this->guessExtension($data);
-        info('PostRepository@storeImage: Got image extension', ['extension' => $extension]);
 
         // Make sure we're only uploading valid image types
         if (! in_array($extension, ['jpeg', 'png', 'gif'])) {
@@ -44,13 +40,11 @@ class AWS
         $path = 'uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
 
         // Push file to S3.
-        info('PostRepository@storeImage: Pushing file to s3');
         $success = Storage::put($path, $data);
-        info('PostRepository@storeImage: Image stored successfully', ['success' => $success]);
+
         if (! $success) {
             throw new HttpException(500, 'Unable to save image to S3.');
         }
-        info('PostRepository@storeImage: Image path to return', ['path' => Storage::url($path)]);
 
         return Storage::url($path);
     }


### PR DESCRIPTION
#### What's this PR do?

During the recent outage on 5/19/18 we adding a bunch of log messages around the `POST api/v3/posts` route to see if there was an issue there. 

This is just some clean up since that was not the issue. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?
https://github.com/DoSomething/devops/issues/408

#### Relevant tickets
 Clean up

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
