### PR TITLE
Adds "view" logic to post policy

### DIFF
--- a/app/Http/Transformers/Legacy/Two/PostTransformer.php
+++ b/app/Http/Transformers/Legacy/Two/PostTransformer.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Http\Transformers\Legacy\Two;
 
-use Gate;
 use Carbon\Carbon;
 use Rogue\Models\Post;
 use League\Fractal\TransformerAbstract;
@@ -32,7 +31,7 @@ class PostTransformer extends TransformerAbstract
             $reacted = $post->reactions->isNotEmpty();
         }
 
-        $response = [
+        return [
             'id' => $post->id,
             'signup_id' => $post->signup_id,
             'northstar_id' => $post->northstar_id,
@@ -47,21 +46,17 @@ class PostTransformer extends TransformerAbstract
                 'original_image_url' => $post->url . '?time='. Carbon::now()->timestamp,
                 'caption' => $post->text,
             ],
+            'tags' => $post->tagSlugs(),
             'reactions' => [
                 'reacted' => $reacted,
                 'total' => isset($post->reactions_count) ? $post->reactions_count : null,
             ],
             'status' => $post->status,
+            'source' => $post->source,
+            'remote_addr' => $post->remote_addr,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];
-
-        if (Gate::allows('viewAll', $post)) {
-            $response['tags'] = $post->tagSlugs();
-            $response['source'] = $post->source;
-        }
-
-        return $response;
     }
 
     /**

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Transformers;
 
+use Gate;
 use Carbon\Carbon;
 use Rogue\Models\Post;
 use League\Fractal\TransformerAbstract;
@@ -50,7 +51,7 @@ class PostTransformer extends TransformerAbstract
             'updated_at' => $post->updated_at->toIso8601String(),
         ];
 
-        if (is_staff_user() || auth()->id() === $post->northstar_id) {
+        if (Gate::allows('viewAll', $post)) {
             $response['tags'] = $post->tagSlugs();
             $response['source'] = $post->source;
             $response['source_details'] = $post->source_details;

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -20,6 +20,22 @@ class PostPolicy
     }
 
     /**
+      * Determine if the full post should be displayed.
+      *
+      * @param  Illuminate\Contracts\Auth\Authenticatable $user
+      * @param  Rogue\Models\Post $post
+      * @return bool
+      */
+    public function viewAll($user, Post $post)
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        return is_staff_user() || $user->northstar_id === $post->northstar_id;
+    }
+
+    /**
      * Determine if the given post can be seen by the user.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -20,12 +20,12 @@ class PostPolicy
     }
 
     /**
-      * Determine if the full post should be displayed.
-      *
-      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-      * @param  Rogue\Models\Post $post
-      * @return bool
-      */
+     * Determine if the full post should be displayed.
+     *
+     * @param  Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  Rogue\Models\Post $post
+     * @return bool
+     */
     public function viewAll($user, Post $post)
     {
         if ($user === null) {


### PR DESCRIPTION
#### What's this PR do?
Adds "view" logic to Post Policy (that should have been added in #702 !) 

#### How should this be reviewed?
- Only admins / owners should be able to see a Post's `tags`, `source`, `source_details`, `remote_addr`, and `details` via the API.

#### Any background context you want to provide?
I noticed that for `v2`, anyone gets `tags` and `source` - should we update this as well? Since we don't use access tokens though I'm not sure if this is possible? 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156700437) Pivotal Card and finishes up #702 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
