### PR TITLE
Quick tweak before running the "rogue:delete" script.

### DIFF
--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -64,7 +64,6 @@ class DeleteUsersCommand extends Command
                 $post->update([
                     'text' => null,
                     'details' => null,
-                    'location' => null,
                     'url' => null,
                 ]);
 

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -34,7 +34,7 @@ class DeleteUsersCommandTest extends TestCase
     {
         // The post and its signup should be soft deleted, and fields that may
         // contain personally-identifiable information should be erased:
-        $this->assertSoftDeleted('posts', ['id' => $post->id, 'text' => null, 'url' => null, 'location' => null, 'details' => null]);
+        $this->assertSoftDeleted('posts', ['id' => $post->id, 'text' => null, 'url' => null, 'details' => null]);
         $this->assertSoftDeleted('signups', ['id' => $post->signup_id, 'why_participated' => null, 'details' => null]);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Based on a conversation with @mjain-1, we've decided to keep the `location` field on these deleted records, since it's no longer able to be tied to a particular individual and could be useful for overall demographic data.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
References [this Slack thread](https://dosomething.slack.com/archives/C8P2VSF32/p1564759454002100).

#### Relevant tickets
[#167624495](https://www.pivotaltracker.com/story/show/167624495)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
