### PR TITLE
creates script to force delete posts by type and source

### DIFF
--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -44,9 +44,9 @@ class ForceDeletePosts extends Command
      */
     public function handle()
     {
-        if ($this->confirm('"Are you sure you want to delete posts of type ' . $this->argument('type') . 'from ' . $this->argument('source'))) {
+        if ($this->confirm('Are you sure you want to delete posts of type ' . $this->argument('type') . 'from ' . $this->argument('source'))) {
 
-            info('Starting to force delete posts by type and source.');
+            info('rogue:forceDeletePosts: Starting to force delete posts by type and source.');
 
             $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
 
@@ -57,9 +57,9 @@ class ForceDeletePosts extends Command
                     $post->forceDelete();
                 });
 
-                info('Posts Deleted!');
+                info('rogue:forceDeletePosts: Posts Deleted!');
             } else {
-                info('No Posts found');
+                info('rogue:forceDeletePosts: No Posts found');
             }
         }
     }

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Post;
+use Illuminate\Console\Command;
+
+class ForceDeletePosts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:forceDeletePosts
+                            {type}
+                            {source}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Force deletes posts in Rogue by type and source';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        info('Starting to force delete posts by type and source.');
+
+        Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->forceDelete();
+
+        info('All posts have been force deleted.');
+    }
+}

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -44,20 +44,23 @@ class ForceDeletePosts extends Command
      */
     public function handle()
     {
-        info('Starting to force delete posts by type and source.');
+        if ($this->confirm('"Are you sure you want to delete posts of type ' . $this->argument('type') . 'from ' . $this->argument('source'))) {
 
-        $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
+            info('Starting to force delete posts by type and source.');
 
-        if ($posts->isNotEmpty()) {
-            $posts->map(function ($post, $key) {
-                $this->postManager->destroy($post->id);
+            $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
 
-                $post->forceDelete();
-            });
+            if ($posts->isNotEmpty()) {
+                $posts->map(function ($post, $key) {
+                    $this->postManager->destroy($post->id);
 
-            info('Posts Deleted!');
-        } else {
-            info('No Posts found');
+                    $post->forceDelete();
+                });
+
+                info('Posts Deleted!');
+            } else {
+                info('No Posts found');
+            }
         }
     }
 }

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -25,6 +25,12 @@ class ForceDeletePosts extends Command
     protected $description = 'Force deletes posts in Rogue by type and source';
 
     /**
+     * The post manager.
+     * @var PostManager
+     */
+    protected $postManager;
+
+    /**
      * Create a new command instance.
      *
      * @return void

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -50,23 +50,24 @@ class ForceDeletePosts extends Command
      */
     public function handle()
     {
-        if ($this->confirm('Are you sure you want to delete posts of type ' . $this->argument('type') . 'from ' . $this->argument('source'))) {
+        if (! $this->confirm('Are you sure you want to delete posts of type ' . $this->argument('type') . 'from ' . $this->argument('source'))) {
+            return;
+        }
 
-            info('rogue:forceDeletePosts: Starting to force delete posts by type and source.');
+        info('rogue:forceDeletePosts: Starting to force delete posts by type and source.');
 
-            $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
+        $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
 
-            if ($posts->isNotEmpty()) {
-                $posts->map(function ($post, $key) {
-                    $this->postManager->destroy($post->id);
+        if ($posts->isNotEmpty()) {
+            $posts->map(function ($post, $key) {
+                $this->postManager->destroy($post->id);
 
-                    $post->forceDelete();
-                });
+                $post->forceDelete();
+            });
 
-                info('rogue:forceDeletePosts: Posts Deleted!');
-            } else {
-                info('rogue:forceDeletePosts: No Posts found');
-            }
+            info('rogue:forceDeletePosts: Posts Deleted!');
+        } else {
+            info('rogue:forceDeletePosts: No Posts found');
         }
     }
 }

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -59,11 +59,11 @@ class ForceDeletePosts extends Command
         $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
 
         if ($posts->isNotEmpty()) {
-            $posts->map(function ($post, $key) {
+            foreach ($posts as $post) {
                 $this->postManager->destroy($post->id);
 
                 $post->forceDelete();
-            });
+            }
 
             info('rogue:forceDeletePosts: Posts Deleted!');
         } else {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -163,12 +163,14 @@ class PostRepository
     {
         $post = Post::findOrFail($postId);
 
-        // Delete the image file from AWS.
-        $this->aws->deleteImage($post->url);
+        if ($post->url) {
+            // Delete the image file from AWS.
+            $this->aws->deleteImage($post->url);
 
-        // Set the url of the post to null.
-        $post->url = null;
-        $post->save();
+            // Set the url of the post to null.
+            $post->url = null;
+            $post->save();
+        }
 
         // Soft delete the post.
         $post->delete();


### PR DESCRIPTION
#### What's this PR do?
- creates script to force delete posts by type and source

#### How should this be reviewed?
- Run this query before running script to see how many posts we start with that have the `type` = `share-social` and created by chompy: 
```
SELECT COUNT(*) FROM posts where type = 'share-social' and source = 'importer-client'; 
```
- Run the script: `php artisan rogue:forceDeletePosts share-social importer-client`
- Run the query again and it should be `0`

#### Any background context you want to provide?
- We started importing Historic FB shares from chompy on prod but realized there was a bug and it created dupes! 
- We now plan to get rid of all the dupes and re-start the script. 
- This script takes in the arguments `type` and `source` since this is what we need in this case but can be modified in the future if we need it. 
- I decided to not expand on [this command](https://github.com/DoSomething/rogue/blob/master/app/Console/Commands/DeletePosts.php) that soft deletes posts based on ID because it seems like, although similar, have different case scenarios for what data is available to us. 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/160102193) Pivotal card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
