### PR TITLE
Remove ability to query on campaign_run_id.

### DIFF
--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -41,7 +41,7 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'campaign_run_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source'
+        'campaign_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source'
     ];
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request removes the ability to query signups based on `campaign_run_id` (forgot in #798). Without this change, Ashes was still able to query based on that field when checking if a signup exists in the `ActivityController` & would always return "false" for new signups.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
References [this failing Ghostie test](https://app.ghostinspector.com/tests/56d8a9691a6744a446a04bf4).

#### Relevant tickets
References #798.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md