### PR TITLE
Remove Glide feature flag & unused code paths.

### DIFF
--- a/app/Http/Controllers/Legacy/Web/ImagesController.php
+++ b/app/Http/Controllers/Legacy/Web/ImagesController.php
@@ -34,7 +34,7 @@ class ImagesController extends Controller
         $this->aws = $aws;
         $this->fastly = $fastly;
 
-        $this->middleware('throttle:30');
+        $this->middleware('throttle:60');
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -167,15 +167,7 @@ class Post extends Model
             return null;
         }
 
-        // If Glide is enabled, provide the default image URL.
-        if (config('features.glide')) {
-            return url('images/' . $this->id);
-        }
-
-        // Ask the storage driver for the path to the image for this post.
-        $path = Storage::url('uploads/reportback-items/edited_' . $this->id . '.jpeg');
-
-        return url($path);
+        return url('images/' . $this->id);
     }
 
     /**

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -7,7 +7,6 @@ use Rogue\Services\AWS;
 use Rogue\Models\Action;
 use Rogue\Models\Review;
 use Rogue\Models\Signup;
-use Rogue\Services\Registrar;
 use Intervention\Image\Facades\Image;
 use Illuminate\Validation\ValidationException;
 
@@ -21,29 +20,13 @@ class PostRepository
     protected $aws;
 
     /**
-     * The user repository.
-     *
-     * @var \Rogue\Services\Registrar
-     */
-    protected $registrar;
-
-    /**
-     * Array of properties needed for cropping and rotating.
-     *
-     * @var array
-     */
-    protected $cropProperties = ['crop_x', 'crop_y', 'crop_width', 'crop_height', 'crop_rotate'];
-
-    /**
      * Create a PostRepository.
      *
      * @param AWS $aws
-     * @param Registrar $registrar
      */
-    public function __construct(AWS $aws, Registrar $registrar)
+    public function __construct(AWS $aws)
     {
         $this->aws = $aws;
-        $this->registrar = $registrar;
     }
 
     /**

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -52,10 +52,7 @@ class PostRepository
     public function create(array $data, $signupId, $authenticatedUserRole = null)
     {
         if (isset($data['file'])) {
-            // Auto-orient the photo by default based on exif data.
-            $image = Image::make($data['file']);
-
-            $fileUrl = $this->aws->storeImage((string) $image->encode('data-url'), $signupId);
+            $fileUrl = $this->aws->storeImage($data['file'], $signupId);
         } else {
             $fileUrl = null;
         }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -145,11 +145,6 @@ class PostRepository
 
         $post->save();
 
-        // Edit the image if there is one
-        if (isset($data['file'])) {
-            $this->crop($data, $post->id);
-        }
-
         // Update the signup's total quantity and why_participated if sent.
         if (isset($data['why_participated'])) {
             $signup->why_participated = $data['why_participated'];
@@ -274,23 +269,5 @@ class PostRepository
 
         // Return the post object including the tags that are related to it.
         return Post::with('signup', 'tags')->findOrFail($post->id);
-    }
-
-    /**
-     * Crop an image
-     *
-     * @TODO - remove when glide is permanent.
-     *
-     * @param  int $signupId
-     * @return url|null
-     */
-    protected function crop($data, $postId)
-    {
-        $editedImage = Image::make($data['file']);
-
-        // use default crop (400x400)
-        $editedImage = $editedImage->fit(400, 400)->encode('jpg', 75);
-
-        return $this->aws->storeImageData((string) $editedImage, 'edited_' . $postId);
     }
 }

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -3,11 +3,9 @@
 namespace Rogue\Services;
 
 use Log;
