### PR TITLE
Makes sure pending count query only counts photo and text posts

### DIFF
--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -68,6 +68,7 @@ class CampaignService
                     DB::raw('SUM(status = "pending") as pending_count'),
                     DB::raw('SUM(status = "rejected") as rejected_count'))
                 ->whereIn('status', ['accepted', 'pending', 'rejected'])
+                ->whereIn('type', ['photo', 'text'])
                 ->where('campaign_id', '=', $campaign['id'])
                 ->whereNull('deleted_at')
                 ->first();

--- a/app/Services/CampaignService.php
+++ b/app/Services/CampaignService.php
@@ -68,6 +68,7 @@ class CampaignService
                     DB::raw('SUM(status = "pending") as pending_count'),
                     DB::raw('SUM(status = "rejected") as rejected_count'))
                 ->whereIn('status', ['accepted', 'pending', 'rejected'])
+                // @TODO: if we ever want to expose other post types in Rogue to review/count, update this.
                 ->whereIn('type', ['photo', 'text'])
                 ->where('campaign_id', '=', $campaign['id'])
                 ->whereNull('deleted_at')


### PR DESCRIPTION
#### What's this PR do?
Updates `getPostTotals` query to only count `photo` and `text` posts so pending count is accurate and bug #818 is properly fixed (was incorrect about why this was happening in #818, discovered in [this comment](https://github.com/DoSomething/rogue/pull/820/files#issuecomment-453563430)). 

#### How should this be reviewed?
👀
On prod, is the Grab the mic run one pending count 0?

#### Any background context you want to provide?
Note: if we ever start showing accepted or rejected count in Rogue admin, we will want to rework this query since this will only count accepted/rejected photo and post counts. 

Also, there are 11 `voter-reg` posts that are `pending` - I believe this is a bug since they should all be `accepted`. We should run an update script to accept these (this is probably the real fix for the bug if we don't want to update this query).

#### Relevant tickets
Fixes issue in [this](https://www.pivotaltracker.com/n/projects/2019429/stories/162968074) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
