### PR TITLE
Doesn't pass $signup to SignupTransformer if it has been soft deleted when hitting GET /posts?include=signup

### DIFF
--- a/app/Console/Commands/ImportAshesCampaigns.php
+++ b/app/Console/Commands/ImportAshesCampaigns.php
@@ -73,8 +73,8 @@ class ImportAshesCampaigns extends Command
                     $campaign = $this->createCampaign($legacy_campaign['run_id'], $legacy_campaign);
                 // If the campaign_id does not equal the next record's campaign_id or the previous record's campaign id, this is either the latest run or there is only one campaign run, so keep the original campaign_id as the id in Rogue.
                 } elseif ($legacy_campaigns_csv->fetchOne($iterator) &&
-                           $legacy_campaign['campaign_id'] != $legacy_campaigns_csv->fetchOne($iterator)['campaign_id'] &&
-                           $legacy_campaign['campaign_id'] != $legacy_campaigns_csv->fetchOne($iterator - 1)) {
+                    $legacy_campaign['campaign_id'] != $legacy_campaigns_csv->fetchOne($iterator)['campaign_id'] &&
+                    $legacy_campaign['campaign_id'] != $legacy_campaigns_csv->fetchOne($iterator - 1)) {
                     $campaign = $this->createCampaign($legacy_campaign['campaign_id'], $legacy_campaign);
                 // If this is the last row in the CSV, it must either be the only run or last run, so use the campaign_id as the id in Rogue.
                 } elseif (! $legacy_campaigns_csv->fetchOne($iterator)) {

--- a/app/Http/Controllers/Traits/AuthorizesWithToken.php
+++ b/app/Http/Controllers/Traits/AuthorizesWithToken.php
@@ -2,8 +2,6 @@
 
 namespace Rogue\Http\Controllers\Traits;
 
-use Rogue\Models\Post;
-
 trait AuthorizesWithToken
 {
     /**
@@ -15,7 +13,7 @@ trait AuthorizesWithToken
      */
     public function allowOwnerStaffOrMachine($user, $model)
     {
-        // If this is a machine token, show full post:
+        // If this is a machine token, show full model:
         if (token()->exists() && ! token()->id()) {
             return true;
         }

--- a/app/Http/Transformers/Legacy/Two/PostTransformer.php
+++ b/app/Http/Transformers/Legacy/Two/PostTransformer.php
@@ -67,6 +67,10 @@ class PostTransformer extends TransformerAbstract
      */
     public function includeSignup(Post $post)
     {
+        if (! $post->signup) {
+            return;
+        }
+
         // Don't include posts but include the user.
         $transformer = (new SignupTransformer)->setDefaultIncludes(['user']);
 

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -70,6 +70,10 @@ class PostTransformer extends TransformerAbstract
      */
     public function includeSignup(Post $post)
     {
+        if (! $post->signup) {
+            return;
+        }
+
         $transformer = (new SignupTransformer)->setDefaultIncludes(['user']);
 
         return $this->item($post->signup, $transformer);

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -63,10 +63,12 @@ class Campaign extends Model
 
             return;
         }
+
         // Parse user-entered strings like '10/31/1990' or `October 31st 1990'.
         if (is_string($value)) {
             $value = strtotime($value);
         }
+
         $this->attributes[$attribute] = $this->fromDateTime($value);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- If there is no `$signup` (it has been soft deleted and we don't have cascading deletes yet) when hitting the` /posts?include=signup`, don't call `SignupTransformer`
- Lots of StyleCi cleanup!

#### How should this be reviewed?
- Test endpoint that doesn't work in [this](https://www.pivotaltracker.com/n/projects/2019429/stories/158442898) Pivotal card and it should work! 

#### Any background context you want to provide?
We're getting a lot of Papertrail errors for this and we want to prevent false alarms!
```
Jul 05 14:19:32 rogue-prod app/web.1: [05-Jul-2018 21:19:32 UTC] [2018-07-05 21:19:32] production.ERROR: Type error: Argument 1 passed to Rogue\Http\Transformers\Legacy\Two\SignupTransformer::transform() must be an instance of Rogue\Models\Signup, null given, called in /app/vendor/league/fractal/src/Scope.php on line 338 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 1 passed to Rogue\\Http\\Transformers\\Legacy\\Two\\SignupTransformer::transform() must be an instance of Rogue\\Models\\Signup, null given, called in /app/vendor/league/fractal/src/Scope.php on line 338 at /app/app/Http/Transformers/Legacy/Two/SignupTransformer.p…
``` 

#### Relevant tickets
Fixes these Pivotal Cards:
https://www.pivotaltracker.com/n/projects/2019429/stories/158870350
https://www.pivotaltracker.com/n/projects/2019429/stories/158442898

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
