### PR TITLE
updates to correct table in migration

### DIFF
--- a/database/migrations/2019_02_20_184538_add_anonymous_column_to_actions_table.php
+++ b/database/migrations/2019_02_20_184538_add_anonymous_column_to_actions_table.php
@@ -26,7 +26,7 @@ class AddAnonymousColumnToActionsTable extends Migration
      */
     public function down()
     {
-        Schema::table('posts', function (Blueprint $table) {
+        Schema::table('actions', function (Blueprint $table) {
             $table->dropColumn('anonymous');
             $table->boolean('active')->comment('Whether or not the action is active.');
         });


### PR DESCRIPTION
#### What's this PR do?
Updates to the correct able in the latest migration (was referencing `posts` instead of `actions` table).
Thanks for catching this, @DFurnes !

#### How should this be reviewed?
👀 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