-use finfo;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class AWS
@@ -29,7 +27,7 @@ class AWS
     public function storeImage(UploadedFile $file, string $filename)
     {
         $data = file_get_contents($file->getPathname());
-        $extension = $this->guessExtension($data);
+        $extension = $file->guessExtension();
 
         // Make sure we're only uploading valid image types
         if (! in_array($extension, ['jpeg', 'png', 'gif'])) {
@@ -48,20 +46,6 @@ class AWS
         }
 
         return Storage::url($path);
-    }
-
-    /**
-     * Guess the extension from a data buffer string.
-     * @param string $data - Data buffer string
-     * @return string - file extension
-     */
-    protected function guessExtension($data)
-    {
-        $f = new finfo();
-        $mimeType = $f->buffer($data, FILEINFO_MIME_TYPE);
-        $guesser = ExtensionGuesser::getInstance();
-
-        return $guesser->guess($mimeType);
     }
 
     /**

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -13,6 +13,12 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 class AWS
 {
     /**
+     * The base path where images are stored.
+     * @param string
+     */
+    protected $base = 'uploads/reportback-items/';
+
+    /**
      * Store a reportback item (image) in S3.
      *
      * @param UploadedFile $file
@@ -32,7 +38,7 @@ class AWS
 
         // Add a unique timestamp (e.g. uploads/folder/filename-1456498664.jpeg) to
         // uploads to prevent AWS cache giving the user an old upload.
-        $path = 'uploads/reportback-items' . '/' . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
+        $path = $this->base . $filename . '-' . md5($data) . '-' . time() . '.' . $extension;
 
         // Push file to S3.
         $success = Storage::put($path, $data);
@@ -67,8 +73,7 @@ class AWS
     public function deleteImage($path)
     {
         // We need to use the relative url for the request to s3.
-        $path = basename($path);
-        $path = 'uploads/reportback-items' . '/' . $path;
+        $path = $this->base . basename($path);
 
         // The delete() method always returns true because it doesn't seem to do anything with
         // any exception that is thrown while trying to delete and just returns true.

--- a/config/features.php
+++ b/config/features.php
@@ -12,8 +12,6 @@ return [
     |
     */
 
-    'glide' => env('DS_ENABLE_GLIDE'),
-
     'blink' => env('DS_ENABLE_BLINK'),
 
     'v3QuantitySupport' => env('DS_ENABLE_V3_QUANTITY_SUPPORT'),

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -17,20 +17,21 @@ class ImagesTest extends TestCase
         // Make a post to view
         $posts = factory(Post::class, 10)->create();
 
-        // View the post 15 times (using 3 different versions)
+        // View the post 60 times (using 3 different versions)
         for ($i = 0; $i < 5; $i++) {
             $response = $this->getJson('images/' . $posts->random()->id)->assertSuccessful(200);
+            $response->assertStatus(200);
         }
         for ($i = 5; $i < 10; $i++) {
             $response = $this->getJson('images/' . $posts->random()->id . '?w=500&h=500&fit=crop');
             $response->assertStatus(200);
         }
-        for ($i = 10; $i < 30; $i++) {
+        for ($i = 10; $i < 60; $i++) {
             $response = $this->getJson('images/' . $posts->random()->id . '?w=250&h=400&fit=crop&filt=sepia');
             $response->assertStatus(200);
         }
 
-        // Get a "Too Many Attempts" response when viewing the post a 16th time
+        // Get a "Too Many Attempts" response when viewing the post a 61st time
         $response = $this->getJson('images/' . $posts->random()->id);
         $response->assertStatus(429);
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request removes the `DS_ENABLE_GLIDE` feature flag in 7300122, since we've been using Glide to format images for quite a long time now without issues! I also did some cleanup & refactoring while I was in some of these files. Notably:

📝 No longer create `edited_XXXX.jpg` images when creating posts, since they're only used when Glide is disabled. This should significantly speed up the `POST v3/posts` endpoint. adba0e8

🆙 Increases the rate limit (from 30/min. to 60/min.) for `GET /images/{id}`. This should reduce the number of alarms we get when folks in the office (or elsewhere) are digging deep into older campaign galleries, while still shielding us from abusive behavior. 5f1a68e

🔗 Removes code that handled Data-URL uploads, since that's not a thing that we allow in the v3 API. This lets us remove a lot of relatively confusing code! 185311f

#### How should this be reviewed?
I'd recommend reviewing this commit-by-commit.

#### Any background context you want to provide?
Our locals & CI environments aren't using S3, so I'll do an extra round of testing on QA.

#### Relevant tickets
This is some pre-work to [#165980718](https://www.pivotaltracker.com/story/show/165980718).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
