### PR TITLE
changes type option to mandatory argument in BulkReviewPosts command 

### DIFF
--- a/app/Console/Commands/BulkReviewPosts.php
+++ b/app/Console/Commands/BulkReviewPosts.php
@@ -61,13 +61,11 @@ class BulkReviewPosts extends Command
         $log = $this->option('log');
         $tags = $this->option('tag') ?? null;
 
-        $postQuery = Post::where([
+        $posts = Post::where([
             ['campaign_id', $this->argument('campaign')],
             ['status', $this->argument('oldStatus')],
             ['type', $this->argument('type')],
-        ]);
-
-        $posts = $postQuery->get();
+        ])->get();
 
         if ($posts->isNotEmpty()) {
             foreach ($posts as $post) {

--- a/app/Console/Commands/BulkReviewPosts.php
+++ b/app/Console/Commands/BulkReviewPosts.php
@@ -17,7 +17,7 @@ class BulkReviewPosts extends Command
                             {campaign}
                             {oldStatus}
                             {newStatus}
-                            {--type= : Filter by the type of post}
+                            {type}
                             {--logfreq=1000: Flag to decide how often this command will log when a post is being updated}
                             {--log : Flag to allow logging in Post Manager}
                             {--tag=* : Tag(s) slug to tag post by. e.g. hide-in-gallery}';
@@ -57,7 +57,6 @@ class BulkReviewPosts extends Command
     {
         info('rogue:bulkreviewposts: Starting to bulk review posts!');
 
-        $postType = $this->option('type') ?? null;
         $logfreq = $this->option('logfreq');
         $log = $this->option('log');
         $tags = $this->option('tag') ?? null;
@@ -65,11 +64,8 @@ class BulkReviewPosts extends Command
         $postQuery = Post::where([
             ['campaign_id', $this->argument('campaign')],
             ['status', $this->argument('oldStatus')],
+            ['type', $this->argument('type')],
         ]);
-
-        if ($postType !== null) {
-            $postQuery = $postQuery->where('type', $postType);
-        }
 
         $posts = $postQuery->get();
 


### PR DESCRIPTION
#### What's this PR do?
changes `type` option to mandatory argument in `BulkReviewPosts` command 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
For some reason, this query wasn't only looking for the `text` type when we ran in Thor (but worked as intended on local, even when I dumped out the thor db to my local). For extra safety measure, we decided to change the `type` option to a mandatory argument in the command.

#### Relevant tickets
Updates command made in #720 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
