### PR TITLE
Adds indexes to posts and signups tables to prevent database lock for force delete test records script

### DIFF
--- a/database/migrations/2018_11_28_162339_add_indexes_to_signups_and_posts_for_force_delete_test_records.php
+++ b/database/migrations/2018_11_28_162339_add_indexes_to_signups_and_posts_for_force_delete_test_records.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexesToSignupsAndPostsForForceDeleteTestRecords extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->index('source');
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index('source');
+            $table->index('text');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropIndex('source');
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex('source');
+            $table->dropIndex('text');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
- Adds indexes to `posts` and `signups` tables to prevent [database lock ](https://github.com/DoSomething/internal/issues/408#issuecomment-390422665) for force delete test records script
  - I didn't add `why_participated` as an index for in the `signups` table because I got this error when I tried to do that (since it is a text blob):
```
SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'why_participated' used in key specification without a key length
```

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/161383417) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
