### PR TITLE
Use the SignupManager instead of using the SignupRepository directly

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -5,8 +5,8 @@ namespace Rogue\Http\Controllers;
 use Rogue\Models\Post;
 use Illuminate\Http\Request;
 use Rogue\Managers\PostManager;
+use Rogue\Managers\SignupManager;
 use Rogue\Http\Requests\PostRequest;
-use Rogue\Repositories\SignupRepository;
 use Rogue\Http\Transformers\PostTransformer;
 use Rogue\Http\Controllers\Traits\FiltersRequests;
 
@@ -22,9 +22,9 @@ class PostsController extends ApiController
     protected $posts;
 
     /**
-     * The signup repository instance.
+     * The SignupManager instance.
      *
-     * @var \Rogue\Repositories\SignupRepository
+     * @var \Rogue\Managers\SignupManager
      */
     protected $signups;
 
@@ -44,10 +44,10 @@ class PostsController extends ApiController
      * Create a controller instance.
      *
      * @param PostManager $posts
-     * @param SignupRepository $signups
+     * @param SignupManager $signups
      * @param PostTransformer $transformer
      */
-    public function __construct(PostManager $posts, SignupRepository $signups, PostTransformer $transformer)
+    public function __construct(PostManager $posts, SignupManager $signups, PostTransformer $transformer)
     {
         $this->posts = $posts;
         $this->signups = $signups;


### PR DESCRIPTION
#### What's this PR do?

This PR updates the `PostController` to use the `SignupManager` when creating signups for a post that doesn't have one. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

This came from [a bug that we found in chompy](https://github.com/DoSomething/chompy/issues/20) where there was a set of signups that were missing from quasar. This was because, in chompy, we just send posts over and then if a signup isn't found we allow rogue to do the work of creating a signup for it. 

The issue was that the logic to create the signup did not go through the `SignupManager` which handles all the business logic of sending the signup record to quasar. 

#### Relevant tickets
Fixes 🐛 in :chompy:

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
