### PR TITLE
Fix order of constraint/column deletion in old migration.

### DIFF
--- a/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
+++ b/database/migrations/2016_10_11_200952_drop_file_id_from_reactions.php
@@ -13,9 +13,9 @@ class DropFileIdFromReactions extends Migration
     public function up()
     {
         Schema::table('reactions', function (Blueprint $table) {
-            $table->dropColumn('file_id');
-
             $table->dropUnique('file_drupal_ns_taxonomy_unique');
+
+            $table->dropColumn('file_id');
         });
     }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes [an issue running migrations in MariaDB](https://dosomething.slack.com/archives/C0YGXUE01/p1544116303023600?thread_ts=1544115869.023000&cid=C0YGXUE01). This made it impossible to spin up a new Rogue database without a database dump made in MySQL, and therefore pretty unhelpful to run MariaDB in development.

Specifically, the issue was because we were trying to delete this constraint once the column it depended on was already removed in the line above, and so we'd get this error:

```
SQLSTATE[42000]: Syntax error or access violation: 1072 Key column 'file_id' doesn't exist in table (SQL: alter table `reactions` drop `file_id`)
```

#### How should this be reviewed?
Take a peek at the changed migration. For extra credit, follow the updated directions in DoSomething/communal-docs#20 to update your Homestead and confirm this works! 🤓

#### Any background context you want to provide?
We've been running MySQL in development, but using MariaDB on our RDS instances. This isn't great dev/prod parity, and so things might work on dev but not on production or vice versa (as this issue demonstrates)! With the change in this pull request, we can start using MariaDB for local development.

#### Relevant tickets
References DoSomething/communal-docs#20.