### PR TITLE
Revert "Always update signup for latest (or empty) run, if it exists."

### DIFF
--- a/app/Http/Controllers/Legacy/Two/SignupsController.php
+++ b/app/Http/Controllers/Legacy/Two/SignupsController.php
@@ -51,7 +51,7 @@ class SignupsController extends ApiController
     public function store(SignupRequest $request)
     {
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id']);
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -65,7 +65,7 @@ class SignupsController extends ApiController
         $northstarId = getNorthstarId($request);
 
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($northstarId, $request['campaign_id']);
+        $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Managers/Legacy/Two/SignupManager.php
+++ b/app/Managers/Legacy/Two/SignupManager.php
@@ -58,11 +58,12 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
+     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId)
+    public function get($northstarId, $campaignId, $campaignRunId)
     {
-        $signup = $this->signup->get($northstarId, $campaignId);
+        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
 
         return $signup;
     }

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -105,11 +105,12 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
+     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId)
+    public function get($northstarId, $campaignId, $campaignRunId)
     {
-        $signup = $this->signup->get($northstarId, $campaignId);
+        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
 
         return $signup;
     }

--- a/app/Repositories/Legacy/Two/SignupRepository.php
+++ b/app/Repositories/Legacy/Two/SignupRepository.php
@@ -49,16 +49,16 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
+     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId)
+    public function get($northstarId, $campaignId, $campaignRunId)
     {
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-        ])->orderByRaw('campaign_run_id IS NULL DESC')
-            ->orderBy('campaign_run_id', 'desc')
-            ->first();
+            'campaign_run_id' => $campaignRunId,
+        ])->first();
 
         return $signup;
     }

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -49,16 +49,16 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
+     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId)
+    public function get($northstarId, $campaignId, $campaignRunId)
     {
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-        ])->orderByRaw('campaign_run_id IS NULL DESC')
-            ->orderBy('campaign_run_id', 'desc')
-            ->first();
+            'campaign_run_id' => $campaignRunId,
+        ])->first();
 
         return $signup;
     }

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -90,6 +90,9 @@ class SignupTest extends TestCase
     {
         $signup = factory(Signup::class)->states('contentful')->create();
 
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignup');
+
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/signups', [
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
@@ -104,66 +107,6 @@ class SignupTest extends TestCase
                 'campaign_id' => $signup->campaign_id,
                 'campaign_run_id' => null,
                 'quantity' => $signup->getQuantity(),
-            ],
-        ]);
-    }
-
-    /**
-     * Test that a POST request to /signups doesn't create duplicate signups
-     * if we don't provide the same 'campaign_run_id' that already is set.
-     *
-     * POST /api/v3/signups
-     * @return void
-     */
-    public function testNotCreatingDuplicateSignupsWithoutRun()
-    {
-        // Create a signup with a `campaign_id` and `campaign_run_id`.
-        $signup = factory(Signup::class)->create();
-
-        // Now, try to sign up again (without providing the same run ID).
-        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/signups', [
-            'northstar_id' => $signup->northstar_id,
-            'campaign_id' => $signup->campaign_id,
-        ]);
-
-        // Make sure we get the 200 response
-        $response->assertStatus(200);
-        $response->assertJson([
-            'data' => [
-                'id' => $signup->id,
-                'campaign_id' => $signup->campaign_id,
-                'campaign_run_id' => $signup->campaign_run_id,
-            ],
-        ]);
-    }
-
-    /**
-     * Test that a POST request to /signups doesn't create duplicate signups
-     * if we don't provide the same 'campaign_run_id' that already is set, and
-     * we've got signups created in a new run-less world alongside old runs.
-     *
-     * POST /api/v3/signups
-     * @return void
-     */
-    public function testNotCreatingDuplicateSignupsWithAndWithoutRunId()
-    {
-        // Create a signup with a `campaign_id` and `campaign_run_id`.
-        $olderSignup = factory(Signup::class)->create();
-        $newerSignup = factory(Signup::class)->create(['campaign_run_id' => null]);
-
-        // Now, try to sign up again (without providing the same run ID).
-        $response = $this->withAccessToken($newerSignup->northstar_id)->postJson('api/v3/signups', [
-            'northstar_id' => $newerSignup->northstar_id,
-            'campaign_id' => $newerSignup->campaign_id,
-        ]);
-
-        // Make sure we get the 200 response
-        $response->assertStatus(200);
-        $response->assertJson([
-            'data' => [
-                'id' => $newerSignup->id,
-                'campaign_id' => $newerSignup->campaign_id,
-                'campaign_run_id' => $newerSignup->campaign_run_id,
             ],
         ]);
     }


### PR DESCRIPTION
This pull request reverts the update made in DoSomething/rogue#788 to (try to) assign signups to the latest `campaign_run_id` if that parameter is omitted from the request. In doing so, however, we'd unintentionally started applying signups to the latest run the user had participated in (not the latest for the whole campaign), and so if a user had participated in a prior run of a campaign they'd not be able to sign up for the new run.