### PR TITLE
Fix up some table styling issues.

### DIFF
--- a/resources/assets/components/Table/index.js
+++ b/resources/assets/components/Table/index.js
@@ -10,7 +10,7 @@ class Table extends React.Component {
   render() {
     const heading = this.props.headings.map((title, index) => (
       <th key={index} className="table__cell">
-        <h3 className="heading -delta">{title}</h3>
+        {title}
       </th>
     ));
 

--- a/resources/assets/components/Table/table.scss
+++ b/resources/assets/components/Table/table.scss
@@ -13,41 +13,38 @@
   }
 }
 
+/**
+ * Table
+ */
 .table {
   display: table;
   width: 100%;
-  border: 1px solid $med-gray;
-  border-radius: 2px;
+  border: 1px solid $light-gray;
+  border-radius: $sm-border-radius;
+  border-collapse: separate; // Needed to display border radius on table.
+
+  @include media($small) {
+    display: block;
+  }
 }
 
 .table__header {
-  background: white;
-  color: $black;
-  border: 1px solid $med-gray;
+  background: $white;
+  color: $purple;
   font-weight: $weight-bold;
   text-align: left;
-
-  @include media($small) {
-    white-space: nowrap;
-  }
 }
 
 .table__row {
   display: table-row;
-  background: $light-gray;
-  border: 1px solid $med-gray;
-}
+  background: $white;
 
-.table__cell {
-  padding: 6px 12px;
-  display: table-cell;
-  border: 1px solid $med-gray;
-
-  @include media($small) {
-    white-space: nowrap;
+  &:nth-of-type(odd) {
+    background: #efefef;
   }
 }
 
-.table__row:nth-child(odd) {
-  background: white;
+.table__cell {
+  padding: ($base-spacing / 4) ($base-spacing / 2);
+  display: table-cell;
 }

--- a/resources/views/campaign-ids/index.blade.php
+++ b/resources/views/campaign-ids/index.blade.php
@@ -32,7 +32,7 @@
                                     <td class="table__cell"><a href="{{ route('campaign-ids.show', [$campaign->id]) }}">{{ $campaign->internal_title}}</a></td>
                                     <td class="table__cell">{{ $campaign->id }}</td>
                                     <td class="table__cell">{{ $campaign->cause }}</td>
-                                    <td class="table__cell"><a href="{{ $campaign->impact_doc }}" target="_blank">{{ $campaign->impact_doc }}</a></td>
+                                    <td class="table__cell"><a href="{{ $campaign->impact_doc }}" target="_blank">Read</a></td>
                                     <td class="table__cell">{{ $campaign->start_date->format('m/d/Y') }}</td>
                                     <td class="table__cell">{{ $campaign->end_date ? $campaign->end_date->format('m/d/Y') : '–' }}</td>
                                 </tr>

--- a/resources/views/campaign-ids/index.blade.php
+++ b/resources/views/campaign-ids/index.blade.php
@@ -18,10 +18,10 @@
                     <table class="table">
                         <thead>
                             <tr class="table__header">
+                              <th class="table__cell">ID</th>
                               <th class="table__cell">Internal Name</th>
-                              <th class="table__cell">Campaign ID</th>
                               <th class="table__cell">Cause</th>
-                              <th class="table__cell">Proof of Impact</th>
+                              <th class="table__cell">Impact</th>
                               <th class="table__cell">Start Date</th>
                               <th class="table__cell">End Date</th>
                             </tr>
@@ -29,8 +29,8 @@
                         <tbody>
                             @foreach($campaigns as $campaign)
                                 <tr class="table__row">
+                                    <td class="table__cell"><code>{{ $campaign->id }}</code></td>
                                     <td class="table__cell"><a href="{{ route('campaign-ids.show', [$campaign->id]) }}">{{ $campaign->internal_title}}</a></td>
-                                    <td class="table__cell">{{ $campaign->id }}</td>
                                     <td class="table__cell">{{ $campaign->cause }}</td>
                                     <td class="table__cell"><a href="{{ $campaign->impact_doc }}" target="_blank">Read</a></td>
                                     <td class="table__cell">{{ $campaign->start_date->format('m/d/Y') }}</td>


### PR DESCRIPTION
#### What's this PR do?
I noticed some styling issues when looking at Campaign IDs on production:

<img width="1301" alt="screen shot 2018-12-10 at 12 34 28 pm" src="https://user-images.githubusercontent.com/583202/49750481-fe729f80-fc78-11e8-929e-cfcd4e94a459.png">

This pull request collapses Impact URLs into "Read" links & snags table styles from Aurora:

<img width="1378" alt="screen shot 2018-12-10 at 12 40 57 pm" src="https://user-images.githubusercontent.com/583202/49750504-121e0600-fc79-11e8-8603-8dc9369e86ca.png">


#### How should this be reviewed?
👀

#### Any background context you want to provide?
🎨

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
