### PR TITLE
Update campaign overview for our brave new world of multi-cause campaigns.

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -82,6 +82,14 @@ class Campaign extends Model
     }
 
     /**
+     * A campaign has many posts.
+     */
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    /**
      * Should we accept new signups & posts for this campaign?
      *
      * @return bool

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -3,11 +3,69 @@ import React from 'react';
 import CampaignTable from '../CampaignTable';
 
 class CampaignOverview extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { search: '' };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  /**
+   * Update state when search term changes.
+   *
+   * @param {*} event
+   */
+  onChange(event) {
+    this.setState({ search: event.target.value });
+  }
+
+  /**
+   * Filter the given campaigns by current search term.
+   *
+   * @return {Array}
+   */
+  filterCampaigns(campaigns) {
+    const search = this.state.search.toLowerCase();
+
+    return campaigns.filter(campaign => {
+      if (this.state.search === '') {
+        return true;
+      }
+
+      const matchesId = campaign.id.toString().includes(search);
+
+      const matchesTitle = campaign.internal_title
+        .toLowerCase()
+        .includes(search);
+
+      const matchesCause = campaign.cause.some(cause =>
+        cause.toLowerCase().includes(search),
+      );
+
+      return matchesId || matchesTitle || matchesCause;
+    });
+  }
+
+  /**
+   * Render the campaign overview!
+   *
+   * @return {React.Element}
+   */
   render() {
-    const { pending, etc } = this.props;
+    const pending = this.filterCampaigns(this.props.pending);
+    const etc = this.filterCampaigns(this.props.etc);
 
     return (
       <div className="container">
+        <div className="container__block -half">
+          <input
+            type="text"
+            className="text-field -search"
+            placeholder="Filter by campaign ID, name, cause..."
+            onChange={this.onChange}
+          />
+        </div>
         <CampaignTable cause="Pending Review" campaigns={pending} />
         <CampaignTable cause="etc." campaigns={etc} />
       </div>

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -66,8 +66,23 @@ class CampaignOverview extends React.Component {
             onChange={this.onChange}
           />
         </div>
-        <CampaignTable cause="Pending Review" campaigns={pending} />
-        <CampaignTable cause="etc." campaigns={etc} />
+        <div className="container__block">
+          <h3>Pending Review</h3>
+          <p>
+            These campaigns are currently active &amp; have posts pending
+            review:
+          </p>
+        </div>
+        <div className="container__block">
+          <CampaignTable campaigns={pending} />
+        </div>
+        <div className="container__block">
+          <h3>Everything Else</h3>
+          <p>These campaigns are either closed or have no pending posts:</p>
+        </div>
+        <div className="container__block">
+          <CampaignTable campaigns={etc} />
+        </div>
       </div>
     );
   }

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -1,22 +1,17 @@
 import React from 'react';
-import { map } from 'lodash';
 
 import CampaignTable from '../CampaignTable';
 
 class CampaignOverview extends React.Component {
   render() {
-    const causeData = this.props;
+    const { pending, etc } = this.props;
 
-    const causeTables = map(causeData, (data, cause) => (
-      <CampaignTable
-        key={cause}
-        cause={cause || 'Uncategorized'}
-        campaigns={data}
-        causeData={causeData}
-      />
-    ));
-
-    return <div className="container">{causeTables}</div>;
+    return (
+      <div className="container">
+        <CampaignTable cause="Pending Review" campaigns={pending} />
+        <CampaignTable cause="etc." campaigns={etc} />
+      </div>
+    );
   }
 }
 

--- a/resources/assets/components/CampaignTable/index.js
+++ b/resources/assets/components/CampaignTable/index.js
@@ -5,14 +5,11 @@ import Table from '../Table';
 
 class CampaignTable extends React.Component {
   render() {
-    const cause = this.props.cause;
     const campaigns = this.props.campaigns;
 
     return (
-      <div className="table-responsive container__block">
-        <h2>{cause}</h2>
+      <div className="table-responsive">
         <Table
-          key={cause}
           className="table"
           headings={['Campaign Name', 'Pending', 'Inbox']}
           data={this.props.campaigns}
@@ -24,7 +21,6 @@ class CampaignTable extends React.Component {
 }
 
 CampaignTable.propTypes = {
-  cause: PropTypes.string.isRequired,
   campaigns: PropTypes.array, // eslint-disable-line react/forbid-prop-types
 };
 

--- a/resources/assets/components/Table/CampaignRow.js
+++ b/resources/assets/components/Table/CampaignRow.js
@@ -17,7 +17,7 @@ class CampaignRow extends React.Component {
       },
       {
         url: null,
-        title: campaign ? campaign.pending_count : 0,
+        title: campaign ? campaign.posts_count : 0,
       },
       {
         url: campaign ? `/campaigns/${campaign.id}/inbox` : '/campaigns',


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the Campaign Overview page to group & sort campaigns by status & pending post count, rather than by cause (since in a multi-cause world, that's a confusing thing to do). I've also added a little search box so users can filter for a campaign based on ID, name, or cause.

![Screen Shot 2019-05-03 at 1 50 05 PM](https://user-images.githubusercontent.com/583202/57155817-65b8f980-6daa-11e9-987e-979edf51be0a.png)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
↕️

#### Relevant tickets
[#165160940](https://www.pivotaltracker.com/story/show/165160940)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md