### PR TITLE
Auto-accept share-social posts when they are created 

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -87,11 +87,13 @@ class PostRepository
             'action' => isset($data['action']) ? $data['action'] : null,
             'url' => $fileUrl,
             'text' => isset($data['text']) ? $data['text'] : null,
-            'status' => 'pending',
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
         ]);
+
+        // If this is a share-social type post, auto-accept.
+        $post->status = $post->type === 'share-social' ? 'accepted' : 'pending';
 
         $isAdmin = auth()->user() && auth()->user()->role === 'admin';
         $hasAdminScope = in_array('admin', token()->scopes());

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -103,12 +103,6 @@ class PostRepository
             // If the admin sets a custom status, set this status.
             if (isset($data['status'])) {
                 $post->status = $data['status'];
-            // If the admin doesn't set a custom status and it is a share-social post, auto-accept it.
-            } elseif (! isset($data['status']) && $post->type === 'share-social') {
-                $post->status = 'accepted';
-            // Otherwise, the status should be pending.
-            } else {
-                $post->status = 'pending';
             }
 
             $post->source = isset($data['source']) ? $data['source'] : token()->client();

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -104,7 +104,7 @@ class PostRepository
             if (isset($data['status'])) {
                 $post->status = $data['status'];
             // If the admin doesn't set a custom status and it is a share-social post, auto-accept it.
-            } elseif (! isset($data['status']) && $post->type ==== 'share-social') {
+            } elseif (! isset($data['status']) && $post->type === 'share-social') {
                 $post->status = 'accepted';
             // Otherwise, the status should be pending.
             } else {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -100,7 +100,17 @@ class PostRepository
 
         // Admin users may provide a source, status, and created_at when uploading a post.
         if ($isAdmin || $hasAdminScope) {
-            $post->status = isset($data['status']) ? $data['status'] : 'pending';
+            // If the admin sets a custom status, set this status.
+            if (isset($data['status'])) {
+                $post->status = $data['status'];
+            // If the admin doesn't set a custom status and it is a share-social post, auto-accept it.
+            } elseif (! isset($data['status']) && $post->type ==== 'share-social') {
+                $post->status = 'accepted';
+            // Otherwise, the status should be pending.
+            } else {
+                $post->status = 'pending';
+            }
+
             $post->source = isset($data['source']) ? $data['source'] : token()->client();
 
             // If there is a created_at property, fill this in (e.g. if created_at is sent when creating a record with the importer app).

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -158,7 +158,7 @@ POST /api/v3/posts
 - **campaign_run_id**: (int)
   The drupal campaign run node id of the campaign that the user's post is associated with.
 - **type**: (string) required.
-  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social.
+  The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **action**: (string) required.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 - **quantity**: (int|nullable) optional.
@@ -169,14 +169,14 @@ POST /api/v3/posts
   Corresponding text for the post (could be photo caption or other words). 256 max characters.
 - **status**: (string).
   Option to set status upon creation if admin uploads post for user.
-- **file**: (multipart/form-data) required for photo posts.
+- **file**: (multipart/form-data) required for `photo` posts.
   File to save of post image.
 - **details** (json).
   A JSON field to store extra details about a post.
 - **dont_send_to_blink** (boolean) optional.
   If included and true, the data for this Post will not be sent to Blink.
 - **created_at** (timestamp).
-  If admin and included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. voter-reg posts, historical FB share posts, etc.).
+  If admin and included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. `voter-reg` posts, historical FB share posts, etc.).
 
 Example Response:
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -286,6 +286,91 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test that a POST request to /posts as an admin creates a new auto-accepted share-social post.
+     *
+     * @return void
+     */
+    public function testCreatingAShareSocialPostAsAdmin()
+    {
+        $signup = factory(Signup::class)->create();
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $text = $this->faker->sentence;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
+            'northstar_id'     => $signup->northstar_id,
+            'campaign_id'      => $signup->campaign_id,
+            'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'share-social',
+            'action'           => 'test-action',
+            'quantity'         => $quantity,
+            'text'             => $text,
+            'details'          => json_encode($details),
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertPostStructure($response);
+
+        $this->assertDatabaseHas('posts', [
+            'signup_id' => $signup->id,
+            'northstar_id' => $signup->northstar_id,
+            'campaign_id' => $signup->campaign_id,
+            'type' => 'share-social',
+            'action' => 'test-action',
+            // Social share posts should be auto-accepted (unless an admin sends a custom status).
+            'status' => 'accepted',
+            'details' => json_encode($details),
+        ]);
+    }
+
+    /**
+     * Test that a POST request to /posts as an admin with a custom status creates a new share-social post that is pending.
+     *
+     * @return void
+     */
+    public function testCreatingAShareSocialPostAsAdminWithCustomStatus()
+    {
+        $signup = factory(Signup::class)->create();
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $text = $this->faker->sentence;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
+            'northstar_id'     => $signup->northstar_id,
+            'campaign_id'      => $signup->campaign_id,
+            'campaign_run_id'  => $signup->campaign_run_id,
+            'type'             => 'share-social',
+            'action'           => 'test-action',
+            'quantity'         => $quantity,
+            'text'             => $text,
+            'details'          => json_encode($details),
+            'status'           => 'pending',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertPostStructure($response);
+
+        $this->assertDatabaseHas('posts', [
+            'signup_id' => $signup->id,
+            'northstar_id' => $signup->northstar_id,
+            'campaign_id' => $signup->campaign_id,
+            'type' => 'share-social',
+            'action' => 'test-action',
+            // Social share posts should be pending since the admin sent a custom status.
+            'status' => 'pending',
+            'details' => json_encode($details),
+        ]);
+    }
+
+    /**
      * Test a post cannot be created that is not one of the following types: text, photo, voter-reg, share-social.
      *
      * @return void

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -279,7 +279,8 @@ class PostTest extends TestCase
             'campaign_id' => $signup->campaign_id,
             'type' => 'share-social',
             'action' => 'test-action',
-            'status' => 'pending',
+            // Social share posts should be auto-accepted (unless an admin sends a custom status).
+            'status' => 'accepted',
             'details' => json_encode($details),
         ]);
     }


### PR DESCRIPTION
#### What's this PR do?
- Auto-accepts `share-social` posts when they are created (unless an admin sets a custom `status` for the post). 
- Updates/adds tests. 
- Updates documentation. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes the first task in [this](https://www.pivotaltracker.com/n/projects/2019429/stories/159629479) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
