### PR TITLE
Fix two flaky tests.

### DIFF
--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1026,7 +1026,7 @@ class PostTest extends TestCase
     public function testPostsIndexAsOwnerHiddenPosts()
     {
         // Owners should only see accepted posts and their own hidden posts.
-        $ownerId = $this->faker->northstar_id;
+        $ownerId = $this->faker->unique()->northstar_id;
 
         // Create posts and associate to this $ownerId.
         $posts = factory(Post::class, 'accepted', 2)->create(['northstar_id' => $ownerId]);

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -803,11 +803,15 @@ class PostTest extends TestCase
     {
         // Create an accepted post.
         $this->mockTime('8/3/2017 14:00:00');
-        $regularPost = factory(Post::class, 'accepted')->create();
+        $regularPost = factory(Post::class, 'accepted')->create([
+            'northstar_id' => $this->faker->unique()->northstar_id,
+        ]);
 
-        // And then later, create 1 post that is anonymous.
+        // And then later, create an anonymous post from another user.
         $this->mockTime('8/3/2017 17:30:00');
-        $anonymousPost = factory(Post::class, 'accepted')->create();
+        $anonymousPost = factory(Post::class, 'accepted')->create([
+            'northstar_id' => $this->faker->unique()->northstar_id,
+        ]);
         $anonymousPost->actionModel->anonymous = 1;
         $anonymousPost->actionModel->save();
 


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes occasional test failures in `testPostsIndexWithAnonymousPosts` and `testPostsIndexAsOwnerHiddenPosts`, both caused when the user IDs generated by Faker would unexpectedly collide. This will make our CI tests for this app more trustworthy.

#### How should this be reviewed?
✅ 👀

#### Any background context you want to provide?
If you ever want to "battle test" a particular test, you can use the `--repeat` argument! For example, this runs the `testPostsIndexAsOwnerHiddenPosts` test 100 times to catch those flaky failures:

```
$ phpunit tests/Http/PostTest.php --filter PostsIndexAsOwnerHiddenPosts --repeat 100

.............F...............F...................F.............  63 / 100 ( 63%)
.....................................                           100 / 100 (100%)

Time: 46.03 seconds, Memory: 32.00MB

There were 3 failures:
...
```

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md