### PR TITLE
Configure New Relic extension in code & update dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "ext-gd": "*",
     "ext-exif": "*",
     "barryvdh/laravel-cors": "^0.11.0",
-    "fzaninotto/faker": "^1.6"
+    "fzaninotto/faker": "^1.6",
+    "ext-newrelic": "*"
   },
   "require-dev": {
     "filp/whoops": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4dd6ddbbba1ff400e8a74770c790460",
+    "content-hash": "d20514417c28bcd0420ca433e0a3fb39",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -60,16 +60,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.81.0",
+            "version": "3.81.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "99e35b38e894425f7626880f6ba017189a1ec337"
+                "reference": "e569fa3e8998dd20896ff189b063b61a5d42369d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/99e35b38e894425f7626880f6ba017189a1ec337",
-                "reference": "99e35b38e894425f7626880f6ba017189a1ec337",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/e569fa3e8998dd20896ff189b063b61a5d42369d",
+                "reference": "e569fa3e8998dd20896ff189b063b61a5d42369d",
                 "shasum": ""
             },
             "require": {
@@ -139,7 +139,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-12-05T21:13:40+00:00"
+            "time": "2018-12-11T23:08:33+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -3234,16 +3234,16 @@
         },
         {
             "name": "spatie/db-dumper",
-            "version": "2.11.1",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/db-dumper.git",
-                "reference": "858ea38e341e2e5f74a5b59cc8184c5c7e94b50d"
+                "reference": "61cf73e3b53e163d6e888a0013b9df6bb235752c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/858ea38e341e2e5f74a5b59cc8184c5c7e94b50d",
-                "reference": "858ea38e341e2e5f74a5b59cc8184c5c7e94b50d",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/61cf73e3b53e163d6e888a0013b9df6bb235752c",
+                "reference": "61cf73e3b53e163d6e888a0013b9df6bb235752c",
                 "shasum": ""
             },
             "require": {
@@ -3280,7 +3280,7 @@
                 "mysqldump",
                 "spatie"
             ],
-            "time": "2018-09-27T06:30:34+00:00"
+            "time": "2018-12-10T10:41:18+00:00"
         },
         {
             "name": "spatie/laravel-backup",
@@ -4847,16 +4847,16 @@
         },
         {
             "name": "itsgoingd/clockwork",
-            "version": "v3.1",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itsgoingd/clockwork.git",
-                "reference": "4adcf0a923849bd68b3f4d2fcb0041a5b8ca59f8"
+                "reference": "69f311569e2bbb0ec4e01e732767c5c8d7c0ef0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itsgoingd/clockwork/zipball/4adcf0a923849bd68b3f4d2fcb0041a5b8ca59f8",
-                "reference": "4adcf0a923849bd68b3f4d2fcb0041a5b8ca59f8",
+                "url": "https://api.github.com/repos/itsgoingd/clockwork/zipball/69f311569e2bbb0ec4e01e732767c5c8d7c0ef0d",
+                "reference": "69f311569e2bbb0ec4e01e732767c5c8d7c0ef0d",
                 "shasum": ""
             },
             "require": {
@@ -4901,7 +4901,7 @@
                 "profiling",
                 "slim"
             ],
-            "time": "2018-12-03T17:36:12+00:00"
+            "time": "2018-12-06T20:42:00+00:00"
         },
         {
             "name": "laravel/dusk",
@@ -6500,7 +6500,8 @@
     "platform": {
         "php": "~7.2.0",
         "ext-gd": "*",
-        "ext-exif": "*"
+        "ext-exif": "*",
+        "ext-newrelic": "*"
     },
     "platform-dev": []
 }

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,3 +1,7 @@
 upload_max_filesize = 10M
 post_max_size = 10M
 memory_limit = 256M
+
+; Custom New Relic settings, in addition to Heroku's
+; defaults, which are set here <https://git.io/fpazT>:
+newrelic.enabled = "${NEW_RELIC_ENABLED}"


### PR DESCRIPTION
#### What's this PR do?
This pull request configures the New Relic extension in code. This will allow us to disable New Relic on our QA instances and still have the extension built when promoting that Heroku slug into production.

Also, updated Composer dependencies:

```
Updating dependencies (including require-dev)
Package operations: 0 installs, 3 updates, 0 removals
  - Updating itsgoingd/clockwork (v3.1 => v3.1.1)
  - Updating aws/aws-sdk-php (3.81.0 => 3.81.3)
  - Updating spatie/db-dumper (2.11.1 => 2.12.0)
```

#### How should this be reviewed?
Builds should pass!

Also, a reminder to [update your Homestead environment](https://git.io/fpdne) if you haven't already (since Composer will now start checking whether `ext-newrelic` is around when running installs/updates). If you don't have time for a rebuild right now, you can run the agent install steps from `after.sh` by hand in your terminal!

#### Any background context you want to provide?
This `NEW_RELIC_ENABLED` environment variable is set in [our `laravel_app` Terraform module](https://github.com/DoSomething/infrastructure/blob/cbd3bde56f64ec821187bd3b299a252031494424/shared/laravel_app/main.tf#L94-L98) if New Relic should be used for that application, and should default to `false` so this isn't enabled on local machines.

#### Relevant tickets
Refs DoSomething/infrastructure#60.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md