### PR TITLE
Updates callpower_campaign_id validation

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -88,7 +88,10 @@ class ActionsController extends Controller
         $this->validate($request, [
             'name' => 'string',
             'post_type' => 'string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => ['required_if:post_type,phone-call', Rule::unique('actions')->ignore($action)],
+            'callpower_campaign_id' => [
+                'required_if:post_type,phone-call',
+                Rule::unique('actions')->ignore($action->id),
+            ],
             'reportback' => 'boolean',
             'civic_action' => 'boolean',
             'scholarship_entry' => 'boolean',

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -47,7 +47,7 @@ class ActionsController extends Controller
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
             'post_type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => 'nullable|required_if:post_type,phone-call|integer|unique:actions,id',
+            'callpower_campaign_id' => 'nullable|required_if:post_type,phone-call|integer|unique:actions',
             'noun' => 'required|string',
             'verb' => 'required|string',
         ]);

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -4,6 +4,7 @@ namespace Rogue\Http\Controllers\Legacy\Web;
 
 use Rogue\Models\Action;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Rogue\Http\Controllers\Controller;
 
 class ActionsController extends Controller
@@ -87,7 +88,7 @@ class ActionsController extends Controller
         $this->validate($request, [
             'name' => 'string',
             'post_type' => 'string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => 'required_if:post_type,phone-call|exists:actions,callpower_campaign_id',
+            'callpower_campaign_id' => ['required_if:post_type,phone-call', Rule::unique('actions')->ignore($action)],
             'reportback' => 'boolean',
             'civic_action' => 'boolean',
             'scholarship_entry' => 'boolean',

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -47,7 +47,7 @@ class ActionsController extends Controller
             'name' => 'required|string',
             'campaign_id' => 'required|integer|exists:campaigns,id',
             'post_type' => 'required|string|in:photo,voter-reg,text,share-social,phone-call',
-            'callpower_campaign_id' => 'required_if:post_type,phone-call|exists:actions,callpower_campaign_id',
+            'callpower_campaign_id' => 'nullable|required_if:post_type,phone-call|integer|unique:actions,id',
             'noun' => 'required|string',
             'verb' => 'required|string',
         ]);


### PR DESCRIPTION
#### What's this PR do?
-Updates validation so `callpower_campaign_id` is an integer and has a unique action `id` so a CallPower campaign can only belong to one action.

#### How should this be reviewed?
- You shouldn't be able to add a `callpower_campaign_id` that isn't an integer.
- There should only be one action associated to one CallPower campaign - you should not be able to make two actions for the same CallPower campaign. 

**Question**: Is this the correct logic that we want? I think we'll need to put this rule in place in order to find the `action_id` but is it ok if we only have one action per CallPower campaign? Would we ever want multiple? cc @sohaibhasan @mjain-1 @ngjo 

#### Relevant tickets
Fixes validation in #849 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
