### PR TITLE
Adds Reject Post Function to Hide Display of Runscope Posts

### DIFF
--- a/app/Jobs/RejectPost.php
+++ b/app/Jobs/RejectPost.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rogue\Jobs;
+
+use Rogue\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+
+class RejectPost implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The post to send to Customer.io.
+     *
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Post $post)
+    {
+        $this->post = $post;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Set the status of post to rejected 
+        $this->post->status = 'rejected'; 
+        $this->post->save();
+
+        // Log
+        info('Automatically rejected post ' . $this->post->id);
+    }
+}
+

--- a/app/Jobs/RejectPost.php
+++ b/app/Jobs/RejectPost.php
@@ -38,11 +38,13 @@ class RejectPost implements ShouldQueue
     public function handle()
     {
 
+
         $this->post->status = 'rejected'; 
         $this->post->save();
 
         // Log
         info('Automatically rejected post ' . $this->post->id);
     }
+
     
 }

--- a/app/Jobs/RejectPost.php
+++ b/app/Jobs/RejectPost.php
@@ -9,13 +9,12 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-
 class RejectPost implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
-     * The post to send to Customer.io.
+     * The post to reject.
      *
      * @var Post
      */
@@ -38,7 +37,6 @@ class RejectPost implements ShouldQueue
      */
     public function handle()
     {
-        // Set the status of post to rejected 
         $this->post->status = 'rejected'; 
         $this->post->save();
 
@@ -46,4 +44,3 @@ class RejectPost implements ShouldQueue
         info('Automatically rejected post ' . $this->post->id);
     }
 }
-

--- a/app/Jobs/RejectPost.php
+++ b/app/Jobs/RejectPost.php
@@ -37,10 +37,12 @@ class RejectPost implements ShouldQueue
      */
     public function handle()
     {
+
         $this->post->status = 'rejected'; 
         $this->post->save();
 
         // Log
         info('Automatically rejected post ' . $this->post->id);
     }
+    
 }

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -31,6 +31,7 @@ class ModelServiceProvider extends ServiceProvider
             }
         });
 
+        
          // When Posts are created reject test events.
          Post::created(function ($post) {                  
              if (in_array($post->text, ['Test runscope upload', 'caption_ghost_test'])) {

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -9,9 +9,6 @@ use Rogue\Models\Signup;
 use Rogue\Jobs\RejectPost;
 use Illuminate\Support\ServiceProvider;
 
-
-
-
 class ModelServiceProvider extends ServiceProvider
 {
     /**
@@ -35,13 +32,12 @@ class ModelServiceProvider extends ServiceProvider
         });
 
          // When Posts are created reject test events.
-         Post::created(function ($post) {
-            // Check if caption matches 'Test runscope upload' and 'caption_ghost_test'                
+         Post::created(function ($post) {                  
              if (in_array($post->text, ['Test runscope upload', 'caption_ghost_test'])) {
-                 // If it does, run the RejectPost function and delay for 15 minutes 
+                 // The post will delay for 2 minutes before being rejected to assure tests are running normally 
                 RejectPost::dispatch($post)->delay(now()->addMinutes(2));
-             }
                 
+             }    
         });
 
         // When Posts are saved create an event for them.

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -10,7 +10,7 @@ use Rogue\Jobs\RejectPost;
 use Illuminate\Support\ServiceProvider;
 
 
-use function GuzzleHttp\Promise\is_rejected;
+
 
 class ModelServiceProvider extends ServiceProvider
 {
@@ -39,7 +39,7 @@ class ModelServiceProvider extends ServiceProvider
             // Check if caption matches 'Test runscope upload' and 'caption_ghost_test'                
              if (in_array($post->text, ['Test runscope upload', 'caption_ghost_test'])) {
                  // If it does, run the RejectPost function and delay for 15 minutes 
-                RejectPost::dispatch($post)->delay(now()->addMinutes(15));
+                RejectPost::dispatch($post)->delay(now()->addMinutes(2));
              }
                 
         });
@@ -50,7 +50,7 @@ class ModelServiceProvider extends ServiceProvider
                 // @TODO: this should include the tags with the post
                 'content' => $post->toJson(),
                 // Use the authenticated user if coming from the web,
-                // Otherwise use the id of the user in the request.
+                // otherwise use the id of the user in the request.
                 'user' => auth()->id() ? auth()->id() : $post->northstar_id,
             ]);
         });

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -31,7 +31,6 @@ class ModelServiceProvider extends ServiceProvider
             }
         });
 
-        
          // When Posts are created reject test events.
          Post::created(function ($post) {                  
              if (in_array($post->text, ['Test runscope upload', 'caption_ghost_test'])) {

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -6,7 +6,11 @@ use Rogue\Models\Post;
 use Rogue\Models\Event;
 use Rogue\Models\Review;
 use Rogue\Models\Signup;
+use Rogue\Jobs\RejectPost;
 use Illuminate\Support\ServiceProvider;
+
+
+use function GuzzleHttp\Promise\is_rejected;
 
 class ModelServiceProvider extends ServiceProvider
 {
@@ -30,13 +34,23 @@ class ModelServiceProvider extends ServiceProvider
             }
         });
 
+         // When Posts are created reject test events.
+         Post::created(function ($post) {
+            // Check if caption matches 'Test runscope upload' and 'caption_ghost_test'                
+             if (in_array($post->text, ['Test runscope upload', 'caption_ghost_test'])) {
+                 // If it does, run the RejectPost function and delay for 15 minutes 
+                RejectPost::dispatch($post)->delay(now()->addMinutes(15));
+             }
+                
+        });
+
         // When Posts are saved create an event for them.
         Post::saved(function ($post) {
             $post->events()->create([
                 // @TODO: this should include the tags with the post
                 'content' => $post->toJson(),
                 // Use the authenticated user if coming from the web,
-                // otherwise use the id of the user in the request.
+                // Otherwise use the id of the user in the request.
                 'user' => auth()->id() ? auth()->id() : $post->northstar_id,
             ]);
         });


### PR DESCRIPTION
#### What's this PR do?
To effectively prevent runscope tests from appearing in a campaign lead's inbox, this PR adds a RejectPost function to delay the appearance of a 'test' post for 15 minutes after it's created and then marks the status of the post as 'rejected'.

#### How should this be reviewed?
In rogue.test, click on upload a photo. 
Add a photo and for the caption add 'test runscope upload' and click submit. 
In terminal and inside of rogue in vagrant  `cd` into the /storage/logs folder and `tail -f` the most current log file. 
In a separate tab in terminal run `php artisan queue:listen`. This will watch the files for any changes made 
You should see an update to the log file 15 minutes after creating the post

#### Any background context you want to provide?
what else?
We want to delay the test posts so that the test experience would mimic the normal user experience 
#### Relevant tickets
Fixes #[161383417](https://www.pivotaltracker.com/story/show/161383417)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
