### PR TITLE
Updates frontend with anonymous post details 

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -52,10 +52,10 @@ class ActionsController extends Controller
 
         // Checkbox values are only sent from the front end if they are checked.
         // Get checkbox values if sent from the front end or via the API.
-        $request['reportback'] = isset($request['reportback']) && $request['reportback'] ? 1 : 0;
-        $request['civic_action'] = isset($request['civic_action']) && $request['civic_action'] ? 1 : 0;
-        $request['scholarship_entry'] = isset($request['scholarship_entry']) && $request['scholarship_entry'] ? 1 : 0;
-        $request['anonymous'] = isset($request['anonymous']) && $request['anonymous'] ? 1 : 0;
+        $request['reportback'] = isset($request['reportback']) && $request['reportback'] ? true : false;
+        $request['civic_action'] = isset($request['civic_action']) && $request['civic_action'] ? true : false;
+        $request['scholarship_entry'] = isset($request['scholarship_entry']) && $request['scholarship_entry'] ? true : false;
+        $request['anonymous'] = isset($request['anonymous']) && $request['anonymous'] ? true : false;
 
         // Check to see if the action exists before creating one.
         $action = Action::where([

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -56,6 +56,7 @@ class ActionsController extends Controller
         $request['civic_action'] = isset($request['civic_action']) && $request['civic_action'] ? 1 : 0;
         $request['scholarship_entry'] = isset($request['scholarship_entry']) && $request['scholarship_entry'] ? 1 : 0;
         $request['anonymous'] = isset($request['anonymous']) && $request['anonymous'] ? 1 : 0;
+        dd($request['anonymous']);
 
         // Check to see if the action exists before creating one.
         $action = Action::where([

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -56,7 +56,6 @@ class ActionsController extends Controller
         $request['civic_action'] = isset($request['civic_action']) && $request['civic_action'] ? 1 : 0;
         $request['scholarship_entry'] = isset($request['scholarship_entry']) && $request['scholarship_entry'] ? 1 : 0;
         $request['anonymous'] = isset($request['anonymous']) && $request['anonymous'] ? 1 : 0;
-        dd($request['anonymous']);
 
         // Check to see if the action exists before creating one.
         $action = Action::where([

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -62,6 +62,10 @@ class Action extends React.Component {
                 <p className="no">No</p>
               )}
             </li>
+          </ul>
+        </div>
+        <div className="container__row">
+          <ul>
             <li>
               <h4>ANONYMOUS POST</h4>
               {action.anonymous === true ? (

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -64,7 +64,7 @@ class Action extends React.Component {
             </li>
             <li>
               <h4>ANONYMOUS POST</h4>
-              {action.anonymous === 1 ? (
+              {action.anonymous === true ? (
                 <p className="yes">Yes</p>
               ) : (
                 <p className="no">No</p>

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -62,6 +62,14 @@ class Action extends React.Component {
                 <p className="no">No</p>
               )}
             </li>
+            <li>
+              <h4>ANONYMOUS POST</h4>
+              {action.anonymous === 1 ? (
+                <p className="yes">Yes</p>
+              ) : (
+                <p className="no">No</p>
+              )}
+            </li>
           </ul>
         </div>
       </div>

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -54,6 +54,11 @@
                           <span class="option__indicator"></span>
                           <span>Scholarship entry</span>
                         </label>
+                        <label class="option -checkbox">
+                          <input type="checkbox" id=anonymous name=anonymous value=1>
+                          <span class="option__indicator"></span>
+                          <span>Anonymous Post</span>
+                        </label>
                     </div>
                     <ul class="form-actions -inline -padded">
                         <li><input type="submit" class="button" value="Create Action"></li>


### PR DESCRIPTION
#### What's this PR do?
Updates frontend with anonymous post details:
  - Adds ability to create an anonymous action: 
![screen shot 2019-02-20 at 4 25 50 pm](https://user-images.githubusercontent.com/9019452/53125518-3412ef00-352c-11e9-9343-52382e425318.png)

  - Updates `Action` component to show if an action is anonymous or not: 
![screen shot 2019-02-20 at 4 24 09 pm](https://user-images.githubusercontent.com/9019452/53125500-278e9680-352c-11e9-873f-f2778e650d44.png)

#### How should this be reviewed?
@lkpttn this looks pretty ugly. Should I move the "ANONYMOUS POST" section to be on a separate line and keep the thirds alignment?

#### Relevant tickets
Fixes frontend for [this](https://www.pivotaltracker.com/n/projects/2019429/stories/164088666) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
