### PR TITLE
Limits a post's siblings to only return 5

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -175,7 +175,7 @@ class Post extends Model
      */
     public function siblings()
     {
-        return $this->hasMany(self::class, 'signup_id', 'signup_id')->take(10);
+        return $this->hasMany(self::class, 'signup_id', 'signup_id')->take(5);
     }
 
     /**

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -44,7 +44,7 @@ Anonymous requests will only return accepted posts. Logged-in users can see acce
 - **include** _(string)_
   - Include additional related records in the response: `signup`, `siblings`
   - e.g. `/posts?include=signup,siblings`
-  - Note: siblings will only load up to 10 siblings (for performance reasons).
+  - Note: siblings will only load up to 5 siblings (for performance reasons).
 
 Example Response:
 


### PR DESCRIPTION
#### What's this PR do?
- The YGTP inbox isn't loading again with a `503` error. This fix limits a post's siblings to only return 5 for the inbox hoping this will be the fix!
- Updates documentation.

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/159506797) Pivotal card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
