### PR TITLE
Makes deleted_at an index in signups table

### DIFF
--- a/database/migrations/2019_01_07_181343_make_deleted_at_index_signups_table.php
+++ b/database/migrations/2019_01_07_181343_make_deleted_at_index_signups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeDeletedAtIndexSignupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropIndex('deleted_at');
+        });
+    }
+}


### PR DESCRIPTION

#### What's this PR do?
Adds migration to make `deleted_at` an index in `signups` table

#### How should this be reviewed?
👀 

#### Relevant tickets
Needed for changes in #818 so the query doesn't timeout.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
