### PR TITLE
Install 'bcmath' extension to support #920.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "dfurnes/environmentalist": "0.0.2",
     "ext-gd": "*",
     "ext-exif": "*",
+    "ext-bcmath": "*",
     "barryvdh/laravel-cors": "^0.11.2",
     "fzaninotto/faker": "^1.6",
     "ext-newrelic": "*",


### PR DESCRIPTION
#### What's this PR do?
The [BCMath](https://www.php.net/manual/en/book.bc.php) extension, which includes fancy math tools, isn't [included by default on Heroku](https://devcenter.heroku.com/articles/php-support#extensions) and so we need to add that dependency to our `composer.json`. This didn't show up on Homestead or Wercker since both of those have that extension included.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
From [our Heroku logs](https://my.papertrailapp.com/systems/dosomething-rogue-dev/events?focus=1121548484760842243&selected=1121548484760842243) for `dosomething-rogue-dev`:

```
Oct 17 14:00:18 dosomething-rogue-dev app/web.1 [17-Oct-2019 18:00:18 UTC] [2019-10-17 18:00:18] development.ERROR: Missing BC Math or GMP extension. {"exception":"[object] (RuntimeException(code: 0): Missing BC Math or GMP extension. at /app/vendor/hashids/hashids/src/Hashids.php:415)"} {"user_id":null,"client_id":null,"request_id":"dfe93001-182f-42ac-a0a9-a64aff71d291"} 
```

#### Relevant tickets
See [this Slack thread](https://dosomething.slack.com/archives/C02BBP0CU/p1571335390012300).

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
