### PR TITLE
Increases image throttling to allow 30 images per minute

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ImagesController.php
+++ b/app/Http/Controllers/Legacy/Web/ImagesController.php
@@ -35,7 +35,7 @@ class ImagesController extends Controller
         $this->aws = $aws;
         $this->fastly = $fastly;
 
-        $this->middleware('throttle:15');
+        $this->middleware('throttle:30');
     }
 
     /**

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -25,7 +25,7 @@ class ImagesTest extends TestCase
             $response = $this->getJson('images/' . $posts->random()->id . '?w=500&h=500&fit=crop');
             $response->assertStatus(200);
         }
-        for ($i = 10; $i < 15; $i++) {
+        for ($i = 10; $i < 30; $i++) {
             $response = $this->getJson('images/' . $posts->random()->id . '?w=250&h=400&fit=crop&filt=sepia');
             $response->assertStatus(200);
         }


### PR DESCRIPTION
#### What's this PR do?
Increases image throttling to allow 30 images per minute.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Papertrail Rate-Limited Requests alerts were very noisy because of this threshold. @DFurnes had a [great idea](https://dosomething.slack.com/archives/C0YGXUE01/p1539096182000100?thread_ts=1539091395.000100&cid=C0YGXUE01) to increase this throttle to avoid false alarms. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
