### PR TITLE
increase the size of varchar in posts and signups tables

### DIFF
--- a/database/migrations/2019_08_26_154638_increase_size_limit_on_source_details_columns_on_posts_and_signup.php
+++ b/database/migrations/2019_08_26_154638_increase_size_limit_on_source_details_columns_on_posts_and_signup.php
@@ -14,7 +14,7 @@ class IncreaseSizeLimitOnSourceDetailsColumnsOnPostsAndSignup extends Migration
     public function up()
     {
         Schema::table('signups', function (Blueprint $table) {
-            $table->string('source_details', 1024)->change();            
+            $table->string('source_details', 1024)->change();
         });
         Schema::table('posts', function (Blueprint $table) {
             $table->string('source_details', 1024)->change();
@@ -29,7 +29,7 @@ class IncreaseSizeLimitOnSourceDetailsColumnsOnPostsAndSignup extends Migration
     public function down()
     {
         Schema::table('signups', function (Blueprint $table) {
-            $table->string('source_details', 255)->change();    
+            $table->string('source_details', 255)->change();
         });
         Schema::table('posts', function (Blueprint $table) {
             $table->string('source_details', 255)->change();


### PR DESCRIPTION
#### What's this PR do?
tell us, what have you changed?
Increase the varchar limit for source_details column (from standard 255 to 1024) in the posts and signups table

#### How should this be reviewed?
tell us, how can we review, to test that this works
The length change can be viewed using Sequel Pro by opening the Rogue database and finding the source_details column in the posts and signup tables .
Testing can be done by monitoring if user input continues to get truncated

#### Any background context you want to provide?
what else?
This is my first PR :)

#### Relevant tickets
Fixes [Pivotal ID #167659502](https://www.pivotaltracker.com/story/show/167659502)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
