### PR TITLE
GraphQL Service Updates (& new CampaignWebsite query)

### DIFF
--- a/app/Console/Commands/UpdatePostsWithActionIds.php
+++ b/app/Console/Commands/UpdatePostsWithActionIds.php
@@ -3,7 +3,6 @@
 namespace Rogue\Console\Commands;
 
 use DB;
-use Rogue\Models\Post;
 use Rogue\Models\Action;
 use Illuminate\Console\Command;
 

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -60,6 +60,6 @@ class GraphQL
             'campaignId' => $campaignId,
         ];
 
-        return $this->query($query, $variables, 'campaignWebsiteByCampaignId');
+        return $this->query($query, $variables);
     }
 }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Services;
 
-use Illuminate\Support\Facades\Log;
 use Softonic\GraphQL\ClientBuilder;
 
 class GraphQL

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -22,7 +22,7 @@ class GraphQL
      * @param  $query     String
      * @param  $variables Array
      * @param  $queryKey  String
-     * @return Array|null
+     * @return array|null
      */
     public function query($query, $variables, $queryKey)
     {
@@ -44,7 +44,7 @@ class GraphQL
      * Query for a CampaignWebsite by campaignId field.
      *
      * @param  $campaignId String
-     * @return Array|null
+     * @return array|null
      */
     public function getCampaignWebsiteByCampaignId($campaignId)
     {

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -29,7 +29,8 @@ class GraphQL
             $response = $this->client->query($query, $variables);
         } catch (\Exception $exception) {
             Log::error(
-                'GraphQL request failed. Variables: '.json_encode($variables).' Exception: '.$exception->getMessage()
+                'GraphQL request failed. Query: '.$query
+                .' Variables: '.json_encode($variables).' Exception: '.$exception->getMessage()
             );
 
             return null;

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -31,6 +31,10 @@ class GraphQL
     /**
      * Query for a CampaignWebsite by campaignId field.
      *
+     * NOTE: We prefer to bundle queries with their associated usage logic.
+     * We've opted to utilize this helper method as an exception to avoid duplication.
+     * (See thread https://git.io/fjoqd).
+     *
      * @param  $campaignId String
      * @return array
      */

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -20,7 +20,7 @@ class GraphQL
      *
      * @param  $query     String
      * @param  $variables Array
-     * @return array|null
+     * @return array
      */
     public function query($query, $variables)
     {
@@ -34,17 +34,17 @@ class GraphQL
                 'exception' => $exception->getMessage(),
             ]);
 
-            return null;
+            return [];
         }
 
-        return $response ? $response->getData() : null;
+        return $response ? $response->getData() : [];
     }
 
     /**
      * Query for a CampaignWebsite by campaignId field.
      *
      * @param  $campaignId String
-     * @return array|null
+     * @return array
      */
     public function getCampaignWebsiteByCampaignId($campaignId)
     {

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Services;
 
+use Illuminate\Support\Facades\Log;
 use Softonic\GraphQL\ClientBuilder;
 
 class GraphQL
@@ -15,14 +16,28 @@ class GraphQL
     }
 
     /**
-     * Run a GraphQL query using the client.
+     * Run a GraphQL query using the client
+     * and parse the data result into a convenient format.
      *
      * @param  $query     String
      * @param  $variables Array
-     * @return \Softonic\GraphQL\Response
+     * @param  $queryKey  String
+     * @return Array|null
      */
-    public function query($query, $variables)
+    public function query($query, $variables, $queryKey)
     {
-        return $this->client->query($query, $variables);
+        // Use try/catch to avoid any GraphQL related errors breaking the application.
+        try {
+            $response = $this->client->query($query, $variables);
+        } catch (\Exception $exception) {
+            Log::error(
+                'GraphQL request failed. Variables: '.json_encode($variables).' Exception: '.$exception->getMessage()
+            );
+
+            return null;
+        }
+
+        return $response ? array_get($response->getData(), $queryKey) : null;
+    }
     }
 }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -28,10 +28,11 @@ class GraphQL
         try {
             $response = $this->client->query($query, $variables);
         } catch (\Exception $exception) {
-            Log::error(
-                'GraphQL request failed. Query: '.$query
-                .' Variables: '.json_encode($variables).' Exception: '.$exception->getMessage()
-            );
+            Log::error('GraphQL request failed.', [
+                'query' => $query,
+                'variables' => $variables,
+                'exception' => $exception->getMessage(),
+            ]);
 
             return null;
         }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -39,5 +39,27 @@ class GraphQL
 
         return $response ? array_get($response->getData(), $queryKey) : null;
     }
+
+    /**
+     * Query for a CampaignWebsite by campaignId field.
+     *
+     * @param  $campaignId String
+     * @return Array|null
+     */
+    public function getCampaignWebsiteByCampaignId($campaignId)
+    {
+        $query = '
+        query GetCampaignWebsiteByCampaignId($campaignId: String!) {
+          campaignWebsiteByCampaignId(campaignId: $campaignId) {
+            title
+            slug
+          }
+        }';
+
+        $variables = [
+            'campaignId' => $campaignId,
+        ];
+
+        return $this->query($query, $variables, 'campaignWebsiteByCampaignId');
     }
 }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -24,18 +24,7 @@ class GraphQL
      */
     public function query($query, $variables)
     {
-        // Use try/catch to avoid any GraphQL related errors breaking the application.
-        try {
-            $response = $this->client->query($query, $variables);
-        } catch (\Exception $exception) {
-            Log::error('GraphQL request failed.', [
-                'query' => $query,
-                'variables' => $variables,
-                'exception' => $exception->getMessage(),
-            ]);
-
-            return [];
-        }
+        $response = $this->client->query($query, $variables);
 
         return $response ? $response->getData() : [];
     }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -16,15 +16,13 @@ class GraphQL
     }
 
     /**
-     * Run a GraphQL query using the client
-     * and parse the data result into a convenient format.
+     * Run a GraphQL query using the client and return the data result.
      *
      * @param  $query     String
      * @param  $variables Array
-     * @param  $queryKey  String
      * @return array|null
      */
-    public function query($query, $variables, $queryKey)
+    public function query($query, $variables)
     {
         // Use try/catch to avoid any GraphQL related errors breaking the application.
         try {
@@ -37,7 +35,7 @@ class GraphQL
             return null;
         }
 
-        return $response ? array_get($response->getData(), $queryKey) : null;
+        return $response ? $response->getData() : null;
     }
 
     /**

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -52,6 +52,6 @@ class GraphQL
             'campaignId' => $campaignId,
         ];
 
-        return $this->query($query, $variables);
+        return $this->query($query, $variables)['campaignWebsiteByCampaignId'];
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR Updates the GraphQL service's `query` method to:
- safely catch & log any errors thrown when querying GraphQL via the client.
- parse out the data result fields into a flat Array of said fields (or `null` result).

Also adds a `getCampaignWebsiteByCampaignId` method (As @katiecrane [predicted](https://github.com/DoSomething/rogue/pull/888#discussion_r291398099)) which utilizes this new `query` format to (and you probably didn't see this coming) get a Campaign Website (Contentful campaign) from GraphQL queried by the `campaignId` (`legacyCampaignId` on Contentful) field.

#### How should this be reviewed?
I made some architectural decisions here which I'd love to be validated/torn apart!
- ~`try/catch`ing the client errors - This felt like a good move so that a single query error wouldn't completely break the site, but is that wrong and breaking the site would be the expected behavior anyway? Or is this ideal and we can be catching faulty queries in our monitoring systems instead of having everything explode?~ (https://github.com/DoSomething/rogue/pull/889#discussion_r297692642)
  - ~logging said errors~
- parsing out the data result - ~Though this adds a new `$queryKey` param to the `query` method, this still felt like a win to me to help encapsulate the parsing logic avoid the repetition in any new queries we add. (We know we always want the actual Array of fields).~ (https://github.com/DoSomething/rogue/pull/889#discussion_r297298568)

I strangely got a styleci complaint about an untouched file, which I fixed in https://github.com/DoSomething/rogue/commit/09b8f3cab08c45c2c1f3af0bde2c14cd88a6eb42 

#### Relevant tickets
https://www.pivotaltracker.com/story/show/166360256

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
