### PR TITLE
Actions controller cleanup!

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -53,6 +53,7 @@ class ActionsController extends Controller
         ]));
 
         // Check to see if the action exists before creating one.
+        // @TODO: Remove once we're no longer fetching by this combination of fields.
         $action = Action::where([
             'name' => $request['name'],
             'campaign_id' => $request['campaign_id'],

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -71,12 +71,14 @@ class ActionsController extends Controller
 
     /**
      * Edit an existing action.
+     *
+     * @param  \Rogue\Models\Action  $action
+     * @param  $campaignId
      */
-    public function edit($campaignId, $actionId)
+    public function edit(Action $action)
     {
         return view('actions.edit')->with([
-            'campaignId' => $campaignId,
-            'action' => Action::find($actionId),
+            'action' => $action,
             'postTypes' => PostType::all(),
         ]);
     }

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -106,7 +106,7 @@ class ActionsController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \Rogue\Models\Action  $campaign
+     * @param  \Rogue\Models\Action  $action
      */
     public function destroy(Action $action)
     {

--- a/app/Http/Controllers/Legacy/Web/ActionsController.php
+++ b/app/Http/Controllers/Legacy/Web/ActionsController.php
@@ -84,10 +84,10 @@ class ActionsController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  \Rogue\Models\Action  $action
+     * @param  \Illuminate\Http\Request  $request
      */
-    public function update(Request $request, Action $action)
+    public function update(Action $action, Request $request)
     {
         $request = $this->fillInOmittedCheckboxes($request);
 

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -108,7 +108,7 @@ class SignupsController extends ApiController
         $orderBy = $request->query('orderBy');
 
         if ($orderBy) {
-            list($column, $direction) = explode(',', $orderBy, 2);
+            [$column, $direction] = explode(',', $orderBy, 2);
 
             if (in_array($column, Signup::$indexes)) {
                 $query = $query->orderBy($column, $direction);

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -23,7 +23,10 @@ class Action extends Model
      *
      * @var array
      */
-    protected $fillable = ['name', 'campaign_id', 'post_type', 'callpower_campaign_id', 'reportback', 'civic_action', 'scholarship_entry', 'anonymous', 'noun', 'verb'];
+    protected $fillable = [
+        'name', 'campaign_id', 'post_type', 'action_type', 'time_commitment', 'callpower_campaign_id',
+        'reportback', 'civic_action', 'scholarship_entry', 'anonymous', 'online', 'quiz', 'noun', 'verb',
+    ];
 
     /**
      * Attributes that can be queried when filtering.
@@ -34,6 +37,16 @@ class Action extends Model
      * @var array
      */
     public static $indexes = ['id', 'campaign_id', 'callpower_campaign_id'];
+
+    /**
+     * Get any fields on this model that are casted to a boolean.
+     *
+     * @return array
+     */
+    public static function getBooleans()
+    {
+        return array_keys(((new self)->casts), 'boolean');
+    }
 
     /**
      * Each action belongs to a campaign.

--- a/app/PostType.php
+++ b/app/PostType.php
@@ -44,8 +44,24 @@ class PostType
      *
      * @return array
      */
+    public static function values()
+    {
+        return array_keys(self::all());
+    }
+
+    /**
+     * Returns list of all valid post types.
+     *
+     * @return array
+     */
     public static function all()
     {
-        return [self::$text, self::$photo, self::$voterReg, self::$shareSocial, self::$phoneCall];
+        return [
+            self::$text => 'Text Post',
+            self::$photo => 'Photo Post',
+            self::$voterReg => 'Voter Registration',
+            self::$shareSocial => 'Social Share',
+            self::$phoneCall => 'Phone Call (CallPower)',
+        ];
     }
 }

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -48,8 +48,11 @@ button.delete {
 
 .form-item.-third {
   float: left;
-  width: 33%;
-  padding-right: $base-spacing / 2;
+  width: 33.33333333333%;
+}
+
+.form-item.-third + .form-item.-third {
+  padding-left: $base-spacing / 2;
 }
 
 .columns-2 {

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -90,7 +90,7 @@ class Action extends React.Component {
           <div className="container__row">
             <a
               className="button -secondary"
-              href={`${campaign.id}/actions/${action.id}/edit`}
+              href={`/actions/${action.id}/edit`}
             >
               Edit Action
             </a>

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -7,63 +7,43 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -narrow">
-                <h1>Add Post Metadata</h1>
-                <form method="post" enctype="application/x-www-form-urlencoded" action="{{ route('actions.store', ['campaign_id' => $campaignId]) }}">
-                {{ csrf_field()}}
+                <h1>Create Action</h1>
+                <form method="POST" action="{{ route('actions.store', ['campaign_id' => $campaignId]) }}">
+                    {{ csrf_field()}}
 
                     <div class="form-item">
                         <label class="field-label">Action Name</label>
-                        <input type="text" name="name" class="text-field" placeholder="Name your action e.g. Teens for Jeans Photo Upload" value="{{old('name') }}">
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Name your action e.g. Teens for Jeans Photo Upload'])
                     </div>
 
-                    <div class="select form-item">
+                    <div class="form-item">
                         <label class="field-label">Post Type</label>
-                        <select name="post_type">
-                            <option value="" disabled selected>Select the post type</option>
-                            @foreach($postTypes as $postType)
-                                @if (old('post_type'))
-                                    <option value="{{ $postType }}" {{ (old('post_type') == $postType ? "selected":"") }}>{{ $postType }}</option>
-                                @else
-                                    <option>{{ $postType }}</option>
-                                @endif
-                            @endforeach
-                        </select>
+                        @include('forms.select', ['name' => 'post_type', 'options' => $postTypes, 'placeholder' => 'What type of post is this?'])
                     </div>
+
                     <div class="form-item -third">
                         <label class="field-label">CallPower Campaign ID</label>
-                        <input type="text" name="callpower_campaign_id" class="text-field" placeholder="e.g. 4 (optional)" value="{{ old('callpower_campaign_id') }}">
+                        @include('forms.text', ['name' => 'callpower_campaign_id', 'placeholder' => 'e.g. 4 (optional)'])
                     </div>
+
                     <div class="form-item -third">
                         <label class="field-label">Action Noun</label>
-                        <input type="text" name="noun" class="text-field" placeholder="e.g. Jeans" value="{{ old('noun') }}">
+                        @include('forms.text', ['name' => 'noun', 'placeholder' => 'e.g. Jeans'])
                     </div>
+
                     <div class="form-item -third">
                         <label class="field-label">Action Verb</label>
-                        <input type="text" name="verb" class="text-field" placeholder="e.g. Collected" value="{{ old('verb') }}">
+                        @include('forms.text', ['name' => 'verb', 'placeholder' => 'e.g. Collected'])
                     </div>
+
                     <div class="form-item">
                         <label class="field-label">Post Details</label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=reportback name=reportback value=1 {{ old('reportback') ? 'checked="checked"' : '' }}>
-                          <span class="option__indicator"></span>
-                          <span>Reportback</span>
-                        </label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=civic_action name=civic_action value=1 {{ old('civic_action') ? 'checked="checked"' : '' }}>
-                          <span class="option__indicator"></span>
-                          <span>Civic action</span>
-                        </label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=scholarship_entry name=scholarship_entry value=1 {{ old('scholarship_entry') ? 'checked="checked"' : '' }}>
-                          <span class="option__indicator"></span>
-                          <span>Scholarship entry</span>
-                        </label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=anonymous name=anonymous value=1 {{ old('anonymous') ? 'checked="checked"' : '' }}>
-                          <span class="option__indicator"></span>
-                          <span>Anonymous Post</span>
-                        </label>
+                        @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback'])
+                        @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action'])
+                        @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry'])
+                        @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous'])
                     </div>
+
                     <ul class="form-actions -inline -padded">
                         <li><input type="submit" class="button" value="Create Action"></li>
                     </ul>

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -9,119 +9,43 @@
             <div class="container__block -narrow">
                 <h1>Edit {{ $action->name }}</h1>
 
-                <form method="post" enctype="application/x-www-form-urlencoded" action="{{ route('actions.update', $action->id) }}">
-                {{ csrf_field()}}
-                <input name="_method" type="hidden" value="PATCH">
+                <form method="POST" action="{{ route('actions.update', $action->id) }}">
+                    {{ csrf_field()}}
+                    {{ method_field('PATCH') }}
 
                     <div class="form-item">
                         <label class="field-label">Action Name</label>
-                        <input type="text" name="name" class="text-field"
-                            @if (old('name'))
-                                value="{{ old('name') }}"
-                            @else
-                                value="{{ $action->name }}"
-                            @endif
-                        >
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Name your action e.g. Teens for Jeans Photo Upload', 'value' => $action->name])
                     </div>
 
-                    <div class="select form-item">
+                    <div class="form-item">
                         <label class="field-label">Post Type</label>
-                        <select name="post_type">
-                            <option value="">Select the post type</option>
-                            @foreach($postTypes as $postType)
-                                @if (old('post_type'))
-                                    <option value="{{ $postType }}" {{ (old('post_type') == $postType ? "selected":"") }}>{{ $postType }}</option>
-                                @else
-                                    <option value="{{ $postType }}" {{ ($action->post_type == $postType ? "selected":"") }}>{{ $postType }}</option>
-                                @endif
-                            @endforeach
-                        </select>
+                        @include('forms.select', ['name' => 'post_type', 'options' => $postTypes, 'value' => $action->post_type, 'placeholder' => 'What type of post is this?'])
                     </div>
+
                     <div class="form-item -third">
                         <label class="field-label">CallPower Campaign ID</label>
-                        <input type="text" name="callpower_campaign_id" class="text-field" placeholder="e.g. 4 (optional)"
-                            @if (old('callpower_campaign_id'))
-                                value="{{ old('callpower_campaign_id') }}"
-                            @else
-                                value="{{ $action->callpower_campaign_id }}"
-                            @endif
-                        >
+                        @include('forms.text', ['name' => 'callpower_campaign_id', 'placeholder' => 'e.g. 4 (optional)', 'value' => $action->callpower_campaign_id])
                     </div>
+
                     <div class="form-item -third">
                         <label class="field-label">Action Noun</label>
-                        <input type="text" name="noun" class="text-field" placeholder="e.g. Jeans"
-                            @if (old('noun'))
-                                value="{{ old('noun') }}"
-                            @else
-                                value="{{ $action->noun }}"
-                            @endif
-                        >
+                        @include('forms.text', ['name' => 'noun', 'placeholder' => 'e.g. Jeans', 'value' => $action->noun])
                     </div>
+
                     <div class="form-item -third">
                         <label class="field-label">Action Verb</label>
-                        <input type="text" name="verb" class="text-field" placeholder="e.g. Collected"
-                            @if (old('verb'))
-                                value="{{ old('verb') }}"
-                            @else
-                                value="{{ $action->verb }}"
-                            @endif
-                        >
+                        @include('forms.text', ['name' => 'verb', 'placeholder' => 'e.g. Collected', 'value' => $action->verb])
                     </div>
+
                     <div class="form-item">
-                        <label class="field-label">Post Details</label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=reportback name=reportback value=1
-                            @if ($errors->any()))
-                                @if (old('reportback'))
-                                    checked="checked"
-                                @endif
-                            @elseif ($action->reportback)
-                                checked="checked"
-                            @endif
-                          >
-                          <span class="option__indicator"></span>
-                          <span>Reportback</span>
-                        </label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=civic_action name=civic_action value=1
-                            @if ($errors->any()))
-                                @if (old('civic_action'))
-                                    checked="checked"
-                                @endif
-                            @elseif ($action->civic_action)
-                                checked="checked"
-                            @endif
-                          >
-                          <span class="option__indicator"></span>
-                          <span>Civic action</span>
-                        </label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=scholarship_entry name=scholarship_entry value=1
-                            @if ($errors->any()))
-                                @if (old('scholarship_entry'))
-                                    checked="checked"
-                                @endif
-                            @elseif ($action->scholarship_entry)
-                                checked="checked"
-                            @endif
-                          >
-                          <span class="option__indicator"></span>
-                          <span>Scholarship entry</span>
-                        </label>
-                        <label class="option -checkbox">
-                          <input type="checkbox" id=anonymous name=anonymous value=1
-                            @if ($errors->any()))
-                                @if (old('anonymous'))
-                                    checked="checked"
-                                @endif
-                            @elseif ($action->anonymous)
-                                checked="checked"
-                            @endif
-                          >
-                          <span class="option__indicator"></span>
-                          <span>Anonymous Post</span>
-                        </label>
+                        <label class="field-label">Action Details</label>
+                        @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback', 'value' => $action->reportback])
+                        @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action', 'value' => $action->civic_action])
+                        @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry', 'value' => $action->scholarship_entry])
+                        @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous', 'value' => $action->anonymous])
                     </div>
+
                     <ul class="form-actions -inline -padded">
                         <li><input type="submit" class="button" value="Update Action"></li>
                     </ul>

--- a/resources/views/forms/option.blade.php
+++ b/resources/views/forms/option.blade.php
@@ -1,0 +1,5 @@
+<label class="option -checkbox">
+    <input type="checkbox" name="{{ $name }}" {{ old($name, ! empty($value)) ? 'checked' : '' }}>
+    <span class="option__indicator"></span>
+    <span>{{ $label }}</span>
+</label>

--- a/resources/views/forms/select.blade.php
+++ b/resources/views/forms/select.blade.php
@@ -1,0 +1,12 @@
+<div class="select">
+    <select name="{{ $name }}">
+        <option value="" disabled>{{ $placeholder or '–' }}</option>
+        @foreach($options as $option => $label)
+            @if (old($name))
+                <option value="{{ $option }}" {{ old($name) === $option ? 'selected': '' }}>{{ $label }}</option>
+            @else
+                <option value="{{ $option }}" {{ isset($value) && $value === $option ? 'selected': '' }}>{{ $label }}</option>
+            @endif
+        @endforeach
+    </select>
+</div>

--- a/resources/views/forms/text.blade.php
+++ b/resources/views/forms/text.blade.php
@@ -1,0 +1,1 @@
+<input type="text" name="{{ $name }}" class="text-field" value="{{ old($name, isset($value) ? $value : '') }}" placeholder="{{ isset($placeholder) ? $placeholder : '' }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,6 @@ $router->get('campaigns/{id}', 'Legacy\Web\CampaignsController@show')->name('cam
 // @TODO: Merge into CampaignsController, above.
 $router->resource('campaign-ids', 'Legacy\Web\CampaignIdsController');
 $router->get('campaign-ids/{id}/actions/create', 'Legacy\Web\ActionsController@create');
-$router->get('campaign-ids/{campaignId}/actions/{actionId}/edit', 'Legacy\Web\ActionsController@edit');
 
 // Actions
 $router->resource('actions', 'Legacy\Web\ActionsController');

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -109,16 +109,20 @@ class ActionTest extends TestCase
         $action = factory(Action::class)->create();
 
         // Update the name.
-        $this->actingAsAdmin()->patchJson('actions/' . $action->id, [
+        $this->actingAsAdmin()->patch('actions/' . $action->id, [
             'name' => 'Updated Name',
+            'post_type' => $action->post_type,
+            'noun' => $action->noun,
+            'verb' => $action->verb,
         ]);
 
         // Make sure the action update is persisted.
         $response = $this->getJson('api/v3/actions/' . $action->id);
-        $decodedResponse = $response->decodeResponseJson();
-
-        $response->assertStatus(200);
-        $this->assertEquals('Updated Name', $decodedResponse['data']['name']);
+        $response->assertJson([
+            'data' => [
+                'name' => 'Updated Name',
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request includes some cleanup to the actions controller & form markup, extracted from my upcoming pull request to add additional metadata fields to this resource.

🕵 Shares common validation rules between store & update methods, so we don't need to keep two different versions of this in sync. This also fixes a teeny bug where you could unset required fields from an actions "edit" page. 21acabb

☑️ Simplifies how we handle checkboxes by using the model's `$casts` array to automatically fill in missing boolean values on the form. 242ae49

📃 Adds partials for text, select, and checkbox field markup. This means less work to add new fields, and cleans up some inconsistencies in how we were handling these. 4a90e4c

💅 Fixes some tiny visual issues ([before](https://user-images.githubusercontent.com/583202/57237052-5d53ff00-6ff4-11e9-9612-61394996cf68.png), [after](https://user-images.githubusercontent.com/583202/57237056-5f1dc280-6ff4-11e9-9c71-3d0b732ba347.png)) on the form. f6e7557

🍃 Some miscellaneous fixes. 3a7caad, 1ea90b3, efb173c, c6dc6d0

#### How should this be reviewed?
It might be easier to go commit-by-commit. If so, linked above!

#### Any background context you want to provide?
N/A

#### Relevant tickets
[#165160940](https://www.pivotaltracker.com/story/show/165160940)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md