### PR TITLE
Saves why_participated to signup if included with new post 

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -109,7 +109,11 @@ class PostRepository
             $this->crop($data, $post->id);
         }
 
-        // Update the signup's total quantity.
+        // Update the signup's total quantity and why_participated if sent.
+        if (isset($data['why_participated'])) {
+            $signup->why_participated = $data['why_participated'];
+        }
+
         $signup->quantity = $signup->posts->sum('quantity');
         $signup->save();
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -58,6 +58,7 @@ class PostTest extends TestCase
         $campaignId = $this->faker->randomNumber(4);
         $campaignRunId = $this->faker->randomNumber(4);
         $quantity = $this->faker->numberBetween(10, 1000);
+        $why_participated = $this->faker->paragraph;
         $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
@@ -73,7 +74,7 @@ class PostTest extends TestCase
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
-            'why_participated' => $this->faker->paragraph,
+            'why_participated' => $why_participated,
             'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
@@ -86,6 +87,7 @@ class PostTest extends TestCase
         $this->assertDatabaseHas('signups', [
             'campaign_id' => $campaignId,
             'northstar_id' => $northstarId,
+            'why_participated' => $why_participated,
         ]);
 
         $this->assertDatabaseHas('posts', [
@@ -108,6 +110,7 @@ class PostTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
+        $why_participated = $this->faker->paragraph;
         $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
@@ -122,7 +125,7 @@ class PostTest extends TestCase
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
-            'why_participated' => $this->faker->paragraph,
+            'why_participated' => $why_participated,
             'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
@@ -141,6 +144,13 @@ class PostTest extends TestCase
             'quantity' => $quantity,
             'details' => json_encode($details),
         ]);
+
+        // Make sure the updated why_participated is updated on the signup.
+        $this->assertDatabaseHas('signups', [
+            'campaign_id' => $signup->campaign_id,
+            'northstar_id' => $signup->northstar_id,
+            'why_participated' => $why_participated,
+        ]);
     }
 
     /**
@@ -153,6 +163,7 @@ class PostTest extends TestCase
         $signup = factory(Signup::class)->create();
         $quantity = $this->faker->numberBetween(10, 1000);
         $text = $this->faker->sentence;
+        $why_participated = $this->faker->paragraph;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Mock the Blink API call.
@@ -166,7 +177,7 @@ class PostTest extends TestCase
             'type'             => 'text',
             'action'           => 'test-action',
             'quantity'         => $quantity,
-            'why_participated' => $this->faker->paragraph,
+            'why_participated' => $why_participated,
             'text'             => $text,
             'details'          => json_encode($details),
         ]);
@@ -183,6 +194,13 @@ class PostTest extends TestCase
             'status' => 'pending',
             'quantity' => $quantity,
             'details' => json_encode($details),
+        ]);
+
+        // Make sure the updated why_participated is updated on the signup.
+        $this->assertDatabaseHas('signups', [
+            'campaign_id' => $signup->campaign_id,
+            'northstar_id' => $signup->northstar_id,
+            'why_participated' => $why_participated,
         ]);
     }
 


### PR DESCRIPTION
#### What's this PR do?
- It was flagged that the `why_participated` was not being saved when a post was submitted. 
- It seems this was overlooked when we built out the `v3` endpoint and we lost all of the `why_participated` data when a signup existed and a post was submitted (if a signup was created at the same time as the post, then we would have this info. However, any new `why_participated` data sent with the post was not saved the the database). 
- This PR fixes that to make sure any `why_participated` sent with a new post submission is saved to the signup. 
- This PR also updates the test to make sure this is happening. 

#### How should this be reviewed?
- All tests should pass. 
- If a `why_participated` is sent with a new post submission, this data should be saved on the signup record. 

#### Any background context you want to provide?
- This was flagged first in [this](https://dosomething.slack.com/archives/C0YGXUE01/p1531948471000062) Slack chat. 
- Next steps in discussion [here](https://github.com/orgs/DoSomething/teams/team-bleed). 

#### Relevant tickets
Fixes the issue in [this](https://www.pivotaltracker.com/n/projects/2019313/stories/159155351) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
