### PR TITLE
Adds filter[action_id] to GET api/v3/posts 

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -53,7 +53,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'northstar_id', 'status', 'created_at', 'source'];
+    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'action_id', 'northstar_id', 'status', 'created_at', 'source'];
 
     /**
      * The tags prefixed with 'good' that will send a post to Slack.

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -42,6 +42,9 @@ If the post's action is marked as "anonymous", the `northstar_id` field will onl
 - **filter[action]** _(string)_
   - The action to filter the response by.
   - e.g. `/posts?filter[action]=action-1`
+- **filter[action_id]** _(string)_
+  - The action id to filter the response by.
+  - e.g. `/posts?filter[action_id]=1`
 - **filter[created_at]** _(timestamp)_
   - The created_at date to filter the response by.
   - e.g. `/posts?filter[created_at]=2017-04-28 01:46:45`


### PR DESCRIPTION
#### What's this PR do?
- Adds `filter[action_id]` to `GET api/v3/posts`.
- Updates documentation.

#### How should this be reviewed?
Make sure you can filter by `action_id` when hitting the `GET /api/v3/posts` endpoint.

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/164121438) Pivotal Card

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
