### PR TITLE
Use short hashes for image URLs.

### DIFF
--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -45,8 +45,10 @@ class ImagesController extends Controller
      * @param  Request $request
      * @return \Illuminate\Http\Response
      */
-    public function show(Post $post, Request $request)
+    public function show(string $hash, Request $request)
     {
+        $post = Post::fromHash($hash);
+
         $server = ServerFactory::create([
             'response' => new LaravelResponseFactory($request),
             'cache' => new Flysystem(new MemoryAdapter()),

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -181,7 +181,8 @@ class Post extends Model
      *
      * @return string
      */
-    public function getHashAttribute() {
+    public function getHashAttribute()
+    {
         return app(Hashids::class)->encode($this->id);
     }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Models;
 
+use Hashids\Hashids;
 use Rogue\Services\GraphQL;
 use Rogue\Events\PostTagged;
 use Illuminate\Support\Facades\Cache;
@@ -62,6 +63,23 @@ class Post extends Model
      * @var array
      */
     public $goodTags = ['good-for-storytelling', 'good-submission', 'good-for-sponsor', 'good-quote', 'good-for-brand'];
+
+    /**
+     * Get a post by its unique hash.
+     *
+     * @param string $hash
+     * @return Post
+     */
+    public static function fromHash($hash)
+    {
+        $result = app(Hashids::class)->decode($hash);
+
+        if (empty($result)) {
+            return null;
+        }
+
+        return self::findOrFail($result[0]);
+    }
 
     /**
      * Each post has events.
@@ -159,6 +177,15 @@ class Post extends Model
     }
 
     /**
+     * Create a hard-to-guess "hash" ID.
+     *
+     * @return string
+     */
+    public function getHashAttribute() {
+        return app(Hashids::class)->encode($this->id);
+    }
+
+    /**
      * Get the URL for the media for this post.
      */
     public function getMediaUrl()
@@ -167,7 +194,7 @@ class Post extends Model
             return null;
         }
 
-        return url('images/' . $this->id);
+        return url('images/' . $this->hash);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Providers;
 
+use Hashids\Hashids;
 use Rogue\Auth\CustomGate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
@@ -22,6 +23,10 @@ class AppServiceProvider extends ServiceProvider
             return new CustomGate($app, function () use ($app) {
                 return call_user_func($app['auth']->userResolver());
             });
+        });
+
+        $this->app->singleton(Hashids::class, function ($app) {
+            return new Hashids(config('app.key'), 10);
         });
 
         // Register global view composer.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "ext-newrelic": "*",
     "sokil/php-isocodes": "^3.0",
     "myclabs/php-enum": "^1.7",
-    "softonic/graphql-client": "^1.2"
+    "softonic/graphql-client": "^1.2",
+    "hashids/hashids": "^4.0"
   },
   "require-dev": {
     "filp/whoops": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08921dd48849e6cf5625f005b496da34",
+    "content-hash": "27d913d606fef5b7c23bf74126ffb0e5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1414,6 +1414,73 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "hashids/hashids",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vinkla/hashids.git",
+                "reference": "43bb2407f16a631f0128f47bcb67ff986c63dde2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vinkla/hashids/zipball/43bb2407f16a631f0128f47bcb67ff986c63dde2",
+                "reference": "43bb2407f16a631f0128f47bcb67ff986c63dde2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Required to use BC Math arbitrary precision mathematics (*).",
+                "ext-gmp": "Required to use GNU multiple precision mathematics (*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hashids\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Akimov",
+                    "email": "ivan@barreleye.com",
+                    "homepage": "https://twitter.com/IvanAkimov"
+                },
+                {
+                    "name": "Vincent Klaiber",
+                    "email": "hello@doubledip.se",
+                    "homepage": "https://doubledip.se"
+                }
+            ],
+            "description": "Generate short, unique, non-sequential ids (like YouTube and Bitly) from numbers",
+            "homepage": "http://hashids.org/php",
+            "keywords": [
+                "bitly",
+                "decode",
+                "encode",
+                "hash",
+                "hashid",
+                "hashids",
+                "ids",
+                "obfuscate",
+                "youtube"
+            ],
+            "time": "2019-04-03T13:40:29+00:00"
         },
         {
             "name": "intervention/image",

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,7 +10,7 @@
  */
 
 // Assets
-$router->get('images/{post}', 'Web\ImagesController@show');
+$router->get('images/{hash}', 'Web\ImagesController@show');
 
 // v3 routes
 $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function () {

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -19,15 +19,15 @@ class ImagesTest extends TestCase
 
         // View the post 60 times (using 3 different versions)
         for ($i = 0; $i < 5; $i++) {
-            $response = $this->getJson('images/' . $posts->random()->id)->assertSuccessful(200);
+            $response = $this->getJson('images/' . $posts->random()->hash)->assertSuccessful(200);
             $response->assertStatus(200);
         }
         for ($i = 5; $i < 10; $i++) {
-            $response = $this->getJson('images/' . $posts->random()->id . '?w=500&h=500&fit=crop');
+            $response = $this->getJson('images/' . $posts->random()->hash . '?w=500&h=500&fit=crop');
             $response->assertStatus(200);
         }
         for ($i = 10; $i < 60; $i++) {
-            $response = $this->getJson('images/' . $posts->random()->id . '?w=250&h=400&fit=crop&filt=sepia');
+            $response = $this->getJson('images/' . $posts->random()->hash . '?w=250&h=400&fit=crop&filt=sepia');
             $response->assertStatus(200);
         }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request updates our `images/{post}` endpoint to use a deterministic (but hard to guess) hash based on the post's ID, using [`hashids`](https://hashids.org/php/). This prevents a curious user from looking at unapproved post's images (while still letting us cache those in Fastly).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
We can't simply apply authorization logic to the `images/{post}` endpoint (like we do for originals in #918) because we want to cache these generated Glide responses in Fastly (and so most requests won't ever hit our servers). That means we want the image to be public but not easily enumerable.

Users are only able to view `posts/{id}` once a post has been approved (or if it's theirs), and so they would not be able to guess the URL for `images/{hash}` until then. This allows admins and users themselves to see unapproved posts without letting anyone else find them until they're in the gallery.

This should be a safe change since we only reference these images based on the post's `url` (rather than trying to create the URLs by hand). However, I'll be sure to give a heads up in #deploys before pushing this up to production. 💬

#### Relevant tickets
[#169188892](https://www.pivotaltracker.com/story/show/169188892)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
