### PR TITLE
Add 'location_name' computed field.

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -48,6 +48,7 @@ class PostTransformer extends TransformerAbstract
             ],
             'status' => $post->status,
             'location' => $post->location,
+            'location_name' => $post->location_name,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
         ];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -138,9 +138,9 @@ class Post extends Model
     }
 
     /**
-     * Cast the location field as a Subdivision object.
+     * Get the location as a human-readable name.
      *
-     * @return \Sokil\IsoCodes\Database\Subdivisions\Subdivision
+     * @return string
      */
     public function getLocationNameAttribute()
     {

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -84,6 +84,7 @@ Example Response:
             },
             "status": "accepted",
             "location": "US-NY",
+            "location_name": "New York",
             "created_at": "2016-11-30T21:21:24+00:00",
             "updated_at": "2017-08-02T14:11:26+00:00"
         },
@@ -106,6 +107,7 @@ Example Response:
             },
             "status": "accepted",
             "location": "US-NY",
+            "location_name": "New York",
             "created_at": "2016-02-10T16:19:25+00:00",
             "updated_at": "2017-08-02T14:11:35+00:00"
         }
@@ -154,6 +156,7 @@ Example Response:
     },
     "status": "accepted",
     "location": "US-NY",
+    "location_name": "New York",
     "created_at": "2019-01-23T19:42:07+00:00",
     "updated_at": "2019-01-23T19:42:07+00:00"
   }
@@ -216,6 +219,7 @@ Example Response:
     },
     "status": "pending",
     "location": "US-NY",
+    "location_name": "New York",
     "created_at": "2018-12-06T21:44:15+00:00",
     "updated_at": "2018-12-06T21:44:15+00:00",
     "tags": [],
@@ -309,7 +313,8 @@ Example response:
           "total": null
       },
       "status": "accepted",
-      "location": "US-NY",
+      "location": "US-MN",
+      "location_name": "Minnesota",
       "source": "rogue-admin",
       "remote_addr": "0.0.0.0",
       "created_at": "2017-10-27T14:50:22+00:00",


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `location_name` computed field that we can use to fill in the "anonymous gallery" in the upcoming Prom campaign, where posts will be "attributed" to the user's state:

![screen shot 2019-02-28 at 2 13 47 pm](https://user-images.githubusercontent.com/583202/53591885-144e7d00-3b63-11e9-8b7f-b6ff58278bba.png)

#### How should this be reviewed?
This turns out to be way more time-consuming than I would've imagined (40-60ms each lookup):

![screen shot 2019-02-28 at 2 03 01 pm](https://user-images.githubusercontent.com/583202/53591957-3cd67700-3b63-11e9-9d66-4d0de5471647.png)

Since that ends up accounting for quite a bit of time on an "index" page with 20+ results, I decided to cache these lookups. Since a state's region code is never (rarely? haha) going to change & takes up very little memory, these are cached forever. Much better:

![screen shot 2019-02-28 at 2 05 35 pm](https://user-images.githubusercontent.com/583202/53592047-7313f680-3b63-11e9-8c1b-a398a6029d97.png)

The best I can tell, that first 80ms lookup is just from initializing the Redis connection. (Either that, or it just has a hard time remembering Minnesota. Dunno what Redis has against the Land of 10,000 Lakes!)

#### Any background context you want to provide?
👑

#### Relevant tickets
References [#164214415](https://www.pivotaltracker.com/story/show/164214415).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md