### PR TITLE
Paginate actions

### DIFF
--- a/resources/assets/components/CampaignIdSingle/index.js
+++ b/resources/assets/components/CampaignIdSingle/index.js
@@ -8,6 +8,7 @@ import RogueClient from '../../utilities/RogueClient';
 import './campaignidsingle.scss';
 
 import Action from '../Action';
+import PagingButtons from '../PagingButtons';
 import UploaderModal from '../UploaderModal';
 import ModalContainer from '../ModalContainer';
 // import CreateActionModal from '../CreateActionModal';
@@ -196,6 +197,11 @@ class CampaignIdSingle extends React.Component {
             Add Action
           </a>
         </div>
+        <PagingButtons
+          onPaginate={this.getActionsByPaginatedLink}
+          prev={this.state.prevPage}
+          next={this.state.nextPage}
+        />
       </div>
     );
   }

--- a/resources/assets/components/CampaignIdSingle/index.js
+++ b/resources/assets/components/CampaignIdSingle/index.js
@@ -29,6 +29,7 @@ class CampaignIdSingle extends React.Component {
     });
 
     this.deleteAction = this.deleteAction.bind(this);
+    this.getActionsByPaginatedLink = this.getActionsByPaginatedLink.bind(this);
     // this.showCreateActionModal = this.showCreateActionModal.bind(this);
     // this.hideCreateActionModal = this.hideCreateActionModal.bind(this);
   }
@@ -37,12 +38,7 @@ class CampaignIdSingle extends React.Component {
     this.getActions(this.props.campaign.id);
   }
 
-  /**
-   * Gets the campaign's actions.
-   *
-   * @param {Integer} campaignId
-   * @return {Object}
-   */
+  // Gets campaign's actions.
   getActions(campaignId) {
     this.api
       .get(`api/v3/actions`, {
@@ -53,14 +49,28 @@ class CampaignIdSingle extends React.Component {
       .then(json =>
         this.setState({
           actions: keyBy(json.data, 'id'),
-          nextPage: json.meta.pagination.links.next
-            ? json.meta.pagination.links.next
-            : null,
-          prevPage: json.meta.pagination.links.previous
-            ? json.meta.pagination.links.previous
-            : null,
+          nextPage: json.meta.pagination.links.next,
+          prevPage: json.meta.pagination.links.previous,
         }),
       );
+  }
+
+  // Make API call to paginated link to get next/previous batch of posts.
+  getActionsByPaginatedLink(url, event) {
+    event.preventDefault();
+
+    // Strip the url to get query parameters.
+    const splitEndpoint = url.split('/');
+    const path = splitEndpoint.slice(-1)[0];
+    const queryString = path.split('?')[1];
+
+    this.api.get('api/v3/actions', queryString).then(json =>
+      this.setState({
+        actions: keyBy(json.data, 'id'),
+        nextPage: json.meta.pagination.links.next,
+        prevPage: json.meta.pagination.links.previous,
+      }),
+    );
   }
 
   // Delete an action.

--- a/resources/assets/components/CampaignIdSingle/index.js
+++ b/resources/assets/components/CampaignIdSingle/index.js
@@ -52,6 +52,12 @@ class CampaignIdSingle extends React.Component {
       .then(json =>
         this.setState({
           actions: keyBy(json.data, 'id'),
+          nextPage: json.meta.pagination.links.next
+            ? json.meta.pagination.links.next
+            : null,
+          prevPage: json.meta.pagination.links.previous
+            ? json.meta.pagination.links.previous
+            : null,
         }),
       );
   }

--- a/resources/assets/components/CampaignIdSingle/index.js
+++ b/resources/assets/components/CampaignIdSingle/index.js
@@ -198,7 +198,13 @@ class CampaignIdSingle extends React.Component {
               })
             : null}
         </div>
-
+        <div className="container__block -narrow">
+          <PagingButtons
+            onPaginate={this.getActionsByPaginatedLink}
+            prev={this.state.prevPage}
+            next={this.state.nextPage}
+          />
+        </div>
         <div className="container__block -narrow">
           <a
             className="button -secondary"
@@ -207,11 +213,6 @@ class CampaignIdSingle extends React.Component {
             Add Action
           </a>
         </div>
-        <PagingButtons
-          onPaginate={this.getActionsByPaginatedLink}
-          prev={this.state.prevPage}
-          next={this.state.nextPage}
-        />
       </div>
     );
   }

--- a/resources/assets/components/PagingButtons/index.js
+++ b/resources/assets/components/PagingButtons/index.js
@@ -7,7 +7,7 @@ class PagingButtons extends React.Component {
   render() {
     const prev = this.props.prev;
     const next = this.props.next;
-
+    console.log(prev, next);
     return (
       <div className="container__block">
         <a

--- a/resources/assets/components/PagingButtons/index.js
+++ b/resources/assets/components/PagingButtons/index.js
@@ -7,7 +7,7 @@ class PagingButtons extends React.Component {
   render() {
     const prev = this.props.prev;
     const next = this.props.next;
-    console.log(prev, next);
+
     return (
       <div className="container__block">
         <a


### PR DESCRIPTION
#### What's this PR do?
Adds pagination for actions on the campaign id single page if there are more than 20 actions (before only showed first 20 actions so user could not view/edit/delete all actions if there are more than 20 actions for the campaign). 

#### How should this be reviewed?
This is how the pagination buttons look (zoomed in) on the campaign id single page: 
![Screen Shot 2019-04-02 at 3 13 56 PM](https://user-images.githubusercontent.com/9019452/55429851-69165680-555a-11e9-911b-46bfce89a07f.png)
![Screen Shot 2019-04-02 at 3 14 02 PM](https://user-images.githubusercontent.com/9019452/55429852-69165680-555a-11e9-9ea8-fe7dc5b3bad2.png)

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/165027544) Pivotal Card.

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
