### PR TITLE
Update users table for new preview fields.

### DIFF
--- a/resources/views/users/partials/_table_users.blade.php
+++ b/resources/views/users/partials/_table_users.blade.php
@@ -15,9 +15,9 @@
                     @foreach ($users as $user)
                         @if ($user)
                             <tr class="table__row">
-                                <td class="table__cell"><a href={{ "/users/" . $user->id }}>{{ $user->first_name or 'Anonymous' }} {{ $user->last_name or '' }}</a></td>
-                                <td class="table__cell">{{ $user->email or ''}}</td>
-                                <td class="table__cell">{{ $user->mobile or ''}}</td>
+                                <td class="table__cell"><a href={{ "/users/" . $user->id }}>{{ $user->display_name }}</a></td>
+                                <td class="table__cell">{{ $user->email_preview or ''}}</td>
+                                <td class="table__cell">{{ $user->mobile_preview or ''}}</td>
                             </tr>
                         @endif
                     @endforeach


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the list of users to display the `email_preview` and `mobile_preview` fields, since `email` and `mobile` aren't included by default (and aren't something we want to show unless necessary).

<img width="1215" alt="Screen Shot 2019-10-03 at 11 29 42 AM" src="https://user-images.githubusercontent.com/583202/66141188-492b2280-e5d1-11e9-8e0f-6f1d379a1292.png">

#### How should this be reviewed?
:eyes:

#### Any background context you want to provide?
🔒

#### Relevant tickets
[#167596656](https://www.pivotaltracker.com/story/show/167596656)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
