### PR TITLE
Removes type-hint so non-user apps can use update post policy method

### DIFF
--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -3,7 +3,6 @@
 namespace Rogue\Policies;
 
 use Rogue\Models\Post;
-use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class PostPolicy

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -21,7 +21,7 @@ class PostPolicy
     /**
      * Determine if the full post should be displayed.
      *
-     * @param  $user
+     * @param  Illuminate\Contracts\Auth\Authenticatable $user
      * @param  Rogue\Models\Post $post
      * @return bool
      */
@@ -37,7 +37,7 @@ class PostPolicy
     /**
      * Determine if the given post can be seen by the user.
      *
-     * @param  $user
+     * @param  Illuminate\Contracts\Auth\Authenticatable $user
      * @param  Rogue\Models\Post $post
      * @return bool
      */
@@ -55,12 +55,16 @@ class PostPolicy
     /**
      * Determine if the given post can be updated by the user.
      *
-     * @param  $user
+     * @param  Illuminate\Contracts\Auth\Authenticatable $user
      * @param  Rogue\Models\Post $post
      * @return bool
      */
     public function update($user, Post $post)
     {
-        return is_staff_user() || $user->northstar_id === $post->northstar_id;
+        if (is_staff_user()) {
+            return true;
+        }
+
+        return $user && $user->northstar_id === $post->northstar_id;
     }
 }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -22,7 +22,7 @@ class PostPolicy
     /**
      * Determine if the full post should be displayed.
      *
-     * @param  Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  $user
      * @param  Rogue\Models\Post $post
      * @return bool
      */
@@ -38,7 +38,7 @@ class PostPolicy
     /**
      * Determine if the given post can be seen by the user.
      *
-     * @param  Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  $user
      * @param  Rogue\Models\Post $post
      * @return bool
      */
@@ -56,11 +56,11 @@ class PostPolicy
     /**
      * Determine if the given post can be updated by the user.
      *
-     * @param  Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  $user
      * @param  Rogue\Models\Post $post
      * @return bool
      */
-    public function update(Authenticatable $user, Post $post)
+    public function update($user, Post $post)
     {
         return is_staff_user() || $user->northstar_id === $post->northstar_id;
     }


### PR DESCRIPTION
#### What's this PR do?
Removes `Authenticatable` type-hint so non-user apps can use update post policy method.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
We need to remove this so Chompy can finish updating! 

#### Relevant tickets
Slack thread [here](https://dosomething.slack.com/archives/C0YGXUE01/p1527701337000521).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
