### PR TITLE
Adds callpower_campaign_id to actions table

### DIFF
--- a/database/migrations/2019_03_06_165023_add_callpower_campaign_id_to_actions_table.php
+++ b/database/migrations/2019_03_06_165023_add_callpower_campaign_id_to_actions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCallpowerCampaignIdToActionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table->integer('callpower_campaign_id')->nullable()->comment('CallPower campaign id.')->after('post_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table->dropColumn('callpower_campaign_id');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Adds `callpower_campaign_id` to `actions` table.

#### How should this be reviewed?
Does the `actions` table have this new column? 

#### Any background context you want to provide?
We want to be able to add the CallPower campaign id to an action in Rogue in order to map go-forward CallPower records to a campaign/action.

The user will create a CallPower campaign. Using this CallPower campaign id, a user in Rogue will add this to the associated action when creating in Rogue.

When a post is created from CallPower, we'll use this column to find the action to create the Post.

#### Relevant tickets
Fixes (this)[https://www.pivotaltracker.com/n/projects/2019429/stories/164436959] Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
