### PR TITLE
Add `filter[is_open]` to Campaigns API.

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -33,6 +33,18 @@ class CampaignsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Campaign::$indexes);
 
+        // Apply scope for the "computed" is_open field:
+        if (isset($filters['is_open'])) {
+            // We can use this to find only open campaigns with a truthy filter
+            // applied, e.g. `?filter[is_open]=true`, or closed campaigns with
+            // a falsy filter, e.g. `?filter[is_open]=false`.
+            if (filter_var($filters['is_open'], FILTER_VALIDATE_BOOLEAN)) {
+                $query->whereOpen();
+            } else {
+                $query->whereClosed();
+            }
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -4,6 +4,7 @@ namespace Rogue\Models;
 
 use Rogue\Types\Cause;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Campaign extends Model
@@ -56,6 +57,34 @@ class Campaign extends Model
     public function posts()
     {
         return $this->hasMany(Post::class);
+    }
+
+    /**
+     * Scope a query to only include "open" campaigns.
+     */
+    public function scopeWhereOpen($query)
+    {
+        $today = now()->format('Y-m-d');
+
+        return $query->whereDate('start_date', '<=', $today)
+            ->where(function (Builder $query) use ($today) {
+                $query->whereNull('end_date')
+                    ->orWhereDate('end_date', '>', $today);
+            });
+    }
+
+    /**
+     * Scope a query to only include "closed" campaigns.
+     */
+    public function scopeWhereClosed($query)
+    {
+        $today = now()->format('Y-m-d');
+
+        return $query->whereDate('start_date', '>', $today)
+            ->orWhere(function (Builder $query) use ($today) {
+                $query->whereNotNull('end_date')
+                    ->whereDate('end_date', '<', $today);
+            });
     }
 
     /**

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -148,10 +148,10 @@ $factory->define(Campaign::class, function (Generator $faker) {
     ];
 });
 
-$factory->defineAs(Campaign::class, 'closed', function () use ($factory) {
+$factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($factory) {
     return array_merge($factory->raw(Campaign::class), [
         'start_date' => $faker->dateTimeBetween('-12 months', '-6 months'),
-        'end_date' => $faker->dateTimeBetween('-3 months', 'now'),
+        'end_date' => $faker->dateTimeBetween('-3 months', 'yesterday'),
     ]);
 });
 

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -11,8 +11,8 @@ GET /api/v3/campaigns
 ### Optional Query Parameters
 
 - **filter[column]** _(string)_
-  - Filter results by the given column: `id`
-  - You can filter by more than one value for a column, e.g. `/campaigns?filter[id]=121,122`
+  - Filter results by the given column: `id`, `is_open`
+  - You can filter by more than one value for the ID column, e.g. `/campaigns?filter[id]=121,122`
 
 Example Response:
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -63,6 +63,26 @@ class CampaignTest extends Testcase
     }
 
     /**
+     * Test that we can filter open or closed campaigns.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testFilteredCampaignIndex()
+    {
+        factory(Campaign::class, 5)->create();
+        factory(Campaign::class, 'closed', 3)->create();
+
+        $response = $this->getJson('api/v3/campaigns?filter[is_open]=true');
+        $decodedResponse = $response->decodeResponseJson();
+        $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson('api/v3/campaigns?filter[is_open]=false');
+        $decodedResponse = $response->decodeResponseJson();
+        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+    }
+
+    /**
      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
      *
      * GET /api/v3/campaigns/:campaign_id


### PR DESCRIPTION
#### What's this PR do?
This pull request allows us to filter the `v3/campaigns` API via the computed `is_open` field, using new `whereOpen` and `whereClosed` query scopes. This will allow us to group open vs. closed campaigns on the "campaign overview" page without loading all 700+ campaigns in-memory.

Here's how this would look via the REST API:

```
https://activity.dosomething.org/api/v3/campaigns?filter[is_open]=true
```

#### How should this be reviewed?
🚥 👀

#### Any background context you want to provide?
📂

#### Relevant tickets
[#169233808](https://www.pivotaltracker.com/story/show/169233808)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
