### PR TITLE
Update Campaign->cause attribute accessor method

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -88,7 +88,9 @@ class Campaign extends Model
      */
     public function getCauseAttribute()
     {
-        return explode(',', $this->attributes['cause']);
+        $cause = $this->attributes['cause'];
+
+        return blank($cause) ? [] : explode(',', $cause);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
It seems that accessing the `Campaign->cause` attribute for a Campaign with `null` or empty string `cause` value returns an array with a single empty string value. 

![image](https://user-images.githubusercontent.com/12417657/61090945-568ba300-a40e-11e9-912d-d6b0c8b44c43.png)


This is because our `getCauseAttribute` accessor method always `explode`s the value, expecting a comma separated string.

This PR adds some logic to just output an empty array for an [`blank`](https://laravel.com/docs/5.5/helpers#method-blank) value.

#### How should this be reviewed?
Does this make sense at all or am I just completely off the mark about this observation / solution? Is the idea perhaps that since valid Campaigns require a Cause, an 'empty' cause is indeed what we desire?

#### Any background context you want to provide?
I bumped into this while testing out adding the `cause` attribute to `Post`/`Signup` blink payloads. While testing for cases where the attribute was unset or null or an empty string, I noticed this array with an empty string value being returned, which I figured could cause some trouble or at least be a misrepresentation of the true value. 

#### Relevant tickets
Related to this effort [Pivotal ID#166360256](https://www.pivotaltracker.com/story/show/166360256)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
