### PR TITLE
Updates GET /api/v3/campaigns endpoint to filter by internal_title and include actions

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -30,6 +30,11 @@ class CampaignsController extends ApiController
     {
         $query = $this->newQuery(Campaign::class);
 
+        if (has_include($request, 'actions')) {
+            // Eagerly load the `action` relationship.
+            $query->with('actions');
+        }
+
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Campaign::$indexes);
 

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -8,6 +8,15 @@ use League\Fractal\TransformerAbstract;
 class CampaignTransformer extends TransformerAbstract
 {
     /**
+     * List of resources possible to include
+     *
+     * @var array
+     */
+    protected $availableIncludes = [
+        'actions',
+    ];
+
+    /**
      * Transform resource data.
      *
      * @param \Rogue\Models\Campaign $campaign
@@ -23,5 +32,16 @@ class CampaignTransformer extends TransformerAbstract
             'created_at' => $campaign->created_at->toIso8601String(),
             'updated_at' => $campaign->updated_at->toIso8601String(),
         ];
+    }
+
+    /**
+     * Include the actions.
+     *
+     * @param \Rogue\Models\Campaign $campaign
+     * @return \League\Fractal\Resource\Collection
+     */
+    public function includeActions(Campaign $campaign)
+    {
+        return $this->collection($campaign->actions, new ActionTransformer);
     }
 }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -31,7 +31,7 @@ class Campaign extends Model
      *
      * @var array
      */
-    public static $indexes = ['id'];
+    public static $indexes = ['id', 'internal_title'];
 
     /**
      * Get the signups associated with this campaign.

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -16,6 +16,9 @@ GET /api/v3/campaigns
 - **filter[internal_title]** _(string)_
   - Filter results by the given column: `internal_title`
   - You can filter by more than one value for a column, e.g. `/campaigns?filter[internal_title]=First Campaign,Second Campaign`
+- **include** _(string)_
+  - Include additional related records in the response: `actions`
+  - e.g. `/posts?include=actions`
 
 Example Response:
 

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -13,6 +13,9 @@ GET /api/v3/campaigns
 - **filter[column]** _(string)_
   - Filter results by the given column: `id`
   - You can filter by more than one value for a column, e.g. `/campaigns?filter[id]=121,122`
+- **filter[internal_title]** _(string)_
+  - Filter results by the given column: `internal_title`
+  - You can filter by more than one value for a column, e.g. `/campaigns?filter[internal_title]=First Campaign,Second Campaign`
 
 Example Response:
 


### PR DESCRIPTION
#### What's this PR do?
Updates `GET /api/v3/campaigns` endpoint to filter by `internal_title` and adds `include=actions`.
  - This is so CallPower can find a `action_id` to send along when creating a Post in Rogue. 
    - It will find the campaign by the `internal_title` and match the `action` by `internal_name` that is the standardized for all CallPower actions. This way, we can get the `action_id`. 

#### How should this be reviewed?
Can you use `filter[internal_name]=` & `include=actions` to find the specific campaign you're looking for? 

#### Relevant tickets
The first implementation step in [this](https://docs.google.com/document/d/1aDNLKZ6BPto65Ce5RDJkXf8LpKGIFdftO13WgZgkO48/edit#) document. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
