### PR TITLE
Adds ability to filter by `created_at` for the v3/posts index 

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -53,7 +53,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'northstar_id', 'status'];
+    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'northstar_id', 'status', 'created_at'];
 
     /**
      * The tags prefixed with 'good' that will send a post to Slack.

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -22,6 +22,9 @@ Anonymous requests will only return accepted posts. Logged-in users can see acce
 - **page** _(integer)_
   - For pagination, specify page of activity to return in the response.
   - e.g. `/posts?page=2`
+- **filter[signup_id]** _(integer)_
+  - The signup ID to filter the response by.
+  - e.g. `/posts?filter[signup_id]=47`
 - **filter[campaign_id]** _(integer)_
   - The campaign ID to filter the response by.
   - e.g. `/posts?filter[campaign_id]=47`
@@ -34,6 +37,12 @@ Anonymous requests will only return accepted posts. Logged-in users can see acce
 - **filter[type]** _(string)_
   - The type to filter the response by.
   - e.g. `/posts?filter[type]=photo,voter-reg`
+- **filter[action]** _(string)_
+  - The action to filter the response by.
+  - e.g. `/posts?filter[action]=action-1`
+- **filter[created_at]** _(timestamp)_
+  - The created_at date to filter the response by.
+  - e.g. `/posts?filter[created_at]=2017-04-28 01:46:45`
 - **filter[exclude]** _(integer)_
   - The post id(s) to exclude in response.
   - e.g. `/posts?filter[exclude]=2,3,4`


### PR DESCRIPTION
#### What's this PR do?
Adds ability to filter by `created_at` for the v3/posts index.
 
#### How should this be reviewed?
👀 
Try to use `api/v3/posts?filter[created_at]=2018-08-13 15:10:03` and only posts that were created at `2018-08-13 15:10:03` should be returned. 
 
#### Any background context you want to provide?
We want to update the [Import Facebook Share Posts](https://github.com/DoSomething/chompy/blob/master/app/Jobs/ImportFacebookSharePosts.php)  job  in Chompy to first check if a post exists in Rogue before creating it. 

In order to make sure that the job doesn't create duplicate posts, we will search by `campaign_id`, `northstar_id`, `action`, and `created_at` date. This adds the ability to do so. 

#### Relevant tickets
Related to [this](https://www.pivotaltracker.com/n/projects/2019429/stories/160102193) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
