### PR TITLE
Fix some bugs with Action IDs.

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -30,8 +30,8 @@ class PostRequest extends Request
             'northstar_id' => 'nullable|objectid',
             'type' => 'required|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
-            'action' => 'required|string',
-            'action_id' => 'integer',
+            'action' => 'required_without:action_id|string',
+            'action_id' => 'required_without:action|integer|exists:actions',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',
             'location' => 'nullable|iso3166',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -31,7 +31,7 @@ class PostRequest extends Request
             'type' => 'required|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
             'action' => 'required_without:action_id|string',
-            'action_id' => 'required_without:action|integer|exists:actions',
+            'action_id' => 'required_without:action|integer|exists:actions,id',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',
             'location' => 'nullable|iso3166',

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -84,11 +84,11 @@ class PostRepository
             $actionId = $data['action_id'];
         } else {
             $type = isset($data['type']) ? $data['type'] : 'photo';
-            $action = Action::where('campaign_id', $signup->campaign_id)->where('post_type', $type)->where('name', $data['action'])->first();
-
-            if (! $action) {
-                throw new ModelNotFoundException('Action not found.');
-            }
+            $action = Action::where([
+                'campaign_id' => $signup->campaign_id,
+                'post_type' => $type,
+                'name' => $data['action'],
+            ])->firstOrFail();
 
             $actionId = $action->id;
         }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -9,7 +9,6 @@ use Rogue\Models\Review;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
 use Intervention\Image\Facades\Image;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class PostRepository
 {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -53,6 +53,35 @@ $factory->define(Post::class, function (Generator $faker) {
     ];
 });
 
