### PR TITLE
Adds CallPower campaign id to action creation

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -87,6 +87,7 @@ class ActionsController extends Controller
         $this->validate($request, [
             'name' => 'string',
             'post_type' => 'string',
+            'callpower_campaign_id' => 'integer',
             'reportback' => 'boolean',
             'civic_action' => 'boolean',
             'scholarship_entry' => 'boolean',

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -47,7 +47,7 @@ class ActionsController extends Controller
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
             'post_type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => 'integer',
+            'callpower_campaign_id' => 'required_if:post_type,phone-call|integer',
             'noun' => 'required|string',
             'verb' => 'required|string',
         ]);

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -47,7 +47,7 @@ class ActionsController extends Controller
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
             'post_type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => 'required_if:post_type,phone-call|integer',
+            'callpower_campaign_id' => 'required_if:post_type,phone-call|integer|exists:actions,callpower_campaign_id',
             'noun' => 'required|string',
             'verb' => 'required|string',
         ]);

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -86,8 +86,8 @@ class ActionsController extends Controller
     {
         $this->validate($request, [
             'name' => 'string',
-            'post_type' => 'string',
-            'callpower_campaign_id' => 'integer',
+            'post_type' => 'string|in:photo,voter-reg,text,share-social,phone-call',
+            'callpower_campaign_id' => 'required_if:post_type,phone-call|exists:actions,callpower_campaign_id',
             'reportback' => 'boolean',
             'civic_action' => 'boolean',
             'scholarship_entry' => 'boolean',

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -46,7 +46,7 @@ class ActionsController extends Controller
         $this->validate($request, [
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
-            'post_type' => 'required|string',
+            'post_type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
             'callpower_campaign_id' => 'integer',
             'noun' => 'required|string',
             'verb' => 'required|string',

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -27,6 +27,7 @@ class ActionsController extends Controller
             'photo',
             'voter-reg',
             'share-social',
+            'phone-call',
         ];
 
         return view('actions.create')->with([
@@ -46,6 +47,7 @@ class ActionsController extends Controller
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
             'post_type' => 'required|string',
+            'callpower_campaign_id' => 'integer',
             'noun' => 'required|string',
             'verb' => 'required|string',
         ]);

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -47,7 +47,7 @@ class ActionsController extends Controller
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
             'post_type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => 'required_if:post_type,phone-call|integer|exists:actions,callpower_campaign_id',
+            'callpower_campaign_id' => 'required_if:post_type,phone-call|exists:actions,callpower_campaign_id',
             'noun' => 'required|string',
             'verb' => 'required|string',
         ]);

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -28,7 +28,7 @@ class PostRequest extends Request
         return [
             'campaign_id' => 'required_without:action_id|integer',
             'northstar_id' => 'nullable|objectid',
-            'type' => 'required|string|in:photo,voter-reg,text,share-social',
+            'type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
             // @TODO: eventually, deprecate action in the payload and make action_id required when all systems have been updated.
             'action' => 'required_without:action_id|string',
             'action_id' => 'required_without:action,campaign_id|integer|exists:actions,id',

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -26,7 +26,7 @@ class Action extends Model
      *
      * @var array
      */
-    protected $fillable = ['name', 'campaign_id', 'post_type', 'reportback', 'civic_action', 'scholarship_entry', 'anonymous', 'noun', 'verb'];
+    protected $fillable = ['name', 'campaign_id', 'post_type', 'callpower_campaign_id', 'reportback', 'civic_action', 'scholarship_entry', 'anonymous', 'noun', 'verb'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -213,7 +213,7 @@ Required params:
 - **action_id**: (int) required without action or campaign_id.
   The action ID of the action that the user's post is associated with.
 - **type**: (string) required.
-  The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
+  The type of post submitted. Must be one of the following types: `photo`, `voter-reg`, `text`, `share-social`, `phone-call`. `share-social` posts will be auto-accepted unless an admin sets a custom `status`.
 - **file**: (multipart/form-data) required for `photo` posts.
   File to save of post image.
 

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -40,7 +40,13 @@ button.delete {
   }
 }
 
-.-third {
+.-half {
+  float: left;
+  width: 50%;
+  padding-right: $base-spacing / 2;
+}
+
+.form-item.-third {
   float: left;
   width: 33%;
   padding-right: $base-spacing / 2;

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -40,8 +40,8 @@ button.delete {
   }
 }
 
-.-half {
+.-third {
   float: left;
-  width: 50%;
+  width: 33%;
   padding-right: $base-spacing / 2;
 }

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -21,6 +21,14 @@ class Action extends React.Component {
           <p>{action.id}</p>
         </div>
         <div className="container__row">
+          <h4>CALLPOWER CAMPAIGN ID</h4>
+          {action.callpower_campaign_id ? (
+            <p>{action.callpower_campaign_id}</p>
+          ) : (
+            <p>-</p>
+          )}
+        </div>
+        <div className="container__row">
           <ul>
             <li>
               <h4>POST TYPE</h4>

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -31,7 +31,7 @@
                     </div>
                     <div class="form-item -third">
                         <label class="field-label">CallPower Campaign ID</label>
-                        <input type="text" name="callpower_campaign_id" class="text-field" placeholder="e.g. 4" value="{{ old('callpower_campaign_id') }}">
+                        <input type="text" name="callpower_campaign_id" class="text-field" placeholder="e.g. 4 (optional)" value="{{ old('callpower_campaign_id') }}">
                     </div>
                     <div class="form-item -third">
                         <label class="field-label">Action Noun</label>

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -29,11 +29,15 @@
                             @endforeach
                         </select>
                     </div>
-                    <div class="form-item -half">
+                    <div class="form-item -third">
+                        <label class="field-label">CallPower Campaign ID</label>
+                        <input type="text" name="callpower_campaign_id" class="text-field" placeholder="e.g. 4" value="{{ old('callpower_campaign_id') }}">
+                    </div>
+                    <div class="form-item -third">
                         <label class="field-label">Action Noun</label>
                         <input type="text" name="noun" class="text-field" placeholder="e.g. Jeans" value="{{ old('noun') }}">
                     </div>
-                    <div class="form-item -half">
+                    <div class="form-item -third">
                         <label class="field-label">Action Verb</label>
                         <input type="text" name="verb" class="text-field" placeholder="e.g. Collected" value="{{ old('verb') }}">
                     </div>

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -13,7 +13,7 @@
 
                     <div class="form-item">
                         <label class="field-label">Action Name</label>
-                        <input type="text" name="name" class="text-field" placeholder="Name your action e.g. Teens for Jeans Photo Upload" value="{{old('internal_title') }}">
+                        <input type="text" name="name" class="text-field" placeholder="Name your action e.g. Teens for Jeans Photo Upload" value="{{old('name') }}">
                     </div>
 
                     <div class="select form-item">
@@ -21,8 +21,8 @@
                         <select name="post_type">
                             <option value="" disabled selected>Select the post type</option>
                             @foreach($postTypes as $postType)
-                                @if (old('postType'))
-                                    <option value="{{ old('postType') }}" {{ (old('postType') == $postType ? "selected":"") }}>{{ $postType }}</option>
+                                @if (old('post_type'))
+                                    <option value="{{ old('postType') }}" {{ (old('post_type') == $postType ? "selected":"") }}>{{ $postType }}</option>
                                 @else
                                     <option>{{ $postType }}</option>
                                 @endif


### PR DESCRIPTION
#### What's this PR do?
- Adds `phone-call` post `type` and post `type` validation. 
- Updates documentation.
- Adds CallPower campaign id to action creation form (front end and backend): 
![screen shot 2019-03-06 at 12 51 21 pm](https://user-images.githubusercontent.com/9019452/53902194-ad234380-400e-11e9-94cf-38061803a34a.png)
- Adds CallPower campaign id to campaign id show page: 
![screen shot 2019-03-06 at 12 50 45 pm](https://user-images.githubusercontent.com/9019452/53902198-b0b6ca80-400e-11e9-922c-10f54be69a30.png)

#### How should this be reviewed?
Are you able to create a new action with a CallPower campaign id? Does this save in the db correctly? 


@ngjo @lkpttn can we add this to the campaign creation playbook? LMK if you have any questions! 
#### Relevant tickets
Fixes (this)[https://www.pivotaltracker.com/n/projects/2019429/stories/164436959] Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
