### PR TITLE
Removes `campaign_id` requirement when creating a signup or post when there's an `action_id`

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -3,6 +3,7 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Post;
+use Rogue\Models\Campaign;
 use Illuminate\Http\Request;
 use Rogue\Managers\PostManager;
 use Rogue\Managers\SignupManager;
@@ -109,7 +110,7 @@ class PostsController extends ApiController
         $northstarId = getNorthstarId($request);
 
         // Get the campaign id from the request by campaign_id or action_id.
-        $campaignId = $request['campaign_id'] ? $request['campaign_id'] : get_campaign_by_action_id($request['action_id'])->id;
+        $campaignId = $request['campaign_id'] ? $request['campaign_id'] : Campaign::fromActionId($request['action_id'])->id;
 
         $signup = $this->signups->get($northstarId, $campaignId);
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -114,7 +114,7 @@ class PostsController extends ApiController
         $signup = $this->signups->get($northstarId, $campaignId);
 
         if (! $signup) {
-            $signup = $this->signups->create($request->all(), $northstarId);
+            $signup = $this->signups->create($request->all(), $northstarId, $campaignId);
         }
 
         $post = $this->posts->create($request->all(), $signup->id);

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -108,7 +108,10 @@ class PostsController extends ApiController
     {
         $northstarId = getNorthstarId($request);
 
-        $signup = $this->signups->get($northstarId, $request['campaign_id']);
+        // Get the campaign id from the request by campaign_id or action_id.
+        $campaignId = $request['campaign_id'] ? $request['campaign_id'] : get_campaign_by_action_id($request['action_id'])->id;
+
+        $signup = $this->signups->get($northstarId, $campaignId);
 
         if (! $signup) {
             $signup = $this->signups->create($request->all(), $northstarId);

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -58,8 +58,8 @@ class SignupsController extends ApiController
     {
         $this->validate($request, [
             'campaign_id' => 'required_without:action_id|integer',
-            'why_participated' => 'string',
             'action_id' => 'required_without:campaign_id|integer',
+            'why_participated' => 'string',
         ]);
 
         $northstarId = getNorthstarId($request);

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -73,7 +73,7 @@ class SignupsController extends ApiController
         $code = $signup ? 200 : 201;
 
         if (! $signup) {
-            $signup = $this->signups->create($request->all(), $northstarId);
+            $signup = $this->signups->create($request->all(), $northstarId, $campaignId);
         }
 
         return $this->item($signup, $code);

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -57,14 +57,18 @@ class SignupsController extends ApiController
     public function store(Request $request)
     {
         $this->validate($request, [
-            'campaign_id' => 'required|integer',
+            'campaign_id' => 'required_without:action_id|integer',
             'why_participated' => 'string',
+            'action_id' => 'required_without:campaign_id|integer',
         ]);
 
         $northstarId = getNorthstarId($request);
 
+        // Get the campaign id from the request by campaign_id or action_id.
+        $campaignId = $request['campaign_id'] ? $request['campaign_id'] : get_campaign_by_action_id($request['action_id'])->id;
+
         // Check to see if the signup exists before creating one.
-        $signup = $this->signups->get($northstarId, $request['campaign_id']);
+        $signup = $this->signups->get($northstarId, $campaignId);
 
         $code = $signup ? 200 : 201;
 

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -3,6 +3,7 @@
 namespace Rogue\Http\Controllers;
 
 use Rogue\Models\Signup;
+use Rogue\Models\Campaign;
 use Illuminate\Http\Request;
 use Rogue\Managers\SignupManager;
 use Rogue\Http\Transformers\SignupTransformer;
@@ -65,7 +66,7 @@ class SignupsController extends ApiController
         $northstarId = getNorthstarId($request);
 
         // Get the campaign id from the request by campaign_id or action_id.
-        $campaignId = $request['campaign_id'] ? $request['campaign_id'] : get_campaign_by_action_id($request['action_id'])->id;
+        $campaignId = $request['campaign_id'] ? $request['campaign_id'] : Campaign::fromActionId($request['action_id'])->id;
 
         // Check to see if the signup exists before creating one.
         $signup = $this->signups->get($northstarId, $campaignId);

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -28,7 +28,7 @@ class PostRequest extends Request
         return [
             'campaign_id' => 'required_without:action_id|integer',
             'northstar_id' => 'nullable|objectid',
-            'type' => 'required_without:action_id|string|in:photo,voter-reg,text,share-social',
+            'type' => 'required|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
             'action' => 'required_without:action_id|string',
             'action_id' => 'required_without:action,campaign_id|integer|exists:actions,id',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -30,7 +30,7 @@ class PostRequest extends Request
             'northstar_id' => 'nullable|objectid',
             'type' => 'required_without:action_id|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
-            'action' => 'required_without:action_id|string',
+            'action' => 'required|string',
             'action_id' => 'required_without:action,campaign_id|integer|exists:actions,id',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -26,7 +26,7 @@ class PostRequest extends Request
         }
 
         return [
-            'campaign_id' => 'required|integer',
+            'campaign_id' => 'required_without:action_id|integer',
             'northstar_id' => 'nullable|objectid',
             'type' => 'required|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -30,7 +30,7 @@ class PostRequest extends Request
             'northstar_id' => 'nullable|objectid',
             'type' => 'required_without:action_id|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
-            'action' => 'required|string',
+            'action' => 'required_without:action_id|string',
             'action_id' => 'required_without:action,campaign_id|integer|exists:actions,id',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -31,7 +31,7 @@ class PostRequest extends Request
             'type' => 'required|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
             'action' => 'required_without:action_id|string',
-            'action_id' => 'required_without:action|integer|exists:actions,id',
+            'action_id' => 'required_without:action,campaign_id|integer|exists:actions,id',
             'why_participated' => 'nullable|string',
             'text' => 'nullable|string|max:256',
             'location' => 'nullable|iso3166',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -28,7 +28,7 @@ class PostRequest extends Request
         return [
             'campaign_id' => 'required_without:action_id|integer',
             'northstar_id' => 'nullable|objectid',
-            'type' => 'required|string|in:photo,voter-reg,text,share-social',
+            'type' => 'required_without:action_id|string|in:photo,voter-reg,text,share-social',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
             'action' => 'required_without:action_id|string',
             'action_id' => 'required_without:action,campaign_id|integer|exists:actions,id',

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -37,7 +37,7 @@ class SignupManager
      */
     public function create($data, $northstarId, $campaignId)
     {
-        $signup = $this->signup->create($data, $northstarId);
+        $signup = $this->signup->create($data, $northstarId, $campaignId);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
         $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -32,9 +32,10 @@ class SignupManager
      *
      * @param array $data
      * @param string $northstarId
+     * @param integer $campaignId
      * @return Illuminate\Database\Eloquent\Model $model
      */
-    public function create($data, $northstarId)
+    public function create($data, $northstarId, $campaignId)
     {
         $signup = $this->signup->create($data, $northstarId);
 

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -32,7 +32,7 @@ class SignupManager
      *
      * @param array $data
      * @param string $northstarId
-     * @param integer $campaignId
+     * @param int $campaignId
      * @return Illuminate\Database\Eloquent\Model $model
      */
     public function create($data, $northstarId, $campaignId)

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -74,11 +74,11 @@ class Campaign extends Model
      *
      * @param $actionId
      */
-    function fromActionId($actionId)
+    public function fromActionId($actionId)
     {
         $action = Action::findOrFail($actionId);
 
-        return Campaign::findOrFail($action->campaign_id);
+        return self::findOrFail($action->campaign_id);
     }
 
     /**

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -70,6 +70,18 @@ class Campaign extends Model
     }
 
     /**
+     * Gets campaign by action_id.
+     *
+     * @param $actionId
+     */
+    function fromActionId($actionId)
+    {
+        $action = Action::findOrFail($actionId);
+
+        return Campaign::findOrFail($action->campaign_id);
+    }
+
+    /**
      * Mutator to parse non-standard date strings into dates accepted by Laravel.
      *
      * @param string|Carbon $value

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -74,7 +74,7 @@ class Campaign extends Model
      *
      * @param $actionId
      */
-    public function fromActionId($actionId)
+    public static function fromActionId($actionId)
     {
         $action = Action::findOrFail($actionId);
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -81,11 +81,11 @@ class PostRepository
         // Get the action_id either from the payload or the DB.
         if (isset($data['action_id'])) {
             $actionId = $data['action_id'];
+            $action = Action::findOrFail($data['action_id']);
         } else {
-            $type = isset($data['type']) ? $data['type'] : 'photo';
             $action = Action::where([
                 'campaign_id' => $signup->campaign_id,
-                'post_type' => $type,
+                'post_type' => $data['type'],
                 'name' => $data['action'],
             ])->firstOrFail();
 
@@ -98,8 +98,8 @@ class PostRepository
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
             'quantity' => isset($data['quantity']) ? $data['quantity'] : null,
-            'type' => isset($data['type']) ? $data['type'] : 'photo',
-            'action' => isset($data['action']) ? $data['action'] : null,
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $actionId,
             'url' => $fileUrl,
             'text' => isset($data['text']) ? $data['text'] : null,

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -19,7 +19,7 @@ class SignupRepository
         $signup = new Signup;
 
         $signup->northstar_id = $northstarId;
-        $signup->campaign_id = $data['campaign_id'] ? $data['campaign_id'] : get_campaign_by_action_id($data['action_id'])->id;];
+        $signup->campaign_id = $data['campaign_id'] ? $data['campaign_id'] : get_campaign_by_action_id($data['action_id'])->id;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : token()->client();
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -11,15 +11,16 @@ class SignupRepository
      *
      * @param  array $data
      * @param  string $northstarId
+     * @param  integer $campaignId
      * @return \Rogue\Models\Signup|null
      */
-    public function create($data, $northstarId)
+    public function create($data, $northstarId, $campaignId)
     {
         // Create the signup
         $signup = new Signup;
 
         $signup->northstar_id = $northstarId;
-        $signup->campaign_id = isset($data['campaign_id']) ? $data['campaign_id'] : get_campaign_by_action_id($data['action_id'])->id;
+        $signup->campaign_id = $campaignId;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : token()->client();
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -19,7 +19,7 @@ class SignupRepository
         $signup = new Signup;
 
         $signup->northstar_id = $northstarId;
-        $signup->campaign_id = $data['campaign_id'];
+        $signup->campaign_id = $data['campaign_id'] ? $data['campaign_id'] : get_campaign_by_action_id($data['action_id'])->id;];
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : token()->client();
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -11,7 +11,7 @@ class SignupRepository
      *
      * @param  array $data
      * @param  string $northstarId
-     * @param  integer $campaignId
+     * @param  int $campaignId
      * @return \Rogue\Models\Signup|null
      */
     public function create($data, $northstarId, $campaignId)

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -19,7 +19,7 @@ class SignupRepository
         $signup = new Signup;
 
         $signup->northstar_id = $northstarId;
-        $signup->campaign_id = $data['campaign_id'] ? $data['campaign_id'] : get_campaign_by_action_id($data['action_id'])->id;
+        $signup->campaign_id = isset($data['campaign_id']) ? $data['campaign_id'] : get_campaign_by_action_id($data['action_id'])->id;
         $signup->why_participated = isset($data['why_participated']) ? $data['why_participated'] : null;
         $signup->source = isset($data['source']) ? $data['source'] : token()->client();
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -136,6 +136,6 @@ function has_include($request, $include)
  */
 function get_campaign_by_action_id($actionId)
 {
-    $action = Action::where('id', $actionId)->first();
-    return Campaign::where('id', $action->campaign_id)->first();
+    $action = Action::findOrFail($actionId);
+    return Campaign::findOrFail($action->campaign_id);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,8 @@
 <?php
 
 use Carbon\Carbon;
+use Rogue\Models\Action;
+use Rogue\Models\Campaign;
 use Illuminate\Support\HtmlString;
 
 /**
@@ -125,4 +127,16 @@ function has_include($request, $include)
     }
 
     return false;
+}
+
+/**
+ * Gets campaign by action_id.
+ *
+ * @param $actionId
+ */
+function get_campaign_by_action_id($actionId)
+{
+    $action = Action::where('id', $actionId);
+
+    return Campaign::where('id', $action->campaign_id);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -136,7 +136,6 @@ function has_include($request, $include)
  */
 function get_campaign_by_action_id($actionId)
 {
-    $action = Action::where('id', $actionId);
-
-    return Campaign::where('id', $action->campaign_id);
+    $action = Action::where('id', $actionId)->first();
+    return Campaign::where('id', $action->campaign_id)->first();
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,8 +1,6 @@
 <?php
 
 use Carbon\Carbon;
-use Rogue\Models\Action;
-use Rogue\Models\Campaign;
 use Illuminate\Support\HtmlString;
 
 /**
@@ -127,16 +125,4 @@ function has_include($request, $include)
     }
 
     return false;
-}
-
-/**
- * Gets campaign by action_id.
- *
- * @param $actionId
- */
-function get_campaign_by_action_id($actionId)
-{
-    $action = Action::findOrFail($actionId);
-
-    return Campaign::findOrFail($action->campaign_id);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -137,5 +137,6 @@ function has_include($request, $include)
 function get_campaign_by_action_id($actionId)
 {
     $action = Action::findOrFail($actionId);
+
     return Campaign::findOrFail($action->campaign_id);
 }

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -176,12 +176,8 @@ POST /api/v3/posts
 
 Required params:
 
-- **type**: (string) required.
-  The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **northstar_id**: (string)
   The `northstar_id` of the user the post belongs to.
-- **action**: (string) required without action_id.
-  Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 - **action_id**: (int) required without action or campaign_id.
   The action ID of the action that the user's post is associated with.
 - **type**: (string) required.

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -184,6 +184,8 @@ Required params:
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 - **action_id**: (int) required without action or campaign_id.
   The action ID of the action that the user's post is associated with.
+- **type**: (string) required.
+  The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **file**: (multipart/form-data) required for `photo` posts.
   File to save of post image.
 
@@ -212,8 +214,6 @@ Deprecated params:
   The Campaign ID of the campaign that the user's post is associated with.
 - **action**: (string) required without action_id.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
-  - **type**: (string) required without action_id.
-    The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 
 Example Response:
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -174,14 +174,16 @@ This will automatically create or update the corresponding signup.
 POST /api/v3/posts
 ```
 
-- **campaign_id**: (int) required.
+- **campaign_id**: (int) required without action_id.
   The Campaign ID of the campaign that the user's post is associated with.
 - **type**: (string) required.
   The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **northstar_id**: (string)
-  The northstar_id of the user the post belongs to.
-- **action**: (string) required.
+  The `northstar_id` of the user the post belongs to.
+- **action**: (string) required without action_id.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
+- **action_id**: (int) required without action.
+  The action ID of the action that the user's post is associated with.
 - **quantity**: (int|nullable) optional.
   The number of reportback nouns verbed. Can be `null`.
 - **why_participated**: (string).

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -174,17 +174,22 @@ This will automatically create or update the corresponding signup.
 POST /api/v3/posts
 ```
 
-- **campaign_id**: (int) required without action_id.
-  The Campaign ID of the campaign that the user's post is associated with.
+Required params:
+
 - **type**: (string) required.
   The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **northstar_id**: (string)
   The `northstar_id` of the user the post belongs to.
 - **action**: (string) required without action_id.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
-- **action_id**: (int) required without action.
+- **action_id**: (int) required without action or campaign_id.
   The action ID of the action that the user's post is associated with.
-- **quantity**: (int|nullable) optional.
+- **file**: (multipart/form-data) required for `photo` posts.
+  File to save of post image.
+
+Optional params:
+
+- **quantity**: (int|nullable).
   The number of reportback nouns verbed. Can be `null`.
 - **why_participated**: (string).
   The reason why the user participated.
@@ -192,16 +197,21 @@ POST /api/v3/posts
   Corresponding text for the post (could be photo caption or other words). 256 max characters.
 - **status**: (string).
   Option to set status upon creation if admin uploads post for user.
-- **file**: (multipart/form-data) required for `photo` posts.
-  File to save of post image.
 - **location** (string).
   The The ISO 3166-2 region code this was submitted from, e.g. `US-NY`.
 - **details** (json).
   A JSON field to store extra details about a post.
-- **dont_send_to_blink** (boolean) optional.
+- **dont_send_to_blink** (boolean).
   If included and true, the data for this Post will not be sent to Blink.
 - **created_at** (timestamp).
   If admin and included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. `voter-reg` posts, historical FB share posts, etc.).
+
+Deprecated params:
+
+- **campaign_id**: (int) required without action_id.
+  The Campaign ID of the campaign that the user's post is associated with.
+- **action**: (string) required without action_id.
+  Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 
 Example Response:
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -212,6 +212,8 @@ Deprecated params:
   The Campaign ID of the campaign that the user's post is associated with.
 - **action**: (string) required without action_id.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
+  - **type**: (string) required without action_id.
+    The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 
 Example Response:
 

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -8,8 +8,10 @@ All `v3 /signups` endpoints require the `activity` scope. `Create`/`update`/`del
 POST /api/v3/signups
 ```
 
-- **campaign_id**: (int|string) required.
+- **campaign_id**: (int|string) required without action_id.
   The drupal node id of the campaign the user is signing up for.
+- **action_id**: (int) required without campaign_id.
+  The action ID of the action that the user's post is associated with.
 - **northstar_id**: (int) optional.
   The `northstar_id` of the user who the signup belongs to. This `northstar_id` will be used when acting `asClient`. Otherwise, if the request comes in acting `asUser`, it will ignore this and attribute the signup to the `northstar_id` from OAuth.
 - **why_participated**: (string) optional.

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -76,8 +76,8 @@ class PostTest extends TestCase
         // Create the post!
         $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'why_participated' => $why_participated,
@@ -100,8 +100,8 @@ class PostTest extends TestCase
         $this->assertDatabaseHas('posts', [
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'location' => $location,
@@ -136,8 +136,8 @@ class PostTest extends TestCase
 
         // Create the post!
         $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'why_participated' => $why_participated,
@@ -160,8 +160,8 @@ class PostTest extends TestCase
         $this->assertDatabaseHas('posts', [
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'location' => $location,
@@ -218,7 +218,7 @@ class PostTest extends TestCase
         $this->assertDatabaseHas('posts', [
             'northstar_id' => $northstarId,
             'campaign_id' => $campaignId,
-            'type' => 'photo',
+            'type' => $action->post_type,
             'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
@@ -249,8 +249,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'why_participated' => $why_participated,
@@ -266,8 +266,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'quantity' => $quantity,
@@ -294,7 +294,10 @@ class PostTest extends TestCase
         $text = $this->faker->sentence;
         $why_participated = $this->faker->paragraph;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
-        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
+        $action = factory(Action::class)->create([
+            'campaign_id' => $signup->campaign_id,
+            'post_type' => 'text',
+        ]);
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -303,8 +306,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'text',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'why_participated' => $why_participated,
@@ -319,8 +322,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'text',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'quantity' => $quantity,
@@ -356,47 +359,6 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test that a POST request to /posts creates a new voter-reg post.
-     *
-     * @return void
-     */
-    public function testCreatingAVoterRegPost()
-    {
-        $signup = factory(Signup::class)->create();
-        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
-        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
-
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
-
-        // Create the post!
-        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
-            'northstar_id'     => $signup->northstar_id,
-            'campaign_id'      => $signup->campaign_id,
-            'type'             => 'voter-reg',
-            'action'           => 'test-action',
-            'action_id'        => $action->id,
-            'quantity'         => null,
-            'text'             => null,
-            'details'          => json_encode($details),
-        ]);
-
-        $response->assertStatus(201);
-        $this->assertPostStructure($response);
-
-        $this->assertDatabaseHas('posts', [
-            'signup_id' => $signup->id,
-            'northstar_id' => $signup->northstar_id,
-            'campaign_id' => $signup->campaign_id,
-            'type' => 'voter-reg',
-            'action' => 'test-action',
-            'action_id' => $action->id,
-            'status' => 'pending',
-            'details' => json_encode($details),
-        ]);
-    }
-
-    /**
      * Test that a POST request to /posts creates a new share-social post.
      *
      * @return void
@@ -407,7 +369,10 @@ class PostTest extends TestCase
         $quantity = $this->faker->numberBetween(10, 1000);
         $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
-        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
+        $action = factory(Action::class)->create([
+            'campaign_id' => $signup->campaign_id,
+            'post_type' => 'share-social',
+        ]);
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -416,8 +381,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'share-social',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'text'             => $text,
@@ -431,8 +396,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'share-social',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             // Social share posts should be auto-accepted (unless an admin sends a custom status).
             'status' => 'accepted',
@@ -451,7 +416,10 @@ class PostTest extends TestCase
         $quantity = $this->faker->numberBetween(10, 1000);
         $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
-        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
+        $action = factory(Action::class)->create([
+            'campaign_id' => $signup->campaign_id,
+            'post_type' => 'share-social',
+        ]);
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -461,7 +429,7 @@ class PostTest extends TestCase
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
             'type'             => 'share-social',
-            'action'           => 'test-action',
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'text'             => $text,
@@ -475,8 +443,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'share-social',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             // Social share posts should be auto-accepted (unless an admin sends a custom status).
             'status' => 'accepted',
@@ -495,7 +463,10 @@ class PostTest extends TestCase
         $quantity = $this->faker->numberBetween(10, 1000);
         $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
-        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
+        $action = factory(Action::class)->create([
+            'campaign_id' => $signup->campaign_id,
+            'post_type' => 'share-social',
+        ]);
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
@@ -504,8 +475,8 @@ class PostTest extends TestCase
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'share-social',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'text'             => $text,
@@ -520,8 +491,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'share-social',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             // Social share posts should be pending since the admin sent a custom status.
             'status' => 'pending',
@@ -609,8 +580,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
@@ -626,8 +597,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'quantity' => $quantity,
@@ -642,8 +613,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => $secondQuantity,
             'text'             => $secondText,
@@ -658,8 +629,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'quantity' => $secondQuantity,
@@ -689,8 +660,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id, 'user')->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'quantity'         => null,
             'text'             => $text,
@@ -705,8 +676,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'quantity' => null,
@@ -732,8 +703,8 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'photo',
-            'action'           => 'test-action',
+            'type'             => $action->post_type,
+            'action'           => $action->name,
             'action_id'        => $action->id,
             'text'             => $text,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
@@ -746,8 +717,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'photo',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'pending',
             'quantity' => null,
@@ -797,7 +768,6 @@ class PostTest extends TestCase
         $action = factory(Action::class)->create([
             'campaign_id' => $signup->campaign_id,
             'name' => 'test-action',
-            'post_type' => 'photo',
         ]);
 
         // Mock the Blink API call.
@@ -807,7 +777,7 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
             'northstar_id'     => $signup->northstar_id,
             'campaign_id'      => $signup->campaign_id,
-            'type'             => 'photo',
+            'type'             => $action->post_type,
             'action'           => 'test-action',
             'quantity'         => $quantity,
             'why_participated' => $this->faker->paragraph,
@@ -822,7 +792,7 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'photo',
+            'type' => $action->post_type,
             'action' => 'test-action',
             'action_id' => $action->id,
             'status' => 'pending',
@@ -1449,7 +1419,10 @@ class PostTest extends TestCase
     public function testCreatingVoterRegistrationPost()
     {
         $signup = factory(Signup::class)->create();
-        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
+        $action = factory(Action::class)->create([
+            'campaign_id' => $signup->campaign_id,
+            'post_type' => 'voter-reg',
+        ]);
 
         $details = [
             'hostname' => 'dosomething.turbovote.org',
@@ -1472,8 +1445,8 @@ class PostTest extends TestCase
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'voter-reg',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'register-form',
             'details' => json_encode($details),
@@ -1486,8 +1459,8 @@ class PostTest extends TestCase
             'signup_id' => $signup->id,
             'northstar_id' => $signup->northstar_id,
             'campaign_id' => $signup->campaign_id,
-            'type' => 'voter-reg',
-            'action' => 'test-action',
+            'type' => $action->post_type,
+            'action' => $action->name,
             'action_id' => $action->id,
             'status' => 'register-form',
             'details' => json_encode($details),

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -86,6 +86,7 @@ class PostTest extends TestCase
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
+        dd($response->decodeResponseJson());
 
         $response->assertStatus(201);
         $this->assertPostStructure($response);

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -86,7 +86,6 @@ class PostTest extends TestCase
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
-        dd($response->decodeResponseJson());
 
         $response->assertStatus(201);
         $this->assertPostStructure($response);

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -111,6 +111,66 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test that a POST request to /posts creates a new
+     * post and signup (if it doesn't already exist) without campaign_id.
+     *
+     * @return void
+     */
+    public function testCreatingAPostAndSignupWithoutCampaignId()
+    {
+        $northstarId = $this->faker->northstar_id;
+        $campaignId = factory(Campaign::class)->create()->id;
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $why_participated = $this->faker->paragraph;
+        $text = $this->faker->sentence;
+        $location = 'US-'.$this->faker->stateAbbr();
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
+
+        // Create an action to refer to.
+        $action = factory(Action::class)->create(['campaign_id' => $campaignId]);
+
+        // Mock the Blink API calls.
+        $this->mock(Blink::class)
+            ->shouldReceive('userSignup')
+            ->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
+            'type'             => 'photo',
+            'action'           => 'test-action',
+            'action_id'        => $action->id,
+            'quantity'         => $quantity,
+            'why_participated' => $why_participated,
+            'text'             => $text,
+            'location'         => $location,
+            'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+            'details'          => json_encode($details),
+        ]);
+        dd($response->decodeResponseJson());
+        $response->assertStatus(201);
+        $this->assertPostStructure($response);
+
+        // Make sure the signup & post are persisted to the database.
+        $this->assertDatabaseHas('signups', [
+            'campaign_id' => $campaignId,
+            'northstar_id' => $northstarId,
+            'why_participated' => $why_participated,
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'northstar_id' => $northstarId,
+            'campaign_id' => $campaignId,
+            'type' => 'photo',
+            'action' => 'test-action',
+            'action_id' => $action->id,
+            'status' => 'pending',
+            'location' => $location,
+            'quantity' => $quantity,
+            'details' => json_encode($details),
+        ]);
+    }
+
+    /**
      * Test that a POST request to /posts creates a new photo post.
      *
      * @return void

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -146,7 +146,7 @@ class PostTest extends TestCase
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
-        dd($response->decodeResponseJson());
+
         $response->assertStatus(201);
         $this->assertPostStructure($response);
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -204,7 +204,7 @@ class PostTest extends TestCase
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
-        dd($response->decodeResponseJson());
+
         $response->assertStatus(201);
         $this->assertPostStructure($response);
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -171,64 +171,6 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test that a POST request to /posts creates a new
-     * post and signup (if it doesn't already exist) without campaign_id or type.
-     *
-     * @return void
-     */
-    public function testCreatingAPostAndSignupWithoutCampaignIdOrType()
-    {
-        $northstarId = $this->faker->northstar_id;
-        $campaignId = factory(Campaign::class)->create()->id;
-        $quantity = $this->faker->numberBetween(10, 1000);
-        $why_participated = $this->faker->paragraph;
-        $text = $this->faker->sentence;
-        $location = 'US-'.$this->faker->stateAbbr();
-        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
-
-        // Create an action to refer to.
-        $action = factory(Action::class)->create(['campaign_id' => $campaignId]);
-
-        // Mock the Blink API calls.
-        $this->mock(Blink::class)
-            ->shouldReceive('userSignup')
-            ->shouldReceive('userSignupPost');
-
-        // Create the post!
-        $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
-            'action_id'        => $action->id,
-            'quantity'         => $quantity,
-            'why_participated' => $why_participated,
-            'text'             => $text,
-            'location'         => $location,
-            'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
-            'details'          => json_encode($details),
-        ]);
-
-        $response->assertStatus(201);
-        $this->assertPostStructure($response);
-
-        // Make sure the signup & post are persisted to the database.
-        $this->assertDatabaseHas('signups', [
-            'campaign_id' => $campaignId,
-            'northstar_id' => $northstarId,
-            'why_participated' => $why_participated,
-        ]);
-
-        $this->assertDatabaseHas('posts', [
-            'northstar_id' => $northstarId,
-            'campaign_id' => $campaignId,
-            'type' => $action->post_type,
-            'action' => $action->name,
-            'action_id' => $action->id,
-            'status' => 'pending',
-            'location' => $location,
-            'quantity' => $quantity,
-            'details' => json_encode($details),
-        ]);
-    }
-
-    /**
      * Test that a POST request to /posts creates a new photo post.
      *
      * @return void


### PR DESCRIPTION
#### What's this PR do?
- Removes `campaign_id` requirement when creating a signup or post when there's an `action_id`.
- Adds test to create a signup and post without `campaign_id` but has `action_id`.
- Fixes tests to use `$action->name` and `$action->post_type` instead of custom string for `action` when creating the post. 
- Deletes `testCreatingAVoterRegPost` because this was a duplicate test.
- Updates documentation. 

cc @rapala61 and @aaronschachter on this too since we were discussing this in [Slack](https://dosomething.slack.com/archives/C0YGXUE01/p1551291369075400?thread_ts=1551285205.065200&cid=C0YGXUE01)! 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/164121341)Pivotal Card

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
