### PR TITLE
Always update signup for latest (or empty) run, if it exists.

### DIFF
--- a/app/Http/Controllers/Legacy/Two/SignupsController.php
+++ b/app/Http/Controllers/Legacy/Two/SignupsController.php
@@ -51,7 +51,7 @@ class SignupsController extends ApiController
     public function store(SignupRequest $request)
     {
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id']);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -65,7 +65,7 @@ class SignupsController extends ApiController
         $northstarId = getNorthstarId($request);
 
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($northstarId, $request['campaign_id']);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Managers/Legacy/Two/SignupManager.php
+++ b/app/Managers/Legacy/Two/SignupManager.php
@@ -61,9 +61,9 @@ class SignupManager
      * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
-        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
+        $signup = $this->signup->get($northstarId, $campaignId);
 
         return $signup;
     }

--- a/app/Managers/Legacy/Two/SignupManager.php
+++ b/app/Managers/Legacy/Two/SignupManager.php
@@ -58,7 +58,6 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
     public function get($northstarId, $campaignId)

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -108,9 +108,9 @@ class SignupManager
      * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
-        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
+        $signup = $this->signup->get($northstarId, $campaignId);
 
         return $signup;
     }

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -105,7 +105,6 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
     public function get($northstarId, $campaignId)

--- a/app/Repositories/Legacy/Two/SignupRepository.php
+++ b/app/Repositories/Legacy/Two/SignupRepository.php
@@ -49,7 +49,6 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
     public function get($northstarId, $campaignId)

--- a/app/Repositories/Legacy/Two/SignupRepository.php
+++ b/app/Repositories/Legacy/Two/SignupRepository.php
@@ -52,13 +52,14 @@ class SignupRepository
      * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'campaign_run_id' => $campaignRunId,
-        ])->first();
+        ])->orderByRaw('campaign_run_id IS NULL')
+            ->orderBy('campaign_run_id', 'desc')
+            ->first();
 
         return $signup;
     }

--- a/app/Repositories/Legacy/Two/SignupRepository.php
+++ b/app/Repositories/Legacy/Two/SignupRepository.php
@@ -56,7 +56,7 @@ class SignupRepository
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-        ])->orderByRaw('campaign_run_id IS NULL')
+        ])->orderByRaw('campaign_run_id IS NULL DESC')
             ->orderBy('campaign_run_id', 'desc')
             ->first();
 

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -49,7 +49,6 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
     public function get($northstarId, $campaignId)

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -52,13 +52,14 @@ class SignupRepository
      * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'campaign_run_id' => $campaignRunId,
-        ])->first();
+        ])->orderByRaw('campaign_run_id IS NULL')
+            ->orderBy('campaign_run_id', 'desc')
+            ->first();
 
         return $signup;
     }

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -56,7 +56,7 @@ class SignupRepository
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-        ])->orderByRaw('campaign_run_id IS NULL')
+        ])->orderByRaw('campaign_run_id IS NULL DESC')
             ->orderBy('campaign_run_id', 'desc')
             ->first();
 

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -90,9 +90,6 @@ class SignupTest extends TestCase
     {
         $signup = factory(Signup::class)->states('contentful')->create();
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignup');
-
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/signups', [
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -109,6 +109,35 @@ class SignupTest extends TestCase
     }
 
     /**
+     * Test that a POST request to /signups doesn't create duplicate signups
+     * if we don't provide the same 'campaign_run_id' that already is set.
+     *
+     * POST /api/v3/signups
+     * @return void
+     */
+    public function testNotCreatingDuplicateSignupsWithoutRun()
+    {
+        // Create a signup with a `campaign_id` and `campaign_run_id`.
+        $signup = factory(Signup::class)->create();
+
+        // Now, try to sign up again (without providing the same run ID).
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/signups', [
+            'northstar_id' => $signup->northstar_id,
+            'campaign_id' => $signup->campaign_id,
+        ]);
+
+        // Make sure we get the 200 response
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'id' => $signup->id,
+                'campaign_id' => $signup->campaign_id,
+                'campaign_run_id' => $signup->campaign_run_id,
+            ],
+        ]);
+    }
+
+    /**
      * Test that non-authenticated user's/apps can't post signups.
      *
      * @return void


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Rogue's `POST v2/signups` and `POST v3/signups` to always update the latest run if it exists for a campaign, rather than making a new one where the `campaign_run_id` is null. This will allow us to stop sending Campaign Run IDs (and run the script in #787) without breaking this functionality for applications that rely on it.

#### How should this be reviewed?
I added a failing test in 3e5590a which demonstrates the issue (we create a new signup when we shouldn't), and you can see the issue is fixed in e51a989. This doesn't break any other tests, and I don't believe we rely on the prior unexpected behavior anywhere.

#### Any background context you want to provide?
This was flagged by @weerd when testing Phoenix's new sans-runs signup logic.

#### Relevant tickets
Fixes [#162426572](https://www.pivotaltracker.com/story/show/162426572).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md