### PR TITLE
Add ISO-3166-2 location field to posts.

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -34,6 +34,7 @@ class PostRequest extends Request
             'action_id' => 'integer',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',
+            'location' => 'nullable|iso3166',
             'quantity' => 'nullable|integer',
             'file' => 'image|dimensions:min_width=400,min_height=400,max_width=5000,max_height_4000',
             'status' => $this->getStatusRules($this->type),

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -48,6 +48,7 @@ class PostTransformer extends TransformerAbstract
                 'total' => $post->reactions_count,
             ],
             'status' => $post->status,
+            'location' => $post->location,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -43,7 +43,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'location'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -28,6 +28,13 @@ class AppServiceProvider extends ServiceProvider
             return preg_match('/^[a-f\d]{24}$/i', $value);
         }, 'The :attribute must be a valid ObjectID.');
 
+        Validator::extend('iso3166', function ($attribute, $value, $parameters, $validator) {
+            $isoCodes = new \Sokil\IsoCodes\IsoCodesFactory();
+            $subDivisions = $isoCodes->getSubdivisions();
+
+            return ! is_null($subDivisions->getByCode($value));
+        }, 'The :attribute must be a valid ISO-3166-2 region code.');
+
         // Attach the user & request ID to context for all log messages.
         Log::getMonolog()->pushProcessor(function ($record) {
             $record['extra']['user_id'] = auth()->id();

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -104,6 +104,7 @@ class PostRepository
             'action_id' => $actionId,
             'url' => $fileUrl,
             'text' => isset($data['text']) ? $data['text'] : null,
+            'location' => isset($data['location']) ? $data['location'] : null,
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "ext-exif": "*",
     "barryvdh/laravel-cors": "^0.11.2",
     "fzaninotto/faker": "^1.6",
-    "ext-newrelic": "*"
+    "ext-newrelic": "*",
+    "sokil/php-isocodes": "^2.2"
   },
   "require-dev": {
     "filp/whoops": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fb0d705cf659a03e9ab9e9d44495fb0",
+    "content-hash": "e049145249d666f70a48f60d9c4e95b4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3231,6 +3231,54 @@
                 "uuid"
             ],
             "time": "2018-07-19T23:38:55+00:00"
+        },
+        {
+            "name": "sokil/php-isocodes",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sokil/php-isocodes.git",
+                "reference": "3b9515770b4ca0cc2f1ee040df4308ae81ea481e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sokil/php-isocodes/zipball/3b9515770b4ca0cc2f1ee040df4308ae81ea481e",
+                "reference": "3b9515770b4ca0cc2f1ee040df4308ae81ea481e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gettext": "*",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpmd/phpmd": "@stable",
+                "phpunit/phpunit": "^4.8 || ^6.5",
+                "satooshi/php-coveralls": ">=0.7.1 <2.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sokil\\IsoCodes\\": [
+                        "src/"
+                    ]
+                },
+                "classmap": [
+                    "stubs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dmytro Sokil",
+                    "email": "dmytro.sokil@gmail.com"
+                }
+            ],
+            "description": "ISO country, subdivision, language, currency and script definitions and their translations. Based on pythons pycountry.",
+            "time": "2019-01-31T14:46:24+00:00"
         },
         {
             "name": "spatie/db-dumper",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -46,6 +46,7 @@ $factory->define(Post::class, function (Generator $faker) {
         'northstar_id' => $this->faker->northstar_id,
         'url' => $url,
         'text' => $faker->sentence(),
+        'location' => 'US-'.$faker->stateAbbr(),
         'source' => 'phpunit',
         'status' => 'pending',
         'quantity' => $faker->randomNumber(2),

--- a/database/migrations/2019_02_20_162039_add_location_to_posts.php
+++ b/database/migrations/2019_02_20_162039_add_location_to_posts.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLocationToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            // This will store a maximum of 6 characters XX-XXX (2-letter country code, hyphen, 2-3 letter region code).
+            $table->string('location', 6)->nullable()->after('details')->comment('The ISO 3166-2 region code this was submitted from.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('location');
+        });
+    }
+}

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -81,6 +81,7 @@ Example Response:
                 "total": 2
             },
             "status": "accepted",
+            "location": "US-NY",
             "created_at": "2016-11-30T21:21:24+00:00",
             "updated_at": "2017-08-02T14:11:26+00:00"
         },
@@ -102,6 +103,7 @@ Example Response:
                 "total": 8
             },
             "status": "accepted",
+            "location": "US-NY",
             "created_at": "2016-02-10T16:19:25+00:00",
             "updated_at": "2017-08-02T14:11:35+00:00"
         }
@@ -149,6 +151,7 @@ Example Response:
     "total": 0
     },
     "status": "accepted",
+    "location": "US-NY",
     "created_at": "2019-01-23T19:42:07+00:00",
     "updated_at": "2019-01-23T19:42:07+00:00"
   }
@@ -179,6 +182,8 @@ POST /api/v3/posts
   Option to set status upon creation if admin uploads post for user.
 - **file**: (multipart/form-data) required for `photo` posts.
   File to save of post image.
+- **location** (string).
+  The The ISO 3166-2 region code this was submitted from, e.g. `US-NY`.
 - **details** (json).
   A JSON field to store extra details about a post.
 - **dont_send_to_blink** (boolean) optional.
@@ -208,6 +213,7 @@ Example Response:
         "total": null
     },
     "status": "pending",
+    "location": "US-NY",
     "created_at": "2018-12-06T21:44:15+00:00",
     "updated_at": "2018-12-06T21:44:15+00:00",
     "tags": [],
@@ -301,6 +307,7 @@ Example response:
           "total": null
       },
       "status": "accepted",
+      "location": "US-NY",
       "source": "rogue-admin",
       "remote_addr": "0.0.0.0",
       "created_at": "2017-10-27T14:50:22+00:00",

--- a/resources/assets/components/Post/__snapshots__/test.js.snap
+++ b/resources/assets/components/Post/__snapshots__/test.js.snap
@@ -273,6 +273,11 @@ exports[`it renders correctly 1`] = `
           <br />
         </span>
         <span>
+          Location
+          : 
+          <br />
+        </span>
+        <span>
           Post Source
           : 
           <br />

--- a/resources/assets/components/Post/index.js
+++ b/resources/assets/components/Post/index.js
@@ -149,6 +149,7 @@ class Post extends React.Component {
                 'Signup Source': signup.source,
                 'Post ID': post.id,
                 'Post Type': post.type,
+                Location: post.location,
                 'Post Source': post.source,
                 Submitted: new Date(post.created_at).toString(),
                 'Northstar Id': signup.northstar_id,

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -61,6 +61,7 @@ class PostTest extends TestCase
         $quantity = $this->faker->numberBetween(10, 1000);
         $why_participated = $this->faker->paragraph;
         $text = $this->faker->sentence;
+        $location = 'US-'.$this->faker->stateAbbr();
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Create an action to refer to.
@@ -80,6 +81,7 @@ class PostTest extends TestCase
             'quantity'         => $quantity,
             'why_participated' => $why_participated,
             'text'             => $text,
+            'location'         => $location,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
@@ -101,6 +103,7 @@ class PostTest extends TestCase
             'action' => 'test-action',
             'action_id' => $action->id,
             'status' => 'pending',
+            'location' => $location,
             'quantity' => $quantity,
             'details' => json_encode($details),
         ]);

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -218,6 +218,26 @@ class PostTest extends TestCase
     }
 
     /**
+     * test validation for updating a post.
+     *
+     * patch /api/v3/posts/195
+     * @return void
+     */
+    public function testCreatingAPostWithValidationErrors()
+    {
+        $signup = factory(Signup::class)->create();
+
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
+            'campaign_id' => 'dog', // This should be a numeric ID.
+            'signup_id' => $signup->id, // This one is okay.
+            'location' => 'the world', // This should be an ISO-3166-2 code.
+            // and we've omitted the required 'type' and 'action' fields!
+        ]);
+
+        $response->assertJsonValidationErrors(['campaign_id', 'location', 'type', 'action']);
+    }
+
+    /**
      * Test that a POST request to /posts creates a new voter-reg post.
      *
      * @return void

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -40,6 +40,7 @@ class PostTest extends TestCase
                 ],
                 'status',
                 'details',
+                'location',
                 'source',
                 'remote_addr',
                 'created_at',


### PR DESCRIPTION
#### What's this PR do?
This pull request adds an optional [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) location field to posts (e.g. `US-NY`, [etc.](https://en.wikipedia.org/wiki/ISO_3166-2:US)). We'll be using this when creating posts in Phoenix for the upcoming "prom" campaign, based on [Fastly's geolocation service](https://github.com/DoSomething/infrastructure/pull/156).

#### How should this be reviewed?
Feel free to review commit-by-commit. I've added tests for new functionality.

#### Any background context you want to provide?
N/A

#### Relevant tickets
[#163728657](https://www.pivotaltracker.com/story/show/163728657)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md