### PR TITLE
Handle Rendering Campaigns Overview with empty/null Categories

### DIFF
--- a/docs/development/installation.md
+++ b/docs/development/installation.md
@@ -11,4 +11,7 @@ $ php artisan rogue:setup
 
 # And finally, build the frontend assets:
 $ npm run build
+
+# Also, feel free to seed the database with dummy data:
+$ php artisan db:seed
 ```

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -53,8 +53,9 @@ class CampaignOverview extends React.Component {
    * @return {React.Element}
    */
   render() {
-    const pending = this.filterCampaigns(this.props.pending);
-    const etc = this.filterCampaigns(this.props.etc);
+    const { pending, etc } = this.props;
+
+    const noCampaignsMessage = <p>No campaigns to display!</p>;
 
     return (
       <div className="container">
@@ -74,14 +75,22 @@ class CampaignOverview extends React.Component {
           </p>
         </div>
         <div className="container__block">
-          <CampaignTable campaigns={pending} />
+          {pending ? (
+            <CampaignTable campaigns={this.filterCampaigns(pending)} />
+          ) : (
+            noCampaignsMessage
+          )}
         </div>
         <div className="container__block">
           <h3>Everything Else</h3>
           <p>These campaigns are either closed or have no pending posts:</p>
         </div>
         <div className="container__block">
-          <CampaignTable campaigns={etc} />
+          {etc ? (
+            <CampaignTable campaigns={this.filterCampaigns(etc)} />
+          ) : (
+            noCampaignsMessage
+          )}
         </div>
       </div>
     );

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -48,15 +48,28 @@ class CampaignOverview extends React.Component {
   }
 
   /**
+   * Render a tabled list of campaigns or a placeholder message if there are none to display.
+   *
+   * @return {Object}
+   */
+  renderCampaignsTable(campaigns) {
+    return (
+      <div className="container__block">
+        {campaigns ? (
+          <CampaignTable campaigns={this.filterCampaigns(campaigns)} />
+        ) : (
+          <p>No campaigns to display!</p>
+        )}
+      </div>
+    );
+  }
+
+  /**
    * Render the campaign overview!
    *
    * @return {React.Element}
    */
   render() {
-    const { pending, etc } = this.props;
-
-    const noCampaignsMessage = <p>No campaigns to display!</p>;
-
     return (
       <div className="container">
         <div className="container__block -half">
@@ -74,24 +87,12 @@ class CampaignOverview extends React.Component {
             review:
           </p>
         </div>
-        <div className="container__block">
-          {pending ? (
-            <CampaignTable campaigns={this.filterCampaigns(pending)} />
-          ) : (
-            noCampaignsMessage
-          )}
-        </div>
+        {this.renderCampaignsTable(this.props.pending)}
         <div className="container__block">
           <h3>Everything Else</h3>
           <p>These campaigns are either closed or have no pending posts:</p>
         </div>
-        <div className="container__block">
-          {etc ? (
-            <CampaignTable campaigns={this.filterCampaigns(etc)} />
-          ) : (
-            noCampaignsMessage
-          )}
-        </div>
+        {this.renderCampaignsTable(this.props.etc)}
       </div>
     );
   }

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -23,6 +23,7 @@ class CampaignOverview extends React.Component {
   /**
    * Filter the given campaigns by current search term.
    *
+   * @param  {Array|Null} campaigns
    * @return {Array}
    */
   filterCampaigns(campaigns) {

--- a/resources/assets/components/CampaignOverview/index.js
+++ b/resources/assets/components/CampaignOverview/index.js
@@ -23,7 +23,7 @@ class CampaignOverview extends React.Component {
   /**
    * Filter the given campaigns by current search term.
    *
-   * @param  {Array|Null} campaigns
+   * @param  {Array} campaigns
    * @return {Array}
    */
   filterCampaigns(campaigns) {
@@ -51,6 +51,7 @@ class CampaignOverview extends React.Component {
   /**
    * Render a tabled list of campaigns or a placeholder message if there are none to display.
    *
+   * @param  {Array|Null} campaigns
    * @return {Object}
    */
   renderCampaignsTable(campaigns) {


### PR DESCRIPTION
#### What's this PR do?
This PR updates the `CampaignOverview` component to handle the scenario where no campaigns are available per category, rendering a simple message instead of attempting to still filter the (`null`) campaigns value.

https://github.com/DoSomething/rogue/commit/0841bf3ecf4f2be7ee83e35390d5565454dcb6df then tentatively refactors some of the logic into a method. This felt DRYer to me, but if this seems too egregious I can just roll this back! (Also, should such a thing be in a method as opposed to its own functional component?)

And finally, https://github.com/DoSomething/rogue/pull/882/commits/e05bcdb755c15ea8a26800338ccedfcbff2ec6ab adds a step to our installation instructions to cover seeding the DB!

#### How should this be reviewed?
Delete all the campaigns from Rogue or review all pending posts and see what happens 😁 

#### Any background context you want to provide?
While setting up Rogue, I attempted to visit the campaigns page before having seeded the database, and the page errored out due to an [attempted filtering](https://github.com/DoSomething/rogue/blob/2dc842f7b1a888b19884ab9c4b2d71e7f884f121/resources/assets/components/CampaignOverview/index.js#L31) of the [empty campaign data](https://github.com/DoSomething/rogue/blob/2dc842f7b1a888b19884ab9c4b2d71e7f884f121/resources/assets/components/CampaignOverview/index.js#L56-L57)

#### Relevant tickets
https://dosomething.slack.com/archives/C2BLZGBPH/p1557773627015300

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
