### PR TITLE
adds check to see if auth()->user() after or conditional in PostRepository

### DIFF
--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -95,7 +95,7 @@ class PostRepository
         // If this is a share-social type post, auto-accept.
         $post->status = $post->type === 'share-social' ? 'accepted' : 'pending';
 
-        $isAdminOrStaff = auth()->user() && auth()->user()->role === 'admin' || auth()->user()->role === 'staff';
+        $isAdminOrStaff = auth()->user() && auth()->user()->role === 'admin' || auth()->user() && auth()->user()->role === 'staff';
         $hasAdminScope = in_array('admin', token()->scopes());
 
         // Admin users may provide a source, status, and created_at when uploading a post.

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -95,7 +95,8 @@ class PostRepository
         // If this is a share-social type post, auto-accept.
         $post->status = $post->type === 'share-social' ? 'accepted' : 'pending';
 
-        $isAdminOrStaff = auth()->user() && auth()->user()->role === 'admin' || auth()->user() && auth()->user()->role === 'staff';
+        $isAdminOrStaff = auth()->user() && in_array(auth()->user()->role, ['admin', 'staff']);
+
         $hasAdminScope = in_array('admin', token()->scopes());
 
         // Admin users may provide a source, status, and created_at when uploading a post.


### PR DESCRIPTION
#### What's this PR do?
adds check to see if `auth()->user()` after `||` conditional in PostRepository to make sure it exists before checking to avoid errors we saw [here](https://dosomething.slack.com/archives/C0YGXUE01/p1546537309014400)

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes work done in #815 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
