### PR TITLE
Adds arbitrary limit to when grabbing campaigns to avoid pagination

### DIFF
--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -72,6 +72,8 @@ class UserOverview extends React.Component {
         filter: {
           id: ids.join(),
         },
+        //@TODO: when we update TransformsRequest.php to include limit=all,
+        // update this API request to use that instead of abritrary 1000.
         limit: 1000,
       })
       .then(json =>

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -72,6 +72,7 @@ class UserOverview extends React.Component {
         filter: {
           id: ids.join(),
         },
+        limit: 1000,
       })
       .then(json =>
         this.setState({

--- a/resources/assets/components/UserOverview/index.js
+++ b/resources/assets/components/UserOverview/index.js
@@ -72,9 +72,10 @@ class UserOverview extends React.Component {
         filter: {
           id: ids.join(),
         },
-        //@TODO: when we update TransformsRequest.php to include limit=all,
-        // update this API request to use that instead of abritrary 1000.
-        limit: 1000,
+        // @TODO: update this to paginate calls to smaller batches or use GraphQL
+        // to be able to request only the subset of campaign fields we actually use for the UI
+        // (to make sure performance isn't hit).
+        limit: 100,
       })
       .then(json =>
         this.setState({


### PR DESCRIPTION
#### What's this PR do?
Adds arbitrary limit to when grabbing campaigns to avoid pagination. I updated some things in [this](https://github.com/DoSomething/rogue/pull/814/files) PR to fix the bug to grab campaign names. However, after testing, it seemed like only some campaign names were showing up on the user page. This is because of pagination! The front end would make a call to `/campaigns` and filter by campaign id according to a user's signup. If a user had many signups, only the first 20 campaign names would show up. This adds a limit of `1000` to hopefully do a quick fix for this. 

In the future, I think we should add something like `limit=all` to the API to avoid this and return all records instead of a paginated collection.

#### How should this be reviewed?
Do all the campaign names in the user profile page in [this](https://www.pivotaltracker.com/n/projects/2019429/stories/162742881) Pivotal Card show up? 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/162742881) Pivotal Card. 
Related to work down in #814 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
