### PR TITLE
Fixes Bug to Allow Staff to Upload Photos for Users and Post is Attributed to User

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -95,11 +95,11 @@ class PostRepository
         // If this is a share-social type post, auto-accept.
         $post->status = $post->type === 'share-social' ? 'accepted' : 'pending';
 
-        $isAdmin = auth()->user() && auth()->user()->role === 'admin';
+        $isAdminOrStaff = auth()->user() && auth()->user()->role === 'admin' || auth()->user()->role === 'staff';
         $hasAdminScope = in_array('admin', token()->scopes());
 
         // Admin users may provide a source, status, and created_at when uploading a post.
-        if ($isAdmin || $hasAdminScope) {
+        if ($isAdminOrStaff || $hasAdminScope) {
             // If the admin sets a custom status, set this status.
             if (isset($data['status'])) {
                 $post->status = $data['status'];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -84,7 +84,7 @@ function getAgeFromBirthdate($birthdate)
  */
 function getNorthstarId($request)
 {
-    if (token()->role() === 'admin' || in_array('admin', token()->scopes())) {
+    if (token()->role() === 'admin' || token()->role() === 'staff' || in_array('admin', token()->scopes())) {
         return isset($request['northstar_id']) ? $request['northstar_id'] : auth()->id();
     }
 


### PR DESCRIPTION
#### What's this PR do?
Fixes Bug to Allow Staff to Upload Photos for Users and Post is Attributed to User. 
  - Before, only admins were able to do this so when a staff user tried to do this, it would upload a photo but would create a post under the staff's `northstar_id`.

#### How should this be reviewed?
- Use a staff account to upload a photo for a user on the `/signups/:signup_id` page.
- You should see the new post in the "Accepted" section. 
- Refresh the page. 
- The post should still be in the "Accepted" section and in the database, have a `northstar_id` of the user, not of the staff user. 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156852601) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
