### PR TITLE
adds share-social as a valid post type

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -29,7 +29,7 @@ class PostRequest extends Request
             'campaign_id' => 'required',
             'campaign_run_id' => 'integer',
             'northstar_id' => 'nullable|objectid',
-            'type' => 'required|string|in:photo,voter-reg,text',
+            'type' => 'required|string|in:photo,voter-reg,text,share-social',
             'action' => 'required|string',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',

--- a/docs/endpoints/Legacy/Two/posts.md
+++ b/docs/endpoints/Legacy/Two/posts.md
@@ -141,7 +141,7 @@ POST /api/v2/posts
 - **updated_at**: (string) optional.
   `Y-m-d H:i:s` format. When the post was last updated.
 - **type**: (string).
-  The type of post submitted e.g. photo, voter-reg, text
+  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social. 
 - **action**: (string).
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -154,7 +154,7 @@ POST /api/v3/posts
 - **campaign_run_id**: (int)
   The drupal campaign run node id of the campaign that the user's post is associated with.
 - **type**: (string) required.
-  The type of post submitted e.g. photo, voter-reg, text
+  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social. 
 - **action**: (string) required.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 - **quantity**: (int|nullable) optional.

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -14,6 +14,39 @@ use Illuminate\Http\UploadedFile;
 class PostTest extends TestCase
 {
     /**
+     * Helper function to assert post structure
+     *
+     */
+    public function assertPostStructure($response)
+    {
+        return $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'signup_id',
+                'northstar_id',
+                'type',
+                'action',
+                'media' => [
+                    'url',
+                    'original_image_url',
+                    'text',
+                ],
+                'quantity',
+                'tags' => [],
+                'reactions' => [
+                    'reacted',
+                    'total',
+                ],
+                'status',
+                'details',
+                'source',
+                'remote_addr',
+                'created_at',
+                'updated_at',
+            ],
+        ]);
+    }
+    /**
      * Test that a POST request to /posts creates a new
      * post and signup, if it doesn't already exist.
      *
@@ -47,32 +80,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         // Make sure the signup & post are persisted to the database.
         $this->assertDatabaseHas('signups', [
@@ -121,32 +129,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -189,33 +172,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -255,33 +212,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -322,33 +253,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -453,32 +358,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -509,32 +389,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -579,32 +434,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -643,32 +473,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,
@@ -1025,32 +830,7 @@ class PostTest extends TestCase
         $response = $this->withAdminAccessToken()->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'created_at',
-                'updated_at',
-                'tags' => [],
-                'source',
-                'details',
-                'remote_addr',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $json = $response->json();
         $this->assertEquals($post->id, $json['data']['id']);
@@ -1068,6 +848,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($post->northstar_id)->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
+        // $this->assertPostStructure($response);
+
         $response->assertJsonStructure([
             'data' => [
                 'id',
@@ -1088,10 +870,6 @@ class PostTest extends TestCase
                 'status',
                 'created_at',
                 'updated_at',
-                'tags' => [],
-                'source',
-                'details',
-                'remote_addr',
             ],
         ]);
 
@@ -1336,32 +1114,7 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => [
-                    'url',
-                    'original_image_url',
-                    'text',
-                ],
-                'quantity',
-                'tags' => [],
-                'reactions' => [
-                    'reacted',
-                    'total',
-                ],
-                'status',
-                'details',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
+        $this->assertPostStructure($response);
 
         $this->assertDatabaseHas('posts', [
             'signup_id' => $signup->id,


### PR DESCRIPTION
#### What's this PR do?
- Adds share-social as a valid post type
- Adds tests to make sure you can create a `voter-reg` and `share-social` post.
- Adds a test to make sure you can't create a post if it isn't one of the following types: `voter-reg`, `share-social`, `photo`, `text`
- Adds `assertPostStructure` helper function in Post tests to DRY up code.

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/158870385) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
