### PR TITLE
Delete posts

### DIFF
--- a/app/Console/Commands/DeletePosts.php
+++ b/app/Console/Commands/DeletePosts.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Illuminate\Console\Command;
+use Rogue\Models\Post;
+
+class DeletePosts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:deleteposts
+                            {ids* : A space-separated list of post ids to delete}
+                            {--force : Whether or not to force delete these posts instead of soft delete (default)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete posts in Rogue by post id with an option to force delete';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $ids = $this->argument('ids');
+
+        $posts = Post::whereIn('id', $ids);
+
+        if ($this->option('force')) {
+            $posts->forceDelete();
+        } else {
+            $posts->delete();
+        }
+
+        $this->info('Posts Deleted!');
+    }
+}

--- a/app/Console/Commands/DeletePosts.php
+++ b/app/Console/Commands/DeletePosts.php
@@ -47,10 +47,15 @@ class DeletePosts extends Command
 
         $posts = Post::whereIn('id', $ids)->get();
 
-        $posts->map(function($post, $key) {
-            $this->postManager->destroy($post->id);
-        });
+        if ($posts->isNotEmpty()) {
+            $posts->map(function($post, $key) {
+                $this->postManager->destroy($post->id);
+            });
 
-        $this->info('Posts Deleted!');
+            $this->info('Posts Deleted!');
+        } else {
+            $this->info('No Posts found');
+        }
+
     }
 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds a command to our arsenal that will let us delete posts as we normally do via the command line, ex:

`php artisan rogue:deleteposts 33 34 35` 

The command above will soft delete posts 33, 34, and 35 and send the deletions to quasar so the data is in sync. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

This came from [a bug that we found in chompy](https://github.com/DoSomething/chompy/issues/20) where there was a set of signups that got duplicate posts made. This was limited to one of the imports we did on 5/15/18. We are still not quite sure what cause this, but we know that these duplicate records need to be removed. 

This command will allow me to just delete those duplicate posts by their post id and for that deletion event to be sent to the data team so things stay in sync. 

#### Relevant tickets
Fixes 🐛 in :chompy:

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
