### PR TITLE
adds northstar_id into posts documentation

### DIFF
--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -178,6 +178,8 @@ POST /api/v3/posts
   The Campaign ID of the campaign that the user's post is associated with.
 - **type**: (string) required.
   The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
+- **northstar_id**: (string)
+  The northstar_id of the user the post belongs to.
 - **action**: (string) required.
   Describes the bucket the action is tied to. A campaign could ask for multiple types of actions throughout the life of the campaign.
 - **quantity**: (int|nullable) optional.


### PR DESCRIPTION
#### What's this PR do?
Adds optional `northstar_id` param in payload to `POST /api/v3/posts`

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This is missing from the documentation. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
