### PR TITLE
Fix missing heading for cause-less campaigns.

### DIFF
--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -10,7 +10,7 @@ class CampaignOverview extends React.Component {
     const causeTables = map(causeData, (data, cause) => (
       <CampaignTable
         key={cause}
-        cause={cause}
+        cause={cause || 'Uncategorized'}
         campaigns={data}
         causeData={causeData}
       />


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes a little display issue in the inbox for cause-less campaigns. Before:

<img width="1378" alt="screen shot 2018-12-10 at 4 01 51 pm" src="https://user-images.githubusercontent.com/583202/49761407-017b8900-fc95-11e8-9e97-f8c93b83544c.png">

And after:

<img width="1378" alt="screen shot 2018-12-10 at 4 01 54 pm" src="https://user-images.githubusercontent.com/583202/49761415-06403d00-fc95-11e8-9da5-ac938c40ec19.png">

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Long-term, we'll probably want to categorize or delete these causeless campaigns… but until that time this makes the admin panel a wee bit less confusing!

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
