### PR TITLE
adds chunking to force delete posts script

### DIFF
--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -52,18 +52,21 @@ class ForceDeletePosts extends Command
     {
         info('rogue:forceDeletePosts: Starting to force delete posts by type and source.');
 
-        $posts = Post::where('type', $this->argument('type'))->where('source', $this->argument('source'))->get();
+        Post::where('type', $this->argument('type'))
+            ->where('source', $this->argument('source'))
+            ->chunk(100, function ($posts) {
+                if ($posts->isNotEmpty()) {
+                    foreach ($posts as $post) {
+                        $this->postManager->destroy($post->id);
 
-        if ($posts->isNotEmpty()) {
-            foreach ($posts as $post) {
-                $this->postManager->destroy($post->id);
+                        $post->forceDelete();
+                    }
 
-                $post->forceDelete();
-            }
-
-            info('rogue:forceDeletePosts: Posts Deleted!');
-        } else {
-            info('rogue:forceDeletePosts: No Posts found');
-        }
+                    info('rogue:forceDeletePosts: Posts Deleted!');
+                } else {
+                    info('rogue:forceDeletePosts: No Posts found');
+                }
+            });
+        info('rogue:forceDeletePosts: ALL DONE!');
     }
 }

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -62,7 +62,7 @@ class ForceDeletePosts extends Command
                         $post->forceDelete();
                     }
 
-                    info('rogue:forceDeletePosts: Posts Deleted!');
+                    info('rogue:forceDeletePosts: 100 posts Deleted!');
                 } else {
                     info('rogue:forceDeletePosts: No Posts found');
                 }


### PR DESCRIPTION
#### What's this PR do?
Adds `chunk` to force delete posts script to save memory when dealing with a lot of records. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
When running on thor, there were 35,550 records that needed to be force deleted. This cause a memory issue: 
![screen shot 2018-08-31 at 10 37 25 am](https://user-images.githubusercontent.com/9019452/44918807-e4383580-ad09-11e8-8795-29d303be52bf.png)

Using `chunk` should help this problem. 

#### Relevant tickets
Updates script created in #762 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
