### PR TITLE
Add campaigns.impact_doc to API response

### DIFF
--- a/app/Http/Controllers/Legacy/Web/CampaignsController.php
+++ b/app/Http/Controllers/Legacy/Web/CampaignsController.php
@@ -49,7 +49,7 @@ class CampaignsController extends Controller
     }
 
     /**
-     * Show particular campaign and it's posts.
+     * Show particular campaign and its posts.
      *
      * @param  int $id
      * @return \Illuminate\Http\Response

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -21,6 +21,7 @@ class CampaignTransformer extends TransformerAbstract
             'start_date' => $campaign->start_date->toIso8601String(),
             'end_date' => optional($campaign->end_date)->toIso8601String(),
             'is_open' => $campaign->isOpen(),
+            'impact_doc' => $campaign->impact_doc,
             'cause' => $campaign->cause,
             'cause_names' => $campaign->getCauseNames(),
             'created_at' => $campaign->created_at->toIso8601String(),


### PR DESCRIPTION
#### What's this PR do?

Fixes missing Proof Of Impact link from a `/campaigns-id/:id` page by returning it from the API response. Is this URL ok to make public?

Example response of a **GET** `/api/v3/campaigns/9003` request:
```
{
  "data": {
    "id": 9003,
    "internal_title": "Assimilated Zerodefect Projection",
    "start_date": "2019-04-25T03:12:15+00:00",
    "end_date": "2020-01-24T21:10:45+00:00",
    "is_open": true,
    "impact_doc": "https://www.google.com/",
    ...
  }
}
```

#### How should this be reviewed?
👀 


#### Relevant tickets
https://www.pivotaltracker.com/n/projects/2019429/stories/166356076

