### PR TITLE
delete unneeded line that was breaking rotate function

### DIFF
--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -219,8 +219,6 @@ const reviewComponent = (Component, data) => {
 
     // Rotate a Post Image.
     rotate(postId) {
-      const post = this.state.posts[postId];
-
       let response = this.api.post(`images/${postId}?rotate=90`);
 
       return response.then(json => {


### PR DESCRIPTION
#### What's this PR do?
Delete unneeded line that was breaking rotate function - on the signup page, when trying to rotate, I got this error:
```
app-ab704991ec4dd340b523.js:25 Uncaught TypeError: Cannot read property '331804' of undefined
```
This line doesn't seem to do anything though so lets delete it! 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes error in #729 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
