### PR TITLE
Removes updating active column in ImportPrePostMetaDataActions.php

### DIFF
--- a/app/Console/Commands/ImportPrePostMetaDataActions.php
+++ b/app/Console/Commands/ImportPrePostMetaDataActions.php
@@ -67,7 +67,6 @@ class ImportPrePostMetaDataActions extends Command
                     'reportback' => $backfill_action['reportback'],
                     'civic_action' => $backfill_action['civic_action'],
                     'scholarship_entry' => $backfill_action['scholarship_entry'],
-                    'active' => $backfill_action['active'],
                     'noun' => $backfill_action['noun'],
                     'verb' => $backfill_action['verb'],
                 ]);


### PR DESCRIPTION
#### What's this PR do?
Removes updating `active` column in ImportPrePostMetaDataActions.php. We decided in groom today we didn't need this data anymore. 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
We'll still keep the `active` column in the `actions` table and remove later if we need to.

#### Relevant tickets
Updates changes made in #825

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
