### PR TITLE
Fixes bug to actually delete from s3 when a post is deleted and adds fastly purge to GDPR script

### DIFF
--- a/EU_members_local.csv
+++ b/EU_members_local.csv
@@ -1,0 +1,4 @@
+,Users Northstar ID,Users Count Distinct Northstar ID
+1,564f36aca59dbf3e6b8b4cfb,1
+2,5589c991a59dbfa93d8b45ae,1
+3,56d5baa7a59dbf106b8b45aa,1

--- a/EU_members_local.csv
+++ b/EU_members_local.csv
@@ -1,4 +1,0 @@
-,Users Northstar ID,Users Count Distinct Northstar ID
-1,564f36aca59dbf3e6b8b4cfb,1
-2,5589c991a59dbfa93d8b45ae,1
-3,56d5baa7a59dbf106b8b45aa,1

--- a/app/Console/Commands/GDPRComplianceCommand.php
+++ b/app/Console/Commands/GDPRComplianceCommand.php
@@ -96,9 +96,9 @@ class GDPRComplianceCommand extends Command
             // Anonymize all caption values, delete image URLs from s3, and tag all posts as hide-in-gallery.
             foreach ($posts as $post) {
                 $post->text = 'EU Member. Removed because of GDPR';
-                // dd($post->id);
+
                 $this->aws->deleteImage($post->url);
-                // $this->fastly->purgeKey('post-'.$post->id);
+                $this->fastly->purgeKey('post-'.$post->id);
 
                 $post->url = null;
 

--- a/app/Console/Commands/GDPRComplianceCommand.php
+++ b/app/Console/Commands/GDPRComplianceCommand.php
@@ -96,9 +96,9 @@ class GDPRComplianceCommand extends Command
             // Anonymize all caption values, delete image URLs from s3, and tag all posts as hide-in-gallery.
             foreach ($posts as $post) {
                 $post->text = 'EU Member. Removed because of GDPR';
-
+                // dd($post->id);
                 $this->aws->deleteImage($post->url);
-                $this->fastly->purgeKey('post-'.$post->id);
+                // $this->fastly->purgeKey('post-'.$post->id);
 
                 $post->url = null;
 

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -12,6 +12,13 @@ use Rogue\Jobs\SendReviewedPostToCustomerIo;
 
 class PostManager
 {
+    /**
+     * The Fastly service instance
+     *
+     * @var Rogue\Services\Fastly
+     */
+    protected $fastly;
+
     /*
      * PostRepository Instance
      *
@@ -25,9 +32,10 @@ class PostManager
      * @param PostRepository $posts
      * @param Blink $blink
      */
-    public function __construct(PostRepository $posts)
+    public function __construct(PostRepository $posts, Fastly $fastly)
     {
         $this->repository = $posts;
+        $this->fastly = $fastly;
     }
 
     /**

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -3,6 +3,7 @@
 namespace Rogue\Managers;
 
 use Rogue\Models\Post;
+use Rogue\Services\Fastly;
 use Rogue\Jobs\SendPostToQuasar;
 use Rogue\Jobs\SendPostToCustomerIo;
 use Rogue\Repositories\PostRepository;
@@ -121,6 +122,10 @@ class PostManager
         ]);
 
         $trashed = $this->repository->destroy($postId);
+
+        if ($trashed) {
+            $this->fastly->purgeKey('post-'.$postId);
+        }
 
         // Dispatch job to send post to Quasar
         SendDeletedPostToQuasar::dispatch($postId);

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -119,6 +119,7 @@ class AWS
         // any exception that is thrown while trying to delete and just returns true.
         // see: \Illuminate\Filesystem\FilesystemAdapter::delete().
         // So we check if the file exists first and then try to delete it.
+        dd('sending ' . $path . ' to storage');
         if (Storage::exists($path)) {
             $success = Storage::delete($path);
         } else {

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -119,7 +119,7 @@ class AWS
         // any exception that is thrown while trying to delete and just returns true.
         // see: \Illuminate\Filesystem\FilesystemAdapter::delete().
         // So we check if the file exists first and then try to delete it.
-        dd('sending ' . $path . ' to storage');
+        dump('sending to exists ' . $path);
         if (Storage::exists($path)) {
             $success = Storage::delete($path);
         } else {

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -120,7 +120,6 @@ class AWS
         // any exception that is thrown while trying to delete and just returns true.
         // see: \Illuminate\Filesystem\FilesystemAdapter::delete().
         // So we check if the file exists first and then try to delete it.
-        Log::info('sending to exists ' . $path);
         if (Storage::exists($path)) {
             $success = Storage::delete($path);
         } else {

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -114,12 +114,13 @@ class AWS
     {
         // We need to use the relative url for the request to s3.
         $path = basename($path);
+        $path = 'uploads/reportback-items' . '/' . $path;
 
         // The delete() method always returns true because it doesn't seem to do anything with
         // any exception that is thrown while trying to delete and just returns true.
         // see: \Illuminate\Filesystem\FilesystemAdapter::delete().
         // So we check if the file exists first and then try to delete it.
-        dump('sending to exists ' . $path);
+        Log::info('sending to exists ' . $path);
         if (Storage::exists($path)) {
             $success = Storage::delete($path);
         } else {

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -7,6 +7,7 @@ use Rogue\Models\Post;
 use Rogue\Models\User;
 use Rogue\Models\Signup;
 use Rogue\Models\Reaction;
+use Rogue\Services\Fastly;
 use DoSomething\Gateway\Blink;
 use Illuminate\Http\UploadedFile;
 
@@ -1092,6 +1093,10 @@ class PostTest extends TestCase
 
         // Mock time of when the post is soft deleted.
         $this->mockTime('8/3/2017 14:00:00');
+
+        // Mock the Fastly API calls.
+        $this->mock(Fastly::class)
+            ->shouldReceive('purgeKey');
 
         $response = $this->withAdminAccessToken()->deleteJson('api/v3/posts/' . $post->id);
 


### PR DESCRIPTION
#### What's this PR do?
Fixes bug to actually delete from s3 when a post is deleted and adds fastly purge to GDPR script in #709 

#### How should this be reviewed?
Delete a post (via API or by running GDPR script) - the url should also be deleted from s3! 

#### Any background context you want to provide?
@DoSomething/team-bleed since this wasn't working before, do we need to do any work to delete images for posts that have been soft deleted? Is this even possible to find the file names again? 

#### Relevant tickets
More work to fix [this](https://www.pivotaltracker.com/n/projects/2019429/stories/157709055) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
