### PR TITLE
Swap back to using optimized queries from CampaignService.

### DIFF
--- a/app/Http/Controllers/Legacy/Web/CampaignsController.php
+++ b/app/Http/Controllers/Legacy/Web/CampaignsController.php
@@ -33,14 +33,13 @@ class CampaignsController extends Controller
      */
     public function index()
     {
-        $campaigns = Campaign::withCount(['posts' => function ($query) {
-            return $query->where('status', 'pending');
-        }])->get();
+        $campaigns = $this->campaignService->findAll();
+        $campaigns = $this->campaignService->appendPendingCountsToCampaigns($campaigns);
 
         $sortedCampaigns = $campaigns->sortByDesc('posts_count')
             ->groupBy(function ($campaign) {
                 $isActive = $campaign->isOpen();
-                $hasPendingPosts = $campaign->posts_count > 0;
+                $hasPendingPosts = $campaign->pending_count > 0;
 
                 return $isActive && $hasPendingPosts ? 'pending' : 'etc';
             })->toArray();

--- a/app/Http/Controllers/Legacy/Web/CampaignsController.php
+++ b/app/Http/Controllers/Legacy/Web/CampaignsController.php
@@ -36,7 +36,7 @@ class CampaignsController extends Controller
         $campaigns = $this->campaignService->findAll();
         $campaigns = $this->campaignService->appendPendingCountsToCampaigns($campaigns);
 
-        $sortedCampaigns = $campaigns->sortByDesc('posts_count')
+        $sortedCampaigns = $campaigns->sortByDesc('pending_count')
             ->groupBy(function ($campaign) {
                 $isActive = $campaign->isOpen();
                 $hasPendingPosts = $campaign->pending_count > 0;

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -56,7 +56,7 @@ class Campaign extends Model
         'lgbtq-rights' => 'LGBTQ+ Rights & Equality ',
         'mental-health' => 'Mental Health',
         'veterans' => 'Military/Veterans',
-        'physical-health' => 'Physical health',
+        'physical-health' => 'Physical Health',
         'racial-justice' => 'Racial Justice/Racial Equity',
         'sexual-harassment' => 'Sexual Harassment & Assault',
         'voter-registration' => 'Voter Registration',

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,17 +226,17 @@
           "dev": true
         },
         "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -903,14 +903,14 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
-          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+          "version": "4.5.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+          "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000960",
-            "electron-to-chromium": "^1.3.124",
-            "node-releases": "^1.1.14"
+            "caniuse-lite": "^1.0.30000963",
+            "electron-to-chromium": "^1.3.127",
+            "node-releases": "^1.1.17"
           }
         }
       }
@@ -2307,9 +2307,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000963",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
-      "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+      "version": "1.0.30000966",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
+      "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
       "dev": true
     },
     "capture-exit": {
@@ -3207,9 +3207,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.125",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
-      "integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
+      "version": "1.3.130",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.130.tgz",
+      "integrity": "sha512-UY2DI+gsnqGtQJqO8wXN0DnpJY+29FwJafACj0h18ZShn5besKnrRq6+lXWUbKzdxw92QQcnTqRLgNByOKXcUg==",
       "dev": true
     },
     "elliptic": {
@@ -3479,9 +3479,9 @@
           "dev": true
         },
         "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         },
         "json-schema-traverse": {
@@ -3666,18 +3666,18 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.12.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
-      "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
+      "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
+        "jsx-ast-utils": "^2.1.0",
         "object.fromentries": "^2.0.0",
-        "prop-types": "^15.6.2",
-        "resolve": "^1.9.0"
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
       },
       "dependencies": {
         "jsx-ast-utils": {
@@ -4316,9 +4316,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
-      "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7130,9 +7130,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-base64": {
       "version": "2.5.1",
@@ -11112,9 +11112,9 @@
       "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
     },
     "uglify-js": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.7.tgz",
-      "integrity": "sha512-GCgJx3BBuaf/QMvBBkhoHDh4SVsHCC3ILEzriPw4FgJJKCuxVBSYLRkDlmT3uhXyGWKs3VN5r0mCkBIZaHWu3w==",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
+      "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11841,9 +11841,9 @@
       "dev": true
     },
     "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"

--- a/resources/assets/components/Table/CampaignRow.js
+++ b/resources/assets/components/Table/CampaignRow.js
@@ -17,7 +17,7 @@ class CampaignRow extends React.Component {
       },
       {
         url: null,
-        title: campaign ? campaign.posts_count : 0,
+        title: campaign ? campaign.pending_count : 0,
       },
       {
         url: campaign ? `/campaigns/${campaign.id}/inbox` : '/campaigns',


### PR DESCRIPTION
#### What's this PR do?
This pull request swaps `CampaignsController` back to using the ol' campaign service, which has some pretty gnarly but better optimized queries for gathering these pending post counts.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I'd forgotten how much work we had to do to get this query working smoothly in `CampaignService`! 

#### Relevant tickets
[#165160940](https://www.pivotaltracker.com/story/show/165160940)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md