### PR TITLE
Include full "action" in the Post response.

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -9,6 +9,10 @@ use League\Fractal\TransformerAbstract;
 
 class PostTransformer extends TransformerAbstract
 {
+    protected $defaultIncludes = [
+        'action_details',
+    ];
+
     /**
      * List of resources possible to include
      *
@@ -95,5 +99,16 @@ class PostTransformer extends TransformerAbstract
     public function includeSiblings(Post $post)
     {
         return $this->collection($post->siblings, new self);
+    }
+
+    /**
+     * Include the action.
+     *
+     * @param \Rogue\Models\Post $post
+     * @return \League\Fractal\Resource\Collection
+     */
+    public function includeActionDetails(Post $post)
+    {
+        return $this->item($post->actionModel, new ActionTransformer);
     }
 }

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -110,7 +110,23 @@ Example Response:
             "location_name": "New York",
             "created_at": "2016-02-10T16:19:25+00:00",
             "updated_at": "2017-08-02T14:11:35+00:00"
-        }
+            "action_details": {
+              "data": {
+                "id": 1,
+                "name": "default",
+                "campaign_id": 9009,
+                "post_type": "photo",
+                "reportback": true,
+                "civic_action": true,
+                "scholarship_entry": true,
+                "anonymous": false,
+                "noun": "things",
+                "verb": "done",
+                "created_at": "2019-02-20T21:42:01+00:00",
+                "updated_at": "2019-02-20T21:42:01+00:00"
+              }
+            }
+          }
     ],
     "meta": {
         "cursor": {
@@ -159,6 +175,22 @@ Example Response:
     "location_name": "New York",
     "created_at": "2019-01-23T19:42:07+00:00",
     "updated_at": "2019-01-23T19:42:07+00:00"
+    "action_details": {
+      "data": {
+        "id": 1,
+        "name": "default",
+        "campaign_id": 9009,
+        "post_type": "photo",
+        "reportback": true,
+        "civic_action": true,
+        "scholarship_entry": true,
+        "anonymous": false,
+        "noun": "things",
+        "verb": "done",
+        "created_at": "2019-02-20T21:42:01+00:00",
+        "updated_at": "2019-02-20T21:42:01+00:00"
+      }
+    }
   }
 }
 ```
@@ -250,6 +282,22 @@ Example Response:
           }
         }
       }
+    },
+    "action_details": {
+      "data": {
+        "id": 1,
+        "name": "default",
+        "campaign_id": 1173,
+        "post_type": "text",
+        "reportback": true,
+        "civic_action": true,
+        "scholarship_entry": true,
+        "anonymous": false,
+        "noun": "things",
+        "verb": "done",
+        "created_at": "2019-02-20T21:42:01+00:00",
+        "updated_at": "2019-02-20T21:42:01+00:00"
+      }
     }
   }
 }
@@ -319,6 +367,23 @@ Example response:
       "remote_addr": "0.0.0.0",
       "created_at": "2017-10-27T14:50:22+00:00",
       "updated_at": "2017-10-30T16:04:53+00:00"
+      "action_details": {
+        "data": {
+          "id": 1,
+          "name": "default",
+          "campaign_id": 9009,
+          "post_type": "text",
+          "reportback": true,
+          "civic_action": true,
+          "scholarship_entry": true,
+          "anonymous": false,
+          "noun": "things",
+          "verb": "done",
+          "created_at": "2019-02-20T21:42:01+00:00",
+          "updated_at": "2019-02-20T21:42:01+00:00"
+        }
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
#### What's this PR do?
This pull request adds an `action_details` field to the Post response, with the contents of the `action` that post was created for. (Named `action_details` since sadly `action` is already taken!)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I decided to add this to the base response since we're already eagerly-loading this relationship (and so it won't incur any further database queries), and this way we don't have to make a separate round-trip to fetch the relationship in our GraphQL resolver. (And we'll often want this, since we need to know whether an action is `anonymous` or not & noun/verb for the gallery!)

#### Relevant tickets
References [#164214415](https://www.pivotaltracker.com/story/show/164214415).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md