### PR TITLE
Logs signup_created_source and post_created_source to set up StatHat Alerts 

### DIFF
--- a/app/Managers/Legacy/Two/PostManager.php
+++ b/app/Managers/Legacy/Two/PostManager.php
@@ -54,7 +54,7 @@ class PostManager
         SendSignupToQuasar::dispatch($post->signup);
 
         // Log that a post was created.
-        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id, 'source' => $post->source]);
+        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id, 'post_created_source' => $post->source]);
 
         return $post;
     }

--- a/app/Managers/Legacy/Two/PostManager.php
+++ b/app/Managers/Legacy/Two/PostManager.php
@@ -54,7 +54,7 @@ class PostManager
         SendSignupToQuasar::dispatch($post->signup);
 
         // Log that a post was created.
-        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id]);
+        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id, 'source' => $post->source]);
 
         return $post;
     }

--- a/app/Managers/Legacy/Two/SignupManager.php
+++ b/app/Managers/Legacy/Two/SignupManager.php
@@ -48,7 +48,7 @@ class SignupManager
         SendSignupToQuasar::dispatch($signup);
 
         // Log that a signup was created.
-        info('signup_created', ['id' => $signup->id, 'northstar_id' => $signup->northstar_id, 'source' => $signup->source]);
+        info('signup_created', ['id' => $signup->id, 'northstar_id' => $signup->northstar_id, 'signup_created_source' => $signup->source]);
 
         return $signup;
     }

--- a/app/Managers/Legacy/Two/SignupManager.php
+++ b/app/Managers/Legacy/Two/SignupManager.php
@@ -48,7 +48,7 @@ class SignupManager
         SendSignupToQuasar::dispatch($signup);
 
         // Log that a signup was created.
-        info('signup_created', ['id' => $signup->id, 'northstar_id' => $signup->northstar_id]);
+        info('signup_created', ['id' => $signup->id, 'northstar_id' => $signup->northstar_id, 'source' => $signup->source]);
 
         return $signup;
     }

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -62,7 +62,7 @@ class PostManager
         SendPostToQuasar::dispatch($post);
 
         // Log that a post was created.
-        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id, 'source' => $post->source]);
+        info('post_created', ['id' => $post->id, 'signup_id' => $post->signup_id, 'post_created_source' => $post->source]);
 
         return $post;
     }

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -50,7 +50,7 @@ class SignupManager
         SendSignupToQuasar::dispatch($signup);
 
         // Log that a signup was created.
-        info('signup_created', ['id' => $signup->id, 'source' => $signup->source]);
+        info('signup_created', ['id' => $signup->id, 'signup_created_source' => $signup->source]);
 
         return $signup;
     }


### PR DESCRIPTION
#### What's this PR do?
- Explicitly logs `signup_created_source` and `post_created_source` when a signup/post is created from either v2 or v3 endpoints so we can set up StatHat alerts for when we aren't receiving new signups/post from our top referrals (Phoenix, Ashes, Gambit). 

#### How should this be reviewed?
👀 

#### Relevant tickets
Continues work done in #727 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
