### PR TITLE
Script to update signup and post campaign ids after legacy campaign migration

### DIFF
--- a/app/Console/Commands/ImportAshesCampaigns.php
+++ b/app/Console/Commands/ImportAshesCampaigns.php
@@ -43,7 +43,7 @@ class ImportAshesCampaigns extends Command
     {
         // Make a local copy of the CSV
         $path = $this->argument('path');
-        info('rogue:legacycampaignimport: Loading in csv from ' . $path);
+        $this->line('rogue:legacycampaignimport: Loading in csv from ' . $path);
 
         $temp = tempnam(sys_get_temp_dir(), 'command_csv');
         file_put_contents($temp, fopen($this->argument('path'), 'r'));

--- a/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
+++ b/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
@@ -2,6 +2,10 @@
 
 namespace Rogue\Console\Commands;
 
+use DB;
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+use Rogue\Models\Campaign;
 use Illuminate\Console\Command;
 
 class UpdateSignupAndPostCampaignIds extends Command
@@ -11,14 +15,14 @@ class UpdateSignupAndPostCampaignIds extends Command
      *
      * @var string
      */
-    protected $signature = 'command:name';
+    protected $signature = 'rogue:updatesignupandpostcampaignids';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Updates signup and post campaign ids after legacy campaign migration and killing of campaign runs.';
 
     /**
      * Create a new command instance.
@@ -37,6 +41,13 @@ class UpdateSignupAndPostCampaignIds extends Command
      */
     public function handle()
     {
-        //
+        // Grab all of the campaigns in the campaigns table.
+        $campaigns = Campaign::all();
+
+        // Update each signup and the signup's post(s) in each campaign with new campaign id.
+        foreach ($campaigns as $campaign) {
+            dd($campaign->campaign_run_id);
+            # code...
+        }
     }
 }

--- a/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
+++ b/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
@@ -54,6 +54,8 @@ class UpdateSignupAndPostCampaignIds extends Command
 
         // Update each signup and the signup's post(s) in each campaign with new campaign id.
         foreach ($campaigns as $campaign) {
+            $this->line('rogue:updatesignupandpostcampaignids: Updating signups/posts under campaign id: ' . $campaign->id);
+
             $signups = Signup::where('campaign_run_id', $campaign->campaign_run_id)->get();
             foreach ($signups as $signup) {
                 // Update the signup's campaign id to the $campaign->id

--- a/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
+++ b/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
@@ -55,7 +55,6 @@ class UpdateSignupAndPostCampaignIds extends Command
         // Update each signup and the signup's post(s) in each campaign with new campaign id.
         foreach ($campaigns as $campaign) {
             $signups = Signup::where('campaign_run_id', $campaign->campaign_run_id)->get();
-
             foreach ($signups as $signup) {
                 // Update the signup's campaign id to the $campaign->id
                 $signup->campaign_id = $campaign->id;

--- a/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
+++ b/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class UpdateSignupAndPostCampaignIds extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:name';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/Console/UpdateSignupAndPostCampaignIdsCommandTest.php
+++ b/tests/Console/UpdateSignupAndPostCampaignIdsCommandTest.php
@@ -15,18 +15,25 @@ class UpdateSignupAndPostCampaignIdsCommandTest extends TestCase
     {
         // Create campaign and set a campaign_run_id.
         $campaign = factory(Campaign::class)->create();
+        // Assign campaign id so we can be sure signup and post below do not have the same id to start.
+        $campaign->id = 99;
         $campaign->campaign_run_id = 1;
         $campaign->save();
 
         // Create a signup and two posts that belong to this signup with a run_id = 1.
         $post = factory(Post::class)->create();
+        $post->campaign_id = 2;
+        $post->save();
+
         $post2 = factory(Post::class)->create();
         $signup = $post->signup;
 
+        $signup->campaign_id = 2;
         $signup->campaign_run_id = 1;
         $signup->save();
 
         $post2->signup_id = $signup->id;
+        $post2->campaign_id = 2;
         $post2->save();
 
         // Run script to update signup and post's campaign id.

--- a/tests/Console/UpdateSignupAndPostCampaignIdsCommandTest.php
+++ b/tests/Console/UpdateSignupAndPostCampaignIdsCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Console;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use Rogue\Models\Post;
+use Rogue\Models\Signup;
+use Rogue\Models\Campaign;
+
+class UpdateSignupAndPostCampaignIdsCommandTest extends TestCase
+{
+
+    public function testUpdatingSignupAndPostCampaignIds()
+    {
+        // Create campaign and set a campaign_run_id.
+        $campaign = factory(Campaign::class)->create();
+        $campaign->campaign_run_id = 1;
+        $campaign->save();
+
+        // Create a signup and two posts that belong to this signup with a run_id = 1.
+        $post = factory(Post::class)->create();
+        $post2 = factory(Post::class)->create();
+        $signup = $post->signup;
+
+        $signup->campaign_run_id = 1;
+        $signup->save();
+
+        $post2->signup_id = $signup->id;
+        $post2->save();
+
+        // Run script to update signup and post's campaign id.
+        $this->artisan('rogue:updatesignupandpostcampaignids');
+
+        // Make sure the signup and posts were updated.
+        $this->assertDatabaseHas('signups', [
+            'id' => $signup->id,
+            'northstar_id' => $signup->northstar_id,
+            'campaign_id' => $campaign->id,
+            'campaign_run_id' => 1,
+            'why_participated' => $signup->why_participated,
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'id' => $post->id,
+            'signup_id' => $signup->id,
+            'campaign_id' => $campaign->id,
+            'northstar_id' => $post->northstar_id,
+            'text' => $post->text,
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'id' => $post2->id,
+            'signup_id' => $signup->id,
+            'campaign_id' => $campaign->id,
+            'northstar_id' => $post2->northstar_id,
+            'text' => $post2->text,
+        ]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
- Adds script to update signup and post campaign ids after legacy campaign migration
  - Grabs all campaigns from the `campaigns` table
  - Gets all signups by `campaign_run_id` and updates the signup's `campaign_id`to the campaign's `id`
  - Gets all signup's posts and updates the post's `campaign_id` to the campaign's `id`
- Adds a test to make sure this logic is working as we expect 

#### How should this be reviewed?
👀 
Is this the most efficient way to do this?

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/162309728) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
