### PR TITLE
Display Signup source_details

### DIFF
--- a/resources/assets/components/Signup/index.js
+++ b/resources/assets/components/Signup/index.js
@@ -486,6 +486,7 @@ class Signup extends React.Component {
                 'Signup ID': signup.id,
                 'Northstar ID': user.id,
                 'Signup Source': signup.source,
+                'Signup Source Details': signup.source_details,
                 'Created At': new Date(signup.created_at).toString(),
               }}
             />


### PR DESCRIPTION
#### What's this PR do?

Allows a dev or admin to view a signup's `source_details` without querying the database.

<img width="400" alt="Screen Shot 2019-07-18 at 1 23 37 PM" src="https://user-images.githubusercontent.com/1236811/61489561-dad6ac80-a95f-11e9-8b5e-416cd71af7cd.png">

#### How should this be reviewed?
:eyes:

#### Any background context you want to provide?

We're looking to save a new `referrer_user_id` property into `source_details` for the [Refer A Friend build.](https://docs.google.com/document/d/1hzw8eBNLTwFFG2KQFdEHdljJbDpgW1awjG3wYjy_A_Q/edit?usp=sharing) As I'm exploring building this out, it'd be swell to see this within the Rogue UI instead of querying the DB.


