### PR TITLE
force deletes action instead of soft deletes

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -133,11 +133,7 @@ class ActionsController extends Controller
      */
     public function destroy(Action $action)
     {
-        $trashed = $action->delete();
-
-        if (! $trashed) {
-            return response()->json(['code' => 500, 'message' => 'There was an error deleting the action']);
-        }
+        $action->forceDelete();
 
         // Log that an action was deleted.
         info('action_deleted', ['id' => $action->id]);


### PR DESCRIPTION
#### What's this PR do?
Force deletes action instead of soft deletes.

#### How should this be reviewed?
Make sure that the action is no longer in the database when deleted. 

#### Any background context you want to provide?
@ngjo wanted to create CallPower actions in the database and there was a mistake with one of them. We deleted it but the functionality only soft deletes actions when deleted via the web route. When she tried to create a new action with that soft deleted action's same `callpower_camapign_id, she wasn't able to because of the unique validation rule. 

We only allow users to delete actions if the campaign has not yet started. Because of this, the main functionality of deleted actions is if it really shouldn't be there. Thus, I think it actually makes sense to force delete these actions instead of soft deleting. 

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
