### PR TITLE
Write `rogue:delete` command output to logs.

### DIFF
--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -39,7 +39,7 @@ class DeleteUsersCommand extends Command
         $csv = Reader::createFromString($input);
         $csv->setHeaderOffset(0);
 
-        $this->line('Deleting activity for ' . count($csv) . ' users...');
+        info('Deleting activity for ' . count($csv) . ' users...');
 
         foreach ($csv->getRecords() as $record) {
             $id = $record[$this->option('id_column')];
@@ -71,9 +71,9 @@ class DeleteUsersCommand extends Command
                 $post->delete();
             }
 
-            $this->info('Deleted: ' . $id . '(' . $posts->count() . ' posts and ' . $signups->count() . ' signups)');
+            info('Deleted: ' . $id . '(' . $posts->count() . ' posts and ' . $signups->count() . ' signups)');
         }
 
-        $this->info('Done!');
+        info('Done!');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the `northstar:delete` command to write data to the application's logs so that we can refer back to it in Papertrail after running this command.

![](https://media.giphy.com/media/Bq69wCni2tdbT40umw/giphy.gif)

#### How should this be reviewed?
This is basically a carbon-copy of DoSomething/northstar#905! 👀 

#### Any background context you want to provide?
I keep getting mixed up on how this works! When running a command in "detached" mode, all standard output [is written to the logs](https://devcenter.heroku.com/articles/one-off-dynos#running-tasks-in-background), but "normal" one-off dynos [only log startup & shutdown](https://devcenter.heroku.com/articles/one-off-dynos#formation-dynos-vs-one-off-dynos).

Since we're piping standard input into this command, we can't run in detached mode & so we'll need to make sure we're explicitly writing these to the log. 🎋 

#### Relevant tickets
[#167327865](https://www.pivotaltracker.com/story/show/167327865)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
