### PR TITLE
Fixes fatal issue on the campaign "show" page.

### DIFF
--- a/resources/views/campaign-ids/show.blade.php
+++ b/resources/views/campaign-ids/show.blade.php
@@ -14,7 +14,11 @@
                 <p>{{ $campaign->cause }}</p>
 
                 <h3>Proof of Impact</h3>
-                <p><a href="{{ url($campaign->impact_doc) }}" target="_blank">{{ $campaign->impact_doc }}</a></p>
+                @if($campaign->impact_doc)
+                    <p><a href="{{ $campaign->impact_doc }}" target="_blank">{{ $campaign->impact_doc }}</a></p>
+                @else
+                    <p>–</p>
+                @endif
 
                 <h3>Start Date</h3>
                 <p>{{ $campaign->start_date->format('m/d/Y') }}</p>

--- a/resources/views/campaign-ids/show.blade.php
+++ b/resources/views/campaign-ids/show.blade.php
@@ -11,7 +11,7 @@
                 <p>{{ $campaign->internal_title }}</p>
 
                 <h3>Cause</h3>
-                <p>{{ $campaign->cause }}</p>
+                <p>{{ $campaign->cause or '–' }}</p>
 
                 <h3>Proof of Impact</h3>
                 @if($campaign->impact_doc)

--- a/resources/views/campaign-ids/show.blade.php
+++ b/resources/views/campaign-ids/show.blade.php
@@ -10,6 +10,9 @@
                 <h3>Internal Campaign Name</h3>
                 <p>{{ $campaign->internal_title }}</p>
 
+                <h3>Campaign ID</h3>
+                <p>{{ $campaign->id }}</p>
+
                 <h3>Cause</h3>
                 <p>{{ $campaign->cause or '–' }}</p>
 


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes up a [fatal error](https://dosomething.slack.com/archives/C0YGXUE01/p1544633480025200) when viewing imported campaigns without an `impact_doc` set, and adds a "Campaign ID" field for a lil' better admin UX.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This was dying because we'd send `null` through `url()` and that would return the `UrlGenerator` instance rather than a string – since this is already a fully formed URL, I just removed that helper! I've also added a fallback so we show a `–` here if it's empty.

#### Relevant tickets
References this [Slack conversation](https://dosomething.slack.com/archives/C0YGXUE01/p1544633480025200).