### PR TITLE
removes image validation from v2 posts

### DIFF
--- a/app/Http/Requests/Legacy/Two/PostRequest.php
+++ b/app/Http/Requests/Legacy/Two/PostRequest.php
@@ -31,7 +31,7 @@ class PostRequest extends Request
             'caption' => 'nullable|string',
             'status' => 'in:pending,accepted,rejected',
             'source' => 'nullable|string',
-            'file' => 'image|dimensions:min_width=400,min_height=400,max_width=5000,max_height_4000',
+            'file' => 'dimensions:min_width=400,min_height=400,max_width=5000,max_height_4000',
             'type' => 'string|in:photo,voter-reg,text',
             'action' => 'string',
         ];


### PR DESCRIPTION
#### What's this PR do?
removes image validation from v2 posts in case an image is sent in as base64 string

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes mistake in #718 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
