### PR TITLE
Limit post siblings to only return up to 10 siblings 

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -85,21 +85,6 @@ class PostsController extends ApiController
             $query = $query->withTag($filters['tag']);
         }
 
-        // If there is a limit set on siblings, include in query.
-        if ($request->query('include')) {
-            foreach ($request->query('include') as $key => $value) {
-                if ((strpos($value, 'siblings') !== false) && (strpos($value, 'limit') !== false)) {
-
-                    $limit = (new \League\Fractal\Manager)
-                            ->parseIncludes($value)
-                            ->getIncludeParams('siblings');
-
-                    $limit = $limit ? (int) $limit->get('limit')[0] : null;
-
-                    $query = $query->withPostLimit($limit);
-                }
-            }
-        }
         return $this->paginatedCollection($query, $request);
     }
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -85,6 +85,21 @@ class PostsController extends ApiController
             $query = $query->withTag($filters['tag']);
         }
 
+        // If there is a limit set on siblings, include in query.
+        if ($request->query('include')) {
+            foreach ($request->query('include') as $key => $value) {
+                if ((strpos($value, 'siblings') !== false) && (strpos($value, 'limit') !== false)) {
+
+                    $limit = (new \League\Fractal\Manager)
+                            ->parseIncludes($value)
+                            ->getIncludeParams('siblings');
+
+                    $limit = $limit ? (int) $limit->get('limit')[0] : null;
+
+                    $query = $query->withPostLimit($limit);
+                }
+            }
+        }
         return $this->paginatedCollection($query, $request);
     }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -393,4 +393,19 @@ class Post extends Model
 
         return false;
     }
+
+    /**
+    * Scope a query to only return X amount of siblings, determined by limit param.
+    *
+    * @param int $limit
+    * @return \Illuminate\Database\Eloquent\Builder
+    */
+    public function scopeWithPostLimit($query, $limit = null)
+    {
+        return $query->with(['siblings' => function ($query) use ($limit) {
+            if ($limit) {
+                $query->take($limit);
+            }
+        }]);
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -175,7 +175,7 @@ class Post extends Model
      */
     public function siblings()
     {
-        return $this->hasMany(self::class, 'signup_id', 'signup_id');
+        return $this->hasMany(self::class, 'signup_id', 'signup_id')->take(10);
     }
 
     /**
@@ -392,20 +392,5 @@ class Post extends Model
         }
 
         return false;
-    }
-
-    /**
-    * Scope a query to only return X amount of siblings, determined by limit param.
-    *
-    * @param int $limit
-    * @return \Illuminate\Database\Eloquent\Builder
-    */
-    public function scopeWithPostLimit($query, $limit = null)
-    {
-        return $query->with(['siblings' => function ($query) use ($limit) {
-            if ($limit) {
-                $query->take($limit);
-            }
-        }]);
     }
 }

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -44,6 +44,7 @@ Anonymous requests will only return accepted posts. Logged-in users can see acce
 - **include** _(string)_
   - Include additional related records in the response: `signup`, `siblings`
   - e.g. `/posts?include=signup,siblings`
+  - Note: siblings will only load up to 10 siblings (for performance reasons).
 
 Example Response:
 
@@ -157,7 +158,7 @@ POST /api/v3/posts
 - **campaign_run_id**: (int)
   The drupal campaign run node id of the campaign that the user's post is associated with.
 - **type**: (string) required.
-  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social. 
+  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social.
 - **action**: (string) required.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 - **quantity**: (int|nullable) optional.

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -52,7 +52,7 @@ const reviewComponent = (Component, data) => {
             campaign_id: campaignId,
             type: 'photo,text',
           },
-          include: ['signup', 'siblings:limit(10)'],
+          include: ['signup', 'siblings'],
         })
         .then(json =>
           this.setState({

--- a/resources/assets/components/WithReviewing/index.js
+++ b/resources/assets/components/WithReviewing/index.js
@@ -52,7 +52,7 @@ const reviewComponent = (Component, data) => {
             campaign_id: campaignId,
             type: 'photo,text',
           },
-          include: ['signup', 'siblings'],
+          include: ['signup', 'siblings:limit(10)'],
         })
         .then(json =>
           this.setState({
@@ -196,7 +196,7 @@ const reviewComponent = (Component, data) => {
         // Make API request to Rogue to update the quantity on the backend
         let response = this.api.delete(`api/v3/posts/${postId}`);
 
-        response.then((result) => {
+        response.then(result => {
           // Update the state
           this.setState(previousState => {
             var newState = { ...previousState };


### PR DESCRIPTION
#### What's this PR do?
Limits post siblings to only return up to 10 siblings and updates documentation.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Inboxes were not loading because there were some posts that had many siblings and the page would time out. Now, we only return up to 10 post siblings so this doesn't happen! 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/159406186) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
