### PR TITLE
Allows for post to have a custom created_at when a post is made

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -36,7 +36,8 @@ class PostRequest extends Request
             'quantity' => 'nullable|integer',
             'file' => 'image|dimensions:min_width=400,min_height=400,max_width=5000,max_height_4000',
             'status' => $this->getStatusRules($this->type),
-            'details'=> 'json',
+            'details' => 'json',
+            'created_at' => 'date',
         ];
     }
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -93,6 +93,11 @@ class PostRepository
             'details' => isset($data['details']) ? $data['details'] : null,
         ]);
 
+        // If there is a created_at property, fill this in (e.g. if created_at is sent when creating a record with the importer app).
+        if ($data['created_at']){
+            $post->created_at = $data['created_at'];
+        }
+
         $isAdmin = auth()->user() && auth()->user()->role === 'admin';
         $hasAdminScope = in_array('admin', token()->scopes());
 
@@ -102,7 +107,7 @@ class PostRepository
             $post->source = isset($data['source']) ? $data['source'] : token()->client();
         }
 
-        $post->save();
+        $post->save(['timestamps' => false]);
 
         // Edit the image if there is one
         if (isset($data['file'])) {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -93,18 +93,18 @@ class PostRepository
             'details' => isset($data['details']) ? $data['details'] : null,
         ]);
 
-        // If there is a created_at property, fill this in (e.g. if created_at is sent when creating a record with the importer app).
-        if ($data['created_at']){
-            $post->created_at = $data['created_at'];
-        }
-
         $isAdmin = auth()->user() && auth()->user()->role === 'admin';
         $hasAdminScope = in_array('admin', token()->scopes());
 
-        // Admin users may provide a source and status when uploading a post.
+        // Admin users may provide a source, status, and created_at when uploading a post.
         if ($isAdmin || $hasAdminScope) {
             $post->status = isset($data['status']) ? $data['status'] : 'pending';
             $post->source = isset($data['source']) ? $data['source'] : token()->client();
+
+            // If there is a created_at property, fill this in (e.g. if created_at is sent when creating a record with the importer app).
+            if (isset($data['created_at'])) {
+                $post->created_at = $data['created_at'];
+            }
         }
 
         $post->save();

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -107,7 +107,7 @@ class PostRepository
             $post->source = isset($data['source']) ? $data['source'] : token()->client();
         }
 
-        $post->save(['timestamps' => false]);
+        $post->save();
 
         // Edit the image if there is one
         if (isset($data['file'])) {

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -175,6 +175,8 @@ POST /api/v3/posts
   A JSON field to store extra details about a post.
 - **dont_send_to_blink** (boolean) optional.
   If included and true, the data for this Post will not be sent to Blink.
+- **created_at** (timestamp).
+  If included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. voter-reg posts, historical FB share posts, etc.).
 
 Example Response:
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -176,7 +176,7 @@ POST /api/v3/posts
 - **dont_send_to_blink** (boolean) optional.
   If included and true, the data for this Post will not be sent to Blink.
 - **created_at** (timestamp).
-  If included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. voter-reg posts, historical FB share posts, etc.).
+  If admin and included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. voter-reg posts, historical FB share posts, etc.).
 
 Example Response:
 


### PR DESCRIPTION
#### What's this PR do?
Allows for post to have a custom `created_at when` a post is made in Rogue.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
I'm currently working on a job in Chompy to ingest historical FB share posts. We [would like](https://github.com/DoSomething/chompy/wiki/How-Historic-FB-Share-Records-are-Imported) for the `created_at` dates to match the `keen.created_at` date from the data sent in. In order to do this, we need to update on the Rogue side to have this ability! 

#### Relevant tickets
This is needed in order to merge [this PR](https://github.com/DoSomething/chompy/pull/34) in Chompy.

Needed to complete [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156165836) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
