### PR TITLE
Update text validation length to be consistent.

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -51,7 +51,7 @@ class PostRequest extends Request
     private function patchRules()
     {
         return [
-            'text' => 'nullable|string|max:140',
+            'text' => 'nullable|string|max:500',
             'location' => 'nullable|iso3166',
             'quantity' => 'nullable|integer',
             'status' => $this->getStatusRules($this->post->type),

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1268,14 +1268,10 @@ class PostTest extends TestCase
 
         $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
             'quantity' => 'this is words not a number!',
-            'text' => 'This must be longer than 140 characters to break the validation rules so here I will create a caption that is longer than 140 characters to test.',
+            'text' => 'a' . str_repeat('h', 512), // ahhh...hhhhh!
         ]);
 
-        $response->assertStatus(422);
-
-        $json = $response->json();
-        $this->assertEquals('The quantity must be an integer.', $json['errors']['quantity'][0]);
-        $this->assertEquals('The text may not be greater than 140 characters.', $json['errors']['text'][0]);
+        $response->assertJsonValidationErrors(['quantity', 'text']);
     }
 
     /**

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1231,7 +1231,7 @@ class PostTest extends TestCase
             'status' => 'register-form',
         ]);
 
-        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status']);
     }
 
     /**
@@ -1253,7 +1253,6 @@ class PostTest extends TestCase
         ]);
 
         $response->assertStatus(401);
-        $this->assertEquals('Unauthenticated.', $response->decodeResponseJson()['message']);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request just includes a quick fix to make sure that the `PUT v3/posts/:id` route validates text length consistently with the rules we use for `POST v3/posts`. References #845.

#### How should this be reviewed?
I updated the behavior in 0b18958 & the associated test in fb499c9. 🚥

I also cleaned this test up to use Laravel's `assertJsonValidationErrors` assertion, so we don't end up with a fatal error if the validation error doesn't fire & avoid having to copy-paste validation messages into our tests. I made similar touchups to two other nearby tests in 5c91d18.

#### Any background context you want to provide?
I noticed this while in this file earlier this morning for #859.

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md