### PR TITLE
Allow updating a posts location, and an authorization logic fix.

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -52,6 +52,7 @@ class PostRequest extends Request
     {
         return [
             'text' => 'nullable|string|max:140',
+            'location' => 'nullable|iso3166',
             'quantity' => 'nullable|integer',
             'status' => $this->getStatusRules($this->post->type),
         ];

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -58,10 +58,23 @@ class PostPolicy
      */
     public function update($user, Post $post)
     {
-        if (is_staff_user()) {
+        return $this->allowOwnerStaffOrMachine($user, $post);
+    }
+
+    /**
+     * Determine if the given post can be reviewed by the user.
+     *
+     * @param  Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  Rogue\Models\Post $post
+     * @return bool
+     */
+    public function review($user, Post $post)
+    {
+        // If this is a machine token, show full model:
+        if (token()->exists() && ! token()->id()) {
             return true;
         }
 
-        return $user && $user->northstar_id === $post->northstar_id;
+        return is_staff_user();
     }
 }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -8,6 +8,7 @@ use Rogue\Models\Action;
 use Rogue\Models\Review;
 use Rogue\Models\Signup;
 use Rogue\Services\Registrar;
+use Illuminate\Support\Facades\Gate;
 use Intervention\Image\Facades\Image;
 use Illuminate\Validation\ValidationException;
 
@@ -170,6 +171,10 @@ class PostRepository
      */
     public function update($post, $data)
     {
+        if (! Gate::allows('review', $post)) {
+            unset($data['status']);
+        }
+
         $post->update($data);
 
         // If the quantity was updated, update the total quantity on the signup.

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1279,6 +1279,33 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test that a user can update their own post, but can't
+     * change it's review status.
+     *
+     * @return void
+     */
+    public function testNonStaffUpdatePost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->withAccessToken($post->northstar_id)->patchJson('api/v3/posts/' . $post->id, [
+            'status' => 'accepted',
+            'location' => 'US-MA',
+            'text' => 'new caption',
+        ]);
+
+        $response->assertJson([
+            'data' => [
+                'media' => [
+                    'text' => 'new caption', // check!
+                ],
+                'location' => 'US-MA',       // check!
+                'status' => 'pending',       // no way, buddy!
+            ],
+        ]);
+    }
+
+    /**
      * Test that a non-admin or user that doesn't own the post can't update post.
      *
      * @return void


### PR DESCRIPTION
#### What's this PR do?
This pull request allows updating a post's location via the `PUT v3/posts/:id` endpoint, which is necessary for backfilling the location of posts submitted for the "Prom For All" broadcast.

I also noticed an authorization bug on this endpoint – any user can use that same endpoint to self-approve their own post! Yikes!! 😱 That's definitely not by design, so I fixed that and added a test to ensure we don't re-introduce that issue again in the future.

#### How should this be reviewed?
Once we remove the old `v1` and `v2` endpoints, it'd be worth doing a close pass over the remaining logic in this application to make sure there aren't other things like this lurking about! 🦈 (For example, we currently allow _waaay_ too many things to be mass-assignable).

#### Any background context you want to provide?
Yikes!! We should do a once-over and make sure we don't do this anywhere else.

#### Relevant tickets
[#164646226](https://www.pivotaltracker.com/story/show/164646226)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md