### PR TITLE
Fix some bugs introduced during cleanup.

### DIFF
--- a/app/Http/Controllers/Legacy/Two/PostsController.php
+++ b/app/Http/Controllers/Legacy/Two/PostsController.php
@@ -5,14 +5,11 @@ namespace Rogue\Http\Controllers\Legacy\Two;
 use Illuminate\Http\Request;
 use Rogue\Managers\Legacy\Two\PostManager;
 use Rogue\Http\Requests\Legacy\Two\PostRequest;
-use Rogue\Http\Controllers\Traits\FiltersRequests;
 use Rogue\Repositories\Legacy\Two\SignupRepository;
 use Rogue\Http\Transformers\Legacy\Two\PostTransformer;
 
 class PostsController extends ApiController
 {
-    use FiltersRequests;
-
     /**
      * The post manager instance.
      *

--- a/app/Http/Controllers/Legacy/Two/PostsController.php
+++ b/app/Http/Controllers/Legacy/Two/PostsController.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Controllers\Legacy\Two;
 
+use Illuminate\Http\Request;
 use Rogue\Managers\Legacy\Two\PostManager;
 use Rogue\Http\Requests\Legacy\Two\PostRequest;
 use Rogue\Http\Controllers\Traits\FiltersRequests;


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes up a few issues from my cleanup in #799.

🐞 Imports `Illuminate\Http\Request` to `PostsController`, fixing these errors we were seeing:

```
[10-Dec-2018 18:48:12 UTC] [2018-12-10 18:48:12] production.ERROR: Class Rogue\Http\Controllers\Legacy\Two\Request does not exist {"exception":"[object] (ReflectionException(code: 0): Class Rogue\\Http\\Controllers\\Legacy\\Two\\Request does not exist at /app/vendor/laravel/framework/src/Illuminate/Routing/RouteSignatureParameters.php:25)"} {"user_id":null,"client_id":null,"request_id":"e72291ea-cdd8-4b90-a9b1-a55b3d86ff8a"} 
```

🗄 Removes unnecessary `FiltersRequests` trait from `PostsController`, since this is [already imported in the `Legacy\Two\ApiController` that we're extending here](https://github.com/DoSomething/rogue/blob/master/app/Http/Controllers/Legacy/Two/ApiController.php).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Bummed we didn't have test coverage for these, but I don't know if it's worth adding since we should be able to remove these shortly, once Ashes is out of the picture.

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md