### PR TITLE
Fixes bug that shows 11 pending posts for Grab the mic run 1 when the inbox is empty

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -70,6 +70,7 @@ class CampaignService
                     DB::raw('SUM(case when posts.status = "rejected" && posts.deleted_at is null then 1 else 0 end) as rejected_count'))
                 ->where('signups.campaign_id', '=', $campaign['id'])
                 ->groupBy('signups.campaign_id')
+                ->whereNull('signups.deleted_at')
                 ->first();
     }
 


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug that shows 11 pending posts for Grab the mic run 1 when the inbox is empty.
- This is happening because the query isn't omitting signups that are deleted - there was a deleted signup that had pending posts and the pending count thus returned 11 because it didn't omit these posts.
- This PR updates the `getPostTotals` query to remove any signups that have been deleted.

#### How should this be reviewed?
👀 
On prod, is the Grab the mic run one pending count 0? 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/162968074) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
