### PR TITLE
Fixes bug where staff weren't able to delete signups or posts or update posts in Rogue admin

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -16,7 +16,7 @@ class EventsController extends ApiController
         $this->transformer = new EventTransformer();
 
         $this->middleware('scopes:activity');
-        $this->middleware('role:admin');
+        $this->middleware('role:admin,staff');
     }
 
     /**

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -55,7 +55,7 @@ class PostsController extends ApiController
 
         $this->middleware('scopes:activity');
         $this->middleware('auth:api', ['only' => ['store', 'update', 'destroy']]);
-        $this->middleware('role:admin', ['only' => ['destroy']]);
+        $this->middleware('role:admin,staff', ['only' => ['destroy']]);
         $this->middleware('scopes:write', ['only' => ['store', 'update', 'destroy']]);
     }
 

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -44,7 +44,7 @@ class SignupsController extends ApiController
 
         $this->middleware('scopes:activity');
         $this->middleware('auth:api', ['only' => ['store', 'update', 'destroy']]);
-        $this->middleware('role:admin', ['only' => ['destroy']]);
+        $this->middleware('role:admin,staff', ['only' => ['destroy']]);
         $this->middleware('scopes:write', ['only' => ['store', 'update', 'destroy']]);
     }
 

--- a/tests/Http/EventTest.php
+++ b/tests/Http/EventTest.php
@@ -180,7 +180,7 @@ class EventTest extends TestCase
         $response->assertStatus(403);
 
         $decodedResponse = $response->decodeResponseJson();
-        $this->assertEquals('Requires one of the following roles: admin', $decodedResponse['message']);
+        $this->assertEquals('Requires one of the following roles: admin, staff', $decodedResponse['message']);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug where staff weren't able to delete signups or posts or update posts in Rogue admin.
  - Allows staff to delete posts and signups.
  - Allows staff to get events (breaking the `Edit | Show History` link bc this hit `GET /v3/events` first). 

#### How should this be reviewed?
- Make sure staff are able to delete signups and posts and can update the quantity in Rogue admin! 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/159005372) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
