### PR TITLE
Updates the `getPostTotals` query to run more efficiently

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -64,11 +64,12 @@ class CampaignService
     {
         return DB::table('posts')
                 ->select('campaign_id',
-                    DB::raw('SUM(case when status = "accepted" && deleted_at is null then 1 else 0 end) as accepted_count'),
-                    DB::raw('SUM(case when status = "pending" && deleted_at is null then 1 else 0 end) as pending_count'),
-                    DB::raw('SUM(case when status = "rejected" && deleted_at is null then 1 else 0 end) as rejected_count'))
+                    DB::raw('SUM(status = "accepted") as accepted_count'),
+                    DB::raw('SUM(status = "pending") as pending_count'),
+                    DB::raw('SUM(status = "rejected") as rejected_count'))
                 ->whereIn('status', ['accepted', 'pending', 'rejected'])
                 ->where('campaign_id', '=', $campaign['id'])
+                ->whereNull('deleted_at')
                 ->first();
     }
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -62,14 +62,13 @@ class CampaignService
      */
     public function getPostTotals($campaign)
     {
-        return DB::table('signups')
-                ->leftJoin('posts', 'signups.id', '=', 'posts.signup_id')
-                ->select('signups.campaign_id',
-                    DB::raw('SUM(case when posts.status = "accepted" && posts.deleted_at is null then 1 else 0 end) as accepted_count'),
-                    DB::raw('SUM(case when posts.status = "pending" && posts.deleted_at is null then 1 else 0 end) as pending_count'),
-                    DB::raw('SUM(case when posts.status = "rejected" && posts.deleted_at is null then 1 else 0 end) as rejected_count'))
-                ->where('signups.campaign_id', '=', $campaign['id'])
-                ->whereNull('signups.deleted_at')
+        return DB::table('posts')
+                ->select('campaign_id',
+                    DB::raw('SUM(case when status = "accepted" && deleted_at is null then 1 else 0 end) as accepted_count'),
+                    DB::raw('SUM(case when status = "pending" && deleted_at is null then 1 else 0 end) as pending_count'),
+                    DB::raw('SUM(case when status = "rejected" && deleted_at is null then 1 else 0 end) as rejected_count'))
+                ->whereIn('status', ['accepted', 'pending', 'rejected'])
+                ->where('campaign_id', '=', $campaign['id'])
                 ->first();
     }
 

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -69,7 +69,6 @@ class CampaignService
                     DB::raw('SUM(case when posts.status = "pending" && posts.deleted_at is null then 1 else 0 end) as pending_count'),
                     DB::raw('SUM(case when posts.status = "rejected" && posts.deleted_at is null then 1 else 0 end) as rejected_count'))
                 ->where('signups.campaign_id', '=', $campaign['id'])
-                ->groupBy('signups.campaign_id')
                 ->whereNull('signups.deleted_at')
                 ->first();
     }

--- a/database/migrations/2019_01_08_215314_creates_compound_index_in_posts_table_with_campaign_id_status_and_deleted_at.php
+++ b/database/migrations/2019_01_08_215314_creates_compound_index_in_posts_table_with_campaign_id_status_and_deleted_at.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatesCompoundIndexInPostsTableWithCampaignIdStatusAndDeletedAt extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index(['campaign_id', 'status', 'deleted_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex(['campaign_id', 'status', 'deleted_at']);
+        });
+    }
+}

--- a/tests/Unit/Services/CampaignServiceTest.php
+++ b/tests/Unit/Services/CampaignServiceTest.php
@@ -22,7 +22,7 @@ class CampaignServiceTest extends TestCase
                 $signup->posts()->saveMany(factory(Post::class, 3)->make(['campaign_id' => $testCampaign['id']]));
                 $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->make(['campaign_id' => $testCampaign['id']]));
                 $signup->posts()->saveMany(factory(Post::class, 'rejected', 3)->make(['campaign_id' => $testCampaign['id']]));
-        });
+            });
 
         $campaignService = $this->app->make(CampaignService::class);
         $campaignCounts = $campaignService->getPostTotals($testCampaign);

--- a/tests/Unit/Services/CampaignServiceTest.php
+++ b/tests/Unit/Services/CampaignServiceTest.php
@@ -15,22 +15,14 @@ class CampaignServiceTest extends TestCase
             'id' => 57,
             'title' => 'Babysitters Club',
         ];
-
         // Create 10 signups for the campaign.
         factory(Signup::class, 10)->create(['campaign_id' => $testCampaign['id']])
-            ->each(function (Signup $signup) {
+            ->each(function (Signup $signup) use ($testCampaign) {
                 // And for each signup, make 3 accepted, 3 rejected, and 3 pending posts.
-                $signup->posts()->saveMany(factory(Post::class, 3)->make());
-                $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->make());
-                $signup->posts()->saveMany(factory(Post::class, 'rejected', 3)->make());
-            });
-
-        $posts = Post::all();
-
-        foreach ($posts as $post) {
-            $post->campaign_id = 57;
-            $post->save();
-        }
+                $signup->posts()->saveMany(factory(Post::class, 3)->make(['campaign_id' => $testCampaign['id']]));
+                $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->make(['campaign_id' => $testCampaign['id']]));
+                $signup->posts()->saveMany(factory(Post::class, 'rejected', 3)->make(['campaign_id' => $testCampaign['id']]));
+        });
 
         $campaignService = $this->app->make(CampaignService::class);
         $campaignCounts = $campaignService->getPostTotals($testCampaign);

--- a/tests/Unit/Services/CampaignServiceTest.php
+++ b/tests/Unit/Services/CampaignServiceTest.php
@@ -25,6 +25,13 @@ class CampaignServiceTest extends TestCase
                 $signup->posts()->saveMany(factory(Post::class, 'rejected', 3)->make());
             });
 
+        $posts = Post::all();
+
+        foreach ($posts as $post) {
+            $post->campaign_id = 57;
+            $post->save();
+        }
+
         $campaignService = $this->app->make(CampaignService::class);
         $campaignCounts = $campaignService->getPostTotals($testCampaign);
 


### PR DESCRIPTION
#### What's this PR do?
After chatting with @DFurnes (see dialogue below), we realized the the query isn't running efficiently for only a few campaigns (including `8017` that have [a ton of posts](https://github.com/DoSomething/rogue/pull/820#issuecomment-452441479)! This query should run more efficiently then the previous query and returns the same information. 

Former approach: 
~~Gets rid of `groupBy` in getPostTotals` query.~~ 
  - ~~From #819 and #818 , `campaigns/:campaign_id` pages were timing out in QA.~~ 
  - ~~Per @DFurnes 's advice, I used clockwork and `[EXPLAIN`](https://www.sitepoint.com/using-explain-to-write-better-mysql-queries/) to improve this SQL statement so it doesn't timeout.~~ 
  - ~~From this, I saw that the query was `Using temporary` and according to the article, this can indicate a troublesome query.~~
  - ~~From [the docs](https://dev.mysql.com/doc/refman/5.6/en/explain-output.html#explain-extra-information) it seems like when `Using temporary` is used, a temporary table is created to hold the results when `GROUP BY` is used.~~
  - ~~By getting rid of `groupBy`, and rerunning the new query with `EXPLAIN`, this was gone and I think all still works.~~

#### How should this be reviewed?
👀 

#### Relevant tickets
#819 
#818 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
