### PR TITLE
removes confirmation message in force deleting script

### DIFF
--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -50,10 +50,6 @@ class ForceDeletePosts extends Command
      */
     public function handle()
     {
-        if (! $this->confirm('Are you sure you want to delete posts of type ' . $this->argument('type') . 'from ' . $this->argument('source'))) {
-            return;
-        }
-
         info('rogue:forceDeletePosts: Starting to force delete posts by type and source.');
 
         $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();


### PR DESCRIPTION
#### What's this PR do?
removes confirmation message in force deleting script because we have [a hunch](https://dosomething.slack.com/archives/C0YGXUE01/p1535663505000100?thread_ts=1535661920.000100&cid=C0YGXUE01) this won't fun on heroku

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes #762 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