+// @TODO: These should all extend a photo-less "base" post, instead.
+$factory->defineAs(Post::class, 'text', function (Generator $faker) {
+    $faker->addProvider(new FakerNorthstarId($faker));
+
+    return [
+        'type' => 'text',
+        'campaign_id' => function () {
+            return factory(Campaign::class)->create()->id;
+        },
+        'signup_id' => function (array $attributes) {
+            // If a 'signup_id' is not provided, create one for the same Campaign & Northstar ID.
+            return factory(Signup::class)->create([
+                'campaign_id' => $attributes['campaign_id'],
+                'northstar_id' => $attributes['northstar_id'],
+            ])->id;
+        },
+        'action_id' => function (array $attributes) {
+            return factory(Action::class)->create([
+                'campaign_id' => $attributes['campaign_id'],
+            ])->id;
+        },
+        'northstar_id' => $this->faker->northstar_id,
+        'text' => $faker->sentence(),
+        'location' => 'US-'.$faker->stateAbbr(),
+        'source' => 'phpunit',
+        'status' => 'pending',
+    ];
+});
+
 $factory->defineAs(Post::class, 'accepted', function () use ($factory) {
     return array_merge($factory->raw(Post::class), ['status' => 'accepted']);
 });

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -17,16 +17,21 @@ class DatabaseSeeder extends Seeder
     {
         // Create 10 campaigns with signups & posts.
         factory(Campaign::class, 10)->create()->each(function (Campaign $campaign) {
+            // Add a "default" action so this functions as expected in the "dev" environment.
+            $action = factory(Action::class)->create(['campaign_id' => $campaign->id, 'name' => 'default']);
+
             // Create 10-20 signups with one accepted post & some pending posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) {
+                ->each(function (Signup $signup) use ($action) {
                     $signup->posts()->save(factory(Post::class, 'accepted')->create([
+                        'action_id' => $action->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
                     $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->create([
+                        'action_id' => $action->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
@@ -35,8 +40,9 @@ class DatabaseSeeder extends Seeder
 
             // Create 5-10 signups with only accepted posts, from lil' angels!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) {
+                ->each(function (Signup $signup) use ($action) {
                     $signup->posts()->save(factory(Post::class, 'accepted')->create([
+                        'action_id' => $action->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
@@ -45,8 +51,9 @@ class DatabaseSeeder extends Seeder
 
             // Create 5-10 signups with rejected posts, from troublemakers!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) {
+                ->each(function (Signup $signup) use ($action) {
                     $signup->posts()->save(factory(Post::class, 'rejected')->create([
+                        'action_id' => $action->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
@@ -59,8 +66,5 @@ class DatabaseSeeder extends Seeder
 
         // And two campaigns with no activity yet.
         factory(Campaign::class, 2)->create();
-
-        // Create four actions.
-        factory(Action::class, 4)->create();
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -18,20 +18,28 @@ class DatabaseSeeder extends Seeder
         // Create 10 campaigns with signups & posts.
         factory(Campaign::class, 10)->create()->each(function (Campaign $campaign) {
             // Add a "default" action so this functions as expected in the "dev" environment.
-            $action = factory(Action::class)->create(['campaign_id' => $campaign->id, 'name' => 'default']);
+            $photoAction = factory(Action::class)->create(['post_type' => 'photo', 'campaign_id' => $campaign->id, 'name' => 'default']);
+            $textAction = factory(Action::class)->create(['post_type' => 'text', 'campaign_id' => $campaign->id, 'name' => 'default']);
 
-            // Create 10-20 signups with one accepted post & some pending posts.
+            // Create 10-20 signups with one accepted photo post & some pending photo and text posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) use ($action) {
+                ->each(function (Signup $signup) use ($photoAction, $textAction) {
                     $signup->posts()->save(factory(Post::class, 'accepted')->create([
-                        'action_id' => $action->id,
+                        'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
                     $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->create([
-                        'action_id' => $action->id,
+                        'action_id' => $photoAction->id,
+                        'signup_id' => $signup->id,
+                        'campaign_id' => $signup->campaign_id,
+                        'northstar_id' => $signup->northstar_id,
+                    ]));
+
+                    $signup->posts()->saveMany(factory(Post::class, 'text', rand(2, 4))->create([
+                        'action_id' => $textAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
@@ -40,9 +48,17 @@ class DatabaseSeeder extends Seeder
 
             // Create 5-10 signups with only accepted posts, from lil' angels!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) use ($action) {
+                ->each(function (Signup $signup) use ($photoAction, $textAction) {
                     $signup->posts()->save(factory(Post::class, 'accepted')->create([
-                        'action_id' => $action->id,
+                        'action_id' => $photoAction->id,
+                        'signup_id' => $signup->id,
+                        'campaign_id' => $signup->campaign_id,
+                        'northstar_id' => $signup->northstar_id,
+                    ]));
+
+                    $signup->posts()->saveMany(factory(Post::class, 'text', rand(2, 4))->create([
+                        'status' => 'accepted', // @TODO: We should have an "accepted" variant of the text factory!
+                        'action_id' => $textAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
@@ -51,9 +67,9 @@ class DatabaseSeeder extends Seeder
 
             // Create 5-10 signups with rejected posts, from troublemakers!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) use ($action) {
+                ->each(function (Signup $signup) use ($photoAction, $textAction) {
                     $signup->posts()->save(factory(Post::class, 'rejected')->create([
-                        'action_id' => $action->id,
+                        'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes some things that caught me off guard when working in Phoenix:

🗺 Instead of throwing a 404 error if an action isn't created, throw a standard 422. (Throwing a 404 is confusing because it indicates that the `v3/posts` API resource doesn't exist, which is not true).

🌱 Add a `default` action to the model seeder so these exist for the dev environment (to match up with what we set in Contentful), and fixes issue where we'd create a fresh action for _every_ single seeded post.

📄 Finally, adds a default "text" action and posts so we can use the Text Submission Action on these seeded campaigns without doing any more manual setup steps.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
N/A

#### Relevant tickets
References [this Slack conversation](https://dosomething.slack.com/archives/C3ASB4204/p1550695423014100).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md