### PR TITLE
Remove ability to write or query campaign_run_id.

### DIFF
--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -63,7 +63,6 @@ class ImportSignupsCommand extends Command
             $existing_signup = Signup::where([
                 ['northstar_id', $missing_signup['northstar_id']],
                 ['campaign_id', $missing_signup['campaign_node_id']],
-                ['campaign_run_id', $missing_signup['campaign_run_id']],
             ])->first();
 
             // Create a signup if there isn't one already
@@ -71,7 +70,6 @@ class ImportSignupsCommand extends Command
                 $signup = Signup::create([
                     'northstar_id' => $missing_signup['northstar_id'],
                     'campaign_id' => $missing_signup['campaign_node_id'],
-                    'campaign_run_id' => $missing_signup['campaign_run_id'],
                     'source' => 'phoenix-next',
                     'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp'] : Carbon::now(),
                 ]);

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -13,7 +13,7 @@ class UpdateSignup extends Command
      *
      * @var string
      */
-    protected $signature = 'rogue:updatesignups {--target= : The name of the field to update} {--targetValue= : The value to update the target with} {--campaign= : The campaign_id to search for signups under} {--campaign_run= : The campaign_run_id to search for signups under} {--date= : Will be used to search for signups greater than the provided value}';
+    protected $signature = 'rogue:updatesignups {--target= : The name of the field to update} {--targetValue= : The value to update the target with} {--campaign= : The campaign_id to search for signups under} {--date= : Will be used to search for signups greater than the provided value}';
 
     /**
      * The console command description.
@@ -67,10 +67,6 @@ class UpdateSignup extends Command
 
         if ($this->option('campaign')) {
             $query = $query->where('campaign_id', $this->option('campaign'));
-        }
-
-        if ($this->option('campaign_run')) {
-            $query = $query->where('campaign_run_id', $this->option('campaign_run'));
         }
 
         // Only take in one date and we assume to be looking for things on or after that date.

--- a/app/Http/Controllers/Legacy/Two/SignupsController.php
+++ b/app/Http/Controllers/Legacy/Two/SignupsController.php
@@ -51,7 +51,7 @@ class SignupsController extends ApiController
     public function store(SignupRequest $request)
     {
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id']);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -103,7 +103,7 @@ class PostsController extends ApiController
     {
         $northstarId = getNorthstarId($request);
 
-        $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($northstarId, $request['campaign_id']);
 
         if (! $signup) {
             $signup = $this->signups->create($request->all(), $northstarId);

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -58,14 +58,13 @@ class SignupsController extends ApiController
     {
         $this->validate($request, [
             'campaign_id' => 'required|integer',
-            'campaign_run_id' => 'int',
             'why_participated' => 'string',
         ]);
 
         $northstarId = getNorthstarId($request);
 
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($northstarId, $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($northstarId, $request['campaign_id']);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Http/Controllers/Traits/PostRequests.php
+++ b/app/Http/Controllers/Traits/PostRequests.php
@@ -18,7 +18,7 @@ trait PostRequests
      */
     public function store(PostRequest $request)
     {
-        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id'], $request['campaign_run_id']);
+        $signup = $this->signups->get($request['northstar_id'], $request['campaign_id']);
 
         $updating = ! is_null($signup);
 

--- a/app/Http/Requests/Legacy/Two/PostRequest.php
+++ b/app/Http/Requests/Legacy/Two/PostRequest.php
@@ -26,7 +26,6 @@ class PostRequest extends Request
         return [
             'northstar_id' => 'required|string',
             'campaign_id' => 'required|integer',
-            'campaign_run_id' => 'int',
             'quantity' => 'nullable|int',
             'caption' => 'nullable|string',
             'status' => 'in:pending,accepted,rejected',

--- a/app/Http/Requests/Legacy/Two/SignupRequest.php
+++ b/app/Http/Requests/Legacy/Two/SignupRequest.php
@@ -26,7 +26,6 @@ class SignupRequest extends Request
         return [
             'northstar_id' => 'required|string',
             'campaign_id' => 'required|integer',
-            'campaign_run_id' => 'int',
             'quantity' => 'int',
             'why_participated' => 'string',
             'source' => 'string|nullable',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -27,7 +27,6 @@ class PostRequest extends Request
 
         return [
             'campaign_id' => 'required|integer',
-            'campaign_run_id' => 'integer',
             'northstar_id' => 'nullable|objectid',
             'type' => 'required|string|in:photo,voter-reg,text,share-social',
             'action' => 'required|string',

--- a/app/Managers/Legacy/Two/SignupManager.php
+++ b/app/Managers/Legacy/Two/SignupManager.php
@@ -58,12 +58,11 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
-        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
+        $signup = $this->signup->get($northstarId, $campaignId);
 
         return $signup;
     }

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -105,12 +105,11 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
-        $signup = $this->signup->get($northstarId, $campaignId, $campaignRunId);
+        $signup = $this->signup->get($northstarId, $campaignId);
 
         return $signup;
     }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -21,7 +21,7 @@ class Campaign extends Model
      *
      * @var array
      */
-    protected $fillable = ['internal_title', 'cause', 'secondary_causes', 'campaign_run_id', 'impact_doc', 'start_date', 'end_date'];
+    protected $fillable = ['internal_title', 'cause', 'secondary_causes', 'impact_doc', 'start_date', 'end_date'];
 
     /**
      * Get the signups associated with this campaign.

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -30,7 +30,7 @@ class Signup extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'campaign_id', 'campaign_run_id', 'quantity', 'quantity_pending', 'why_participated', 'source', 'source_details', 'details', 'created_at', 'updated_at'];
+    protected $fillable = ['id', 'northstar_id', 'campaign_id', 'quantity', 'quantity_pending', 'why_participated', 'source', 'source_details', 'details', 'created_at', 'updated_at'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Repositories/Legacy/Two/SignupRepository.php
+++ b/app/Repositories/Legacy/Two/SignupRepository.php
@@ -19,7 +19,6 @@ class SignupRepository
 
         $signup->northstar_id = $data['northstar_id'];
         $signup->campaign_id = $data['campaign_id'];
-        $signup->campaign_run_id = isset($data['campaign_run_id']) ? $data['campaign_run_id'] : null;
         $signup->quantity = isset($data['quantity']) ? $data['quantity'] : null;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : null;
@@ -49,15 +48,13 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'campaign_run_id' => $campaignRunId,
         ])->first();
 
         return $signup;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -20,7 +20,6 @@ class SignupRepository
 
         $signup->northstar_id = $northstarId;
         $signup->campaign_id = $data['campaign_id'];
-        $signup->campaign_run_id = isset($data['campaign_run_id']) ? $data['campaign_run_id'] : null;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : token()->client();
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;
@@ -49,15 +48,13 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @param  int $campaignRunId
      * @return \Rogue\Models\Signup|null
      */
-    public function get($northstarId, $campaignId, $campaignRunId)
+    public function get($northstarId, $campaignId)
     {
         $signup = Signup::where([
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'campaign_run_id' => $campaignRunId,
         ])->first();
 
         return $signup;

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -33,7 +33,7 @@ class ExportService
      *
      * @return string CSV data
      */
-    public function exportSignups($campaignId, $campaignRunId)
+    public function exportSignups($campaignId)
     {
         // return $campaignId;
         $writer = Writer::createFromFileObject(new SplTempFileObject());
@@ -45,7 +45,6 @@ class ExportService
 
         $signups = Signup::whereNull('details')->where([
             ['campaign_id', '=', $campaignId],
-            ['campaign_run_id', '=', $campaignRunId],
             ['source', '=', 'phoenix-next'],
         ])->cursor();
 
@@ -54,7 +53,6 @@ class ExportService
 
             $nextRow = [
                 'campaign_id' => $signup->campaign_id,
-                'campaign_run_id' => $signup->campaign_run_id,
                 'northstar_id' => $signup->northstar_id,
                 'first_name' => $northstarUser->first_name ?? 'N/A',
                 'last_name' => $northstarUser->last_name ?? 'N/A',

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -63,7 +63,6 @@ $factory->define(Signup::class, function (Generator $faker) {
         'campaign_id' => function () {
             return factory(Campaign::class)->create()->id;
         },
-        'campaign_run_id' => $faker->randomNumber(4),
         'why_participated' => $faker->sentence(),
         'source' => 'phpunit',
         'details' => $faker->randomElement([null, 'fun-affiliate-stuff', 'i-say-the-tails']),

--- a/docs/endpoints/Legacy/Two/activity.md
+++ b/docs/endpoints/Legacy/Two/activity.md
@@ -9,7 +9,7 @@ GET /api/v2/activity
 ### Optional Query Parameters
 
 - **filter[column]** _(integer)_
-  - Filter results by the given column: `id`, `campaign_id`, `campaign_run_id`, `northstar_id`
+  - Filter results by the given column: `id`, `campaign_id`, `northstar_id`
   - You can filter by more than one column, e.g. `/activity?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/activity?filter[id]=121,122`
 - **limit** _(default is 20)_

--- a/docs/endpoints/Legacy/Two/posts.md
+++ b/docs/endpoints/Legacy/Two/posts.md
@@ -107,9 +107,7 @@ POST /api/v2/posts
 - **northstar_id**: (string) required.
   The northstar id of the user creating the post.
 - **campaign_id**: (int|string) required.
-  The drupal node id of the campaign that the user's post is associated with.
-- **campaign_run_id**: (int) optional.
-  The drupal campaign run node id of the campaign that the user's post is associated with.
+  The ID of the campaign that the user's post is associated with.
 - **quantity**: (int).
   The number of reportback nouns verbed.
 - **why_participated**: (string).
@@ -141,7 +139,7 @@ POST /api/v2/posts
 - **updated_at**: (string) optional.
   `Y-m-d H:i:s` format. When the post was last updated.
 - **type**: (string).
-  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social. 
+  The type of post submitted. Must be one of the following types: photo, voter-reg, text, share-social.
 - **action**: (string).
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 

--- a/docs/endpoints/Legacy/Two/signups.md
+++ b/docs/endpoints/Legacy/Two/signups.md
@@ -9,9 +9,7 @@ POST /api/v2/signups
 - **northstar_id**: (string) required.
   The northstar id of the user signing up.
 - **campaign_id**: (int|string) required.
-  The drupal node id of the campaign the user is signing up for.
-- **campaign_run_id**: (int) optional.
-  The drupal campaign run node id of the campaign run the user is signing up for.
+  The ID of the campaign the user is signing up for.
 - **quantity**: (int) optional.
   The approved number of reportback nouns verbed.
 - **quantity_pending**: (int) optional.

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -167,8 +167,6 @@ POST /api/v3/posts
 
 - **campaign_id**: (int) required.
   The Campaign ID of the campaign that the user's post is associated with.
-- **campaign_run_id**: (int)
-  The drupal campaign run node id of the campaign that the user's post is associated with.
 - **type**: (string) required.
   The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **action**: (string) required.

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -10,8 +10,6 @@ POST /api/v3/signups
 
 - **campaign_id**: (int|string) required.
   The drupal node id of the campaign the user is signing up for.
-- **campaign_run_id**: (int) optional.
-  The drupal campaign run node id of the campaign run the user is signing up for.
 - **northstar_id**: (int) optional.
   The `northstar_id` of the user who the signup belongs to. This `northstar_id` will be used when acting `asClient`. Otherwise, if the request comes in acting `asUser`, it will ignore this and attribute the signup to the `northstar_id` from OAuth.
 - **why_participated**: (string) optional.
@@ -65,7 +63,7 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
   - You can also use include parameters to only return posts by type.
   - e.g. To only return text and photo posts: `api/v3/signups?include=posts:type(text|photo)`
 - **filter[column]** _(string)_
-  - Filter results by the given column: `northstar_id`, `campaign_id`, `campaign_run_id`, `source`
+  - Filter results by the given column: `northstar_id`, `campaign_id`, `source`
   - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
 - **orderBy** _(string)_

--- a/resources/assets/components/PostUploader/index.js
+++ b/resources/assets/components/PostUploader/index.js
@@ -53,7 +53,6 @@ class PostUploader extends React.Component {
       media: this.state.media,
       text: this.caption.value,
       campaignId: this.props.campaignId,
-      campaignRunId: this.props.campaignRunId,
       northstarId: this.props.northstarId,
       status: 'accepted',
     };
@@ -174,7 +173,6 @@ class PostUploader extends React.Component {
 
 PostUploader.propTypes = {
   campaignId: PropTypes.string.isRequired,
-  campaignRunId: PropTypes.number,
   northstarId: PropTypes.string.isRequired,
   signup: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   source: PropTypes.string.isRequired,

--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -359,7 +359,6 @@ class Signup extends React.Component {
     const fields = {
       northstar_id: post.northstarId,
       campaign_id: post.campaignId,
-      campaign_run_id: post.campaignRunId,
       quantity: post.quantity,
       why_participated: post.whyParticipated,
       text: post.text,

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -29,9 +29,6 @@ class SignupCard extends React.Component {
                 {campaign ? campaign.internal_title : signup.campaign_id}
               </h2>
               <h4 className="heading">Campaign ID: {signup.campaign_id}</h4>
-              <h4 className="heading">
-                Campaign Run ID: {signup.campaign_run_id}
-              </h4>
               {campaign ? (
                 <h4 className="heading">
                   Campaign Run Start Date: {campaign.start_date}
@@ -80,7 +77,6 @@ SignupCard.propTypes = {
     why_participated: PropTypes.string,
     signup_id: PropTypes.number,
     campaign_id: PropTypes.string,
-    campaign_run_id: PropTypes.number,
     quantity: PropTypes.number,
   }).isRequired,
   campaign: PropTypes.shape({

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -7,26 +7,6 @@ import { RestApiClient } from '@dosomething/gateway';
 import { extractPostsFromSignups } from '../../helpers';
 
 class SignupCard extends React.Component {
-  /**
-   * Gets the campaign run start date.
-   *
-   * @param {Object} campaignRuns
-   * @param {String} campaignRunId
-   * @return {String}
-   */
-  getCampaignRunStartDate(campaignRuns, campaignRunId) {
-    for (const key in campaignRuns) {
-      if (campaignRuns[key].id == campaignRunId) {
-        const date = campaignRuns[key].start_date;
-
-        if (date) {
-          return campaignRuns[key].start_date.split(' ')[0];
-        }
-      }
-      return null;
-    }
-  }
-
   render() {
     const signup = this.props.signup;
     const campaign = this.props.campaign;
@@ -46,7 +26,7 @@ class SignupCard extends React.Component {
           <div className="container__block -half">
             <div className="container__row">
               <h2 className="heading">
-                {campaign ? campaign.title : signup.campaign_id}
+                {campaign ? campaign.internal_title : signup.campaign_id}
               </h2>
               <h4 className="heading">Campaign ID: {signup.campaign_id}</h4>
               <h4 className="heading">
@@ -54,11 +34,7 @@ class SignupCard extends React.Component {
               </h4>
               {campaign ? (
                 <h4 className="heading">
-                  Campaign Run Start Date:{' '}
-                  {this.getCampaignRunStartDate(
-                    campaign.campaign_runs.current,
-                    signup.campaign_run_id,
-                  )}
+                  Campaign Run Start Date: {campaign.start_date}
                 </h4>
               ) : null}
             </div>
@@ -74,13 +50,7 @@ class SignupCard extends React.Component {
                   <div className="quantity">{signup.quantity}</div>
                 </div>
                 <div className="figure__body">
-                  <h4 className="reportback-noun-verb">
-                    {campaign
-                      ? `${campaign.reportback_info.noun} ${
-                          campaign.reportback_info.verb
-                        }`
-                      : ''}
-                  </h4>
+                  <h4 className="reportback-noun-verb">things done</h4>
                 </div>
               </div>
             ) : null}
@@ -114,9 +84,8 @@ SignupCard.propTypes = {
     quantity: PropTypes.number,
   }).isRequired,
   campaign: PropTypes.shape({
-    title: PropTypes.string,
-    campaign_runs: PropTypes.object,
-    reportback_info: PropTypes.object,
+    internal_title: PropTypes.string,
+    start_date: PropTypes.string,
   }),
 };
 

--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -31,7 +31,7 @@ class SignupCard extends React.Component {
               <h4 className="heading">Campaign ID: {signup.campaign_id}</h4>
               {campaign ? (
                 <h4 className="heading">
-                  Campaign Run Start Date: {campaign.start_date}
+                  Campaign Start Date: {campaign.start_date}
                 </h4>
               ) : null}
             </div>

--- a/resources/assets/components/UploaderModal/index.js
+++ b/resources/assets/components/UploaderModal/index.js
@@ -45,7 +45,6 @@ class UploaderModal extends React.Component {
 UploaderModal.propTypes = {
   signup: PropTypes.shape({
     campaign_id: PropTypes.string,
-    campaign_run_id: PropTypes.number,
     northstar_id: PropTypes.string,
   }).isRequired,
   campaign: PropTypes.shape({

--- a/resources/assets/components/UploaderModal/index.js
+++ b/resources/assets/components/UploaderModal/index.js
@@ -13,7 +13,6 @@ class UploaderModal extends React.Component {
 
     const photoUploaderProps = {
       campaignId: signup.campaign_id,
-      campaignRunId: signup.campaign_run_id,
       northstarId: signup.northstar_id,
       noun: {
         plural: 'items',

--- a/tests/Console/ImportSignupsCommandTest.php
+++ b/tests/Console/ImportSignupsCommandTest.php
@@ -20,7 +20,6 @@ class ImportSignupsCommandTest extends TestCase
         $this->assertDatabaseHas('signups', [
             'northstar_id' => '56e83a07469c64d8578b5ed4',
             'campaign_id' => '362',
-            'campaign_run_id' => '2341',
             'source' => 'phoenix-next',
             'created_at' => '2014-03-13 21:39:01',
         ]);
@@ -28,7 +27,6 @@ class ImportSignupsCommandTest extends TestCase
         $this->assertDatabaseHas('signups', [
             'northstar_id' => '5589c9bb469c6475138b81f0',
             'campaign_id' => '1144',
-            'campaign_run_id' => '5066',
             'source' => 'phoenix-next',
             'created_at' => '2013-11-06 23:32:03',
         ]);

--- a/tests/Http/Legacy/Two/ActivityApiTest.php
+++ b/tests/Http/Legacy/Two/ActivityApiTest.php
@@ -309,7 +309,7 @@ class ActivityApiTest extends TestCase
      * GET /activity?filter[]=
      * @return void
      */
-    public function testActivityIndexWithNorthstarIdAndCampaignRunIdFilters()
+    public function testActivityIndexWithNorthstarIdAndCampaignIdFilters()
     {
         $signup = factory(Signup::class)->create(['northstar_id' => 17, 'campaign_id' => 143]);
         factory(Signup::class, 5)->create();

--- a/tests/Http/Legacy/Two/ActivityApiTest.php
+++ b/tests/Http/Legacy/Two/ActivityApiTest.php
@@ -29,7 +29,6 @@ class ActivityApiTest extends TestCase
                     'signup_id',
                     'northstar_id',
                     'campaign_id',
-                    'campaign_run_id',
                     'quantity',
                     'why_participated',
                     'signup_source',
@@ -125,17 +124,16 @@ class ActivityApiTest extends TestCase
      */
     public function testActivityIndexWithMultipleFilters()
     {
-        factory(Signup::class, 3)->create(['campaign_id' => 14, 'campaign_run_id' => 132]);
+        factory(Signup::class, 3)->create(['campaign_id' => 14, 'source' => 'factory']);
         factory(Signup::class, 5)->create();
 
-        $response = $this->getJson('api/v2/activity?filter[campaign_id]=14&filter[campaign_run_id]=132');
+        $response = $this->getJson('api/v2/activity?filter[campaign_id]=14&filter[source]=factory');
 
         $response->assertStatus(200);
         $response->assertJson([
             'data' => [
                 [
                     'campaign_id' => 14,
-                    'campaign_run_id' => 132,
                     // ...
                 ],
             ],
@@ -146,14 +144,14 @@ class ActivityApiTest extends TestCase
      * Test for retrieving a user's activity with combination of query params
      * where we expect nothing to be returned.
      *
-     * GET /activity?filter[campaign_run_id]=479,49&filter[campaign_run_id]=z
+     * GET /activity?filter[campaign_id]=479,49&filter[campaign_id]=z
      * @return void
      */
     public function testActivityIndexWithFilterAndNoResults()
     {
         $signups = factory(Signup::class, 2)->create();
 
-        $response = $this->getJson('api/v2/activity?filter[campaign_id]=' . $signups[0]->campaign_id . ',' . $signups[1]->campaign_id . '&filter[campaign_run_id]=z');
+        $response = $this->getJson('api/v2/activity?filter[campaign_id]=' . $signups[0]->campaign_id . ',' . $signups[1]->campaign_id . '&filter[campaign_id]=z');
 
         $response->assertStatus(200);
         $response->assertJson(['data' => []]);
@@ -247,7 +245,6 @@ class ActivityApiTest extends TestCase
                     'signup_id',
                     'northstar_id',
                     'campaign_id',
-                    'campaign_run_id',
                     'quantity',
                     'why_participated',
                     'signup_source',
@@ -307,17 +304,17 @@ class ActivityApiTest extends TestCase
     }
 
     /**
-     * Test for retrieving a user's activity with northstar_id and campaign_run_id query params.
+     * Test for retrieving a user's activity with northstar_id and campaign_id query params.
      *
      * GET /activity?filter[]=
      * @return void
      */
     public function testActivityIndexWithNorthstarIdAndCampaignRunIdFilters()
     {
-        $signup = factory(Signup::class)->create(['northstar_id' => 17, 'campaign_run_id' => 143]);
+        $signup = factory(Signup::class)->create(['northstar_id' => 17, 'campaign_id' => 143]);
         factory(Signup::class, 5)->create();
 
-        $response = $this->getJson('api/v2/activity?filter[northstar_id]=17&filter[campaign_run_id]=143');
+        $response = $this->getJson('api/v2/activity?filter[northstar_id]=17&filter[campaign_id]=143');
 
         $response->assertStatus(200);
         $response->assertJson([
@@ -325,7 +322,7 @@ class ActivityApiTest extends TestCase
                 [
                     'signup_id' => $signup->id,
                     'northstar_id' => '17',
-                    'campaign_run_id' => '143',
+                    'campaign_id' => '143',
                 ],
             ],
             'meta' => [

--- a/tests/Http/Legacy/Two/PostApiTest.php
+++ b/tests/Http/Legacy/Two/PostApiTest.php
@@ -20,7 +20,6 @@ class PostApiTest extends TestCase
     {
         $northstar_id = $this->faker->uuid;
         $campaign_id = $this->faker->randomNumber(4);
-        $campaign_run_id = $this->faker->randomNumber(4);
         $quantity = 10;
         $caption = $this->faker->sentence;
 
@@ -33,7 +32,6 @@ class PostApiTest extends TestCase
         $response = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $northstar_id,
             'campaign_id'      => $campaign_id,
-            'campaign_run_id'  => $campaign_run_id,
             'quantity'         => $quantity,
             'type'             => 'photo',
             'action'           => 'default',
@@ -93,7 +91,6 @@ class PostApiTest extends TestCase
         $response = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
             'num_participants' => null,
@@ -147,7 +144,6 @@ class PostApiTest extends TestCase
         $response = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => $quantity,
             'type'             => 'photo',
             'action'           => 'default',
@@ -207,7 +203,6 @@ class PostApiTest extends TestCase
         $response = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
             'num_participants' => null,
@@ -249,7 +244,6 @@ class PostApiTest extends TestCase
         $secondResponse = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => $secondQuantity,
             'num_participants' => null,
             'caption'          => $secondCaption,
@@ -313,7 +307,6 @@ class PostApiTest extends TestCase
         $firstPost = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => 10,
             'caption'          => 'Fake caption',
             'source'           => 'testing',
@@ -335,7 +328,6 @@ class PostApiTest extends TestCase
         $secondPost = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => 20,
             'caption'          => 'Fake caption',
             'source'           => 'testing',
@@ -362,7 +354,6 @@ class PostApiTest extends TestCase
         $thirdPost = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => 5,
             'caption'          => 'Fake caption',
             'source'           => 'testing',
@@ -394,7 +385,6 @@ class PostApiTest extends TestCase
         $fourthPost = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => 25,
             'caption'          => 'Fake caption',
             'source'           => 'testing',
@@ -455,7 +445,6 @@ class PostApiTest extends TestCase
         $firstPost = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => 10,
             'caption'          => 'Fake caption',
             'source'           => 'testing',
@@ -477,7 +466,6 @@ class PostApiTest extends TestCase
         $secondPost = $this->withRogueApiKey()->json('POST', 'api/v2/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'quantity'         => 20,
             'caption'          => 'Fake caption',
             'source'           => 'testing',

--- a/tests/Http/Legacy/Two/SignupApiTest.php
+++ b/tests/Http/Legacy/Two/SignupApiTest.php
@@ -17,7 +17,6 @@ class SignupApiTest extends TestCase
     {
         $northstarId = '54fa272b469c64d7068b456a';
         $campaignId = $this->faker->randomNumber(4);
-        $campaignRunId = $this->faker->randomNumber(4);
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
@@ -25,7 +24,6 @@ class SignupApiTest extends TestCase
         $response = $this->withRogueApiKey()->postJson('api/v2/signups', [
             'northstar_id'     => $northstarId,
             'campaign_id'      => $campaignId,
-            'campaign_run_id'  => $campaignRunId,
             'source'           => 'the-fox-den',
             'details'          => 'affiliate-messaging',
         ]);
@@ -36,7 +34,6 @@ class SignupApiTest extends TestCase
             'data' => [
                 'northstar_id' => $northstarId,
                 'campaign_id' => $campaignId,
-                'campaign_run_id' => $campaignRunId,
                 'signup_source' => 'the-fox-den',
                 'quantity' => null,
                 'why_participated' => null,
@@ -47,7 +44,6 @@ class SignupApiTest extends TestCase
         $this->assertDatabaseHas('signups', [
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'campaign_run_id' => $campaignRunId,
             'details' => 'affiliate-messaging',
         ]);
     }

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -56,7 +56,6 @@ class PostTest extends TestCase
     {
         $northstarId = $this->faker->northstar_id;
         $campaignId = $this->faker->randomNumber(4);
-        $campaignRunId = $this->faker->randomNumber(4);
         $quantity = $this->faker->numberBetween(10, 1000);
         $why_participated = $this->faker->paragraph;
         $text = $this->faker->sentence;
@@ -70,7 +69,6 @@ class PostTest extends TestCase
         // Create the post!
         $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,
-            'campaign_run_id'  => $campaignRunId,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -121,7 +119,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -173,7 +170,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'text',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -221,7 +217,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'voter-reg',
             'action'           => 'test-action',
             'quantity'         => null,
@@ -262,7 +257,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'share-social',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -304,7 +298,6 @@ class PostTest extends TestCase
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'share-social',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -346,7 +339,6 @@ class PostTest extends TestCase
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'share-social',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -389,7 +381,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'social-share',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -419,7 +410,6 @@ class PostTest extends TestCase
         $response = $this->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -451,7 +441,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -483,7 +472,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $secondQuantity,
@@ -528,7 +516,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => null,
@@ -569,7 +556,6 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'text'             => $text,
@@ -609,7 +595,6 @@ class PostTest extends TestCase
         $response = $this->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'campaign_run_id'  => $signup->campaign_run_id,
             'type'             => 'photo',
             'action'           => 'test-action',
             'quantity'         => $quantity,
@@ -776,26 +761,20 @@ class PostTest extends TestCase
      */
     public function testPostsIndexAsOwner()
     {
-        // Owners should only see accepted posts and their own pending/rejected posts.
-        $posts = factory(Post::class, 2)->create();
-        $rejectedPosts = factory(Post::class, 'rejected', 3)->create();
+        $userId = $this->faker->unique()->northstar_id;
+        factory(Post::class, 2)->create(['northstar_id' => $userId]);
+        factory(Post::class, 'rejected', 1)->create(['northstar_id' => $userId]);
 
-        $northstarId = $this->faker->northstar_id;
+        $otherId = $this->faker->unique()->northstar_id;
+        factory(Post::class, 'rejected', 4)->create(['northstar_id' => $otherId]);
 
-        foreach ($posts as $post) {
-            $post->northstar_id = $northstarId;
-            $post->save();
-        }
 
-        foreach ($rejectedPosts as $rejectedPost) {
-            $rejectedPost->northstar_id = $this->faker->unique()->northstar_id;
-            $rejectedPost->save();
-        }
+        // Owners should only see their own pending/accepted posts, and not
+        // any others user's pending or rejected posts:
+        $response = $this->withAccessToken($userId)->getJson('api/v3/posts');
 
-        $response = $this->withAccessToken($northstarId)->getJson('api/v3/posts');
-        $response->assertStatus(200);
-        $response->assertJsonCount(2, 'data');
-
+        $response->assertSuccessful();
+        $response->assertJsonCount(3, 'data');
         $response->assertJsonStructure([
             'data' => [
                 '*' => [
@@ -1205,7 +1184,6 @@ class PostTest extends TestCase
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'campaign_run_id' => $signup->campaign_run_id,
             'type' => 'voter-reg',
             'action' => 'test-action',
             'status' => 'register-form',

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -769,8 +769,8 @@ class PostTest extends TestCase
         factory(Post::class, 'rejected', 4)->create(['northstar_id' => $otherId]);
 
 
-        // Owners should only see their own pending/accepted posts, and not
-        // any others user's pending or rejected posts:
+        // Owners should be able to see their own posts of any status, but
+        // not pending or rejected posts from other users.
         $response = $this->withAccessToken($userId)->getJson('api/v3/posts');
 
         $response->assertSuccessful();


### PR DESCRIPTION
#### What's this PR do?
This pull request removes the ability to create new posts or signups with `campaign_run_id` values or to filter on existing values (so `?filter[campaign_run_id]`, for example, is a no-op). We can make a follow-up pull request in a few sprints to remove the `campaign_run_id` field from the database and transformers once and for all.

#### How should this be reviewed?
I started by removing assertions that depended on `campaign_run_id`, then removed the ability to read or write that value from the application. Rather than add some short-lived tests to ensure we can't write this value anymore, let's just have a quick testing party after we deploy this.

#### Any background context you want to provide?
The plan is to deploy this [once we've run the script](https://github.com/DoSomething/infrastructure/issues/61) to remove `campaign_run_id` values in production, so that even if Ashes, Phoenix, and Gambit aren't immediately updated to stop querying or writing this value, we can safely ignore it here.

#### Relevant tickets
References DoSomething/infrastructure#61.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md