### PR TITLE
Fix Slack notification bugs & add some missing information.

### DIFF
--- a/app/Events/PostTagged.php
+++ b/app/Events/PostTagged.php
@@ -25,6 +25,13 @@ class PostTagged
      */
     public $tag;
 
+    /*
+     * The user ID who tagged this post.
+     *
+     * @var string
+     */
+    public $adminId;
+
     /**
      * Create a new event instance.
      *
@@ -34,5 +41,6 @@ class PostTagged
     {
         $this->post = $post;
         $this->tag = $tag;
+        $this->adminId = auth()->id();
     }
 }

--- a/app/Events/PostTagged.php
+++ b/app/Events/PostTagged.php
@@ -26,21 +26,13 @@ class PostTagged
     public $tag;
 
     /**
-     * Whether or not to log that this Signup was sent to Quasar.
-     *
-     * @var bool
-     */
-    public $log;
-
-    /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(Post $post, Tag $tag, $log)
+    public function __construct(Post $post, Tag $tag)
     {
         $this->post = $post;
         $this->tag = $tag;
-        $this->log = $log;
     }
 }

--- a/app/Listeners/SendTaggedNotification.php
+++ b/app/Listeners/SendTaggedNotification.php
@@ -28,6 +28,7 @@ class SendTaggedNotification
     {
         $post = $event->post;
         $tag = $event->tag;
+        $adminId = $event->adminId;
 
         info('post_tagged', ['id' => $post->id, 'tag' => $tag->tag_slug]);
 

--- a/app/Listeners/SendTaggedNotification.php
+++ b/app/Listeners/SendTaggedNotification.php
@@ -34,7 +34,7 @@ class SendTaggedNotification
 
         if (! ($post->hasGoodTag()) && in_array($tag->tag_slug, $post->goodTags)) {
             Notification::route('slack', config('services.slack.url'))
-                ->notify(new SlackTagNotification($post));
+                ->notify(new SlackTagNotification($post, $tag, $adminId));
         }
     }
 }

--- a/app/Listeners/SendTaggedNotification.php
+++ b/app/Listeners/SendTaggedNotification.php
@@ -29,12 +29,7 @@ class SendTaggedNotification
         $post = $event->post;
         $tag = $event->tag;
 
-        if ($event->log) {
-            info('post_tagged', [
-                'id' => $post->id,
-                'tag' => $tag->tag_slug,
-            ]);
-        }
+        info('post_tagged', ['id' => $post->id, 'tag' => $tag->tag_slug]);
 
         if (! ($post->hasGoodTag()) && in_array($tag->tag_slug, $post->goodTags)) {
             Notification::route('slack', config('services.slack.url'))

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -82,6 +82,14 @@ class Post extends Model
     }
 
     /**
+     * Each post belongs to an action.
+     */
+    public function campaign()
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+
+    /**
      * Each post has events.
      */
     public function events()

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -365,9 +365,8 @@ class Post extends Model
     /**
      * Apply the given tag to this post.
      * @param $tag Tag to tag post with
-     * @param $log Whether or not to log when a post is tagged.
      */
-    public function tag($tag, $log = true)
+    public function tag($tag)
     {
         // If a tag slug is sent in, change to the tag name.
         if (strpos($tag, '-')) {
@@ -388,7 +387,7 @@ class Post extends Model
             // Update timestamps on the Post when adding a tag
             $this->touch();
 
-            event(new PostTagged($this, $tag, $log));
+            event(new PostTagged($this, $tag));
         }
 
         return $this;

--- a/app/Notifications/SlackTagNotification.php
+++ b/app/Notifications/SlackTagNotification.php
@@ -2,10 +2,23 @@
 
 namespace Rogue\Notifications;
 
+use Rogue\Models\Tag;
 use Rogue\Models\Post;
+use Rogue\Services\GraphQL;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
+
+const SLACK_NOTIFICATION_QUERY = '
+    query SlackNotificationQuery($userId: String!, $adminId: String!) {
+        user(id: $userId) {
+            displayName
+        }
+        admin: user(id: $adminId) {
+            displayName
+        }
+    }
+';
 
 class SlackTagNotification extends Notification
 {
@@ -18,14 +31,30 @@ class SlackTagNotification extends Notification
      */
     public $post;
 
+    /*
+     * Tag Instance
+     *
+     * @var Rogue\Models\Tag;
+     */
+    public $tag;
+
+    /*
+     * The admin who tagged this post.
+     *
+     * @var string;
+     */
+    public $adminId;
+
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct(Post $post)
+    public function __construct(Post $post, Tag $tag, string $adminId)
     {
         $this->post = $post;
+        $this->tag = $tag;
+        $this->adminId = $adminId;
     }
 
     /**
@@ -51,11 +80,22 @@ class SlackTagNotification extends Notification
             return;
         }
 
+        // Get the user & reviewer's names for the notification:
+        $data = app(GraphQL::class)->query(SLACK_NOTIFICATION_QUERY, [
+            'userId' => $this->post->northstar_id,
+            'adminId' => $this->adminId
+        ]);
+
+        $userName = $data['user']['displayName'];
+        $adminName = $data['admin']['displayName'];
+
         return (new SlackMessage)
             ->from('Rogue', ':tonguecat:')
-            ->content('Another badass member submitted a post!')
-            ->attachment(function ($attachment) {
-                $attachment->title('Click here for more details in Rogue! We\'ll be adding member info. in Slack soon.', route('signups.show', [$this->post->signup_id], true))
+            ->content($adminName . ' just tagged this post as "' . $this->tag->tag_name . '":')
+            ->attachment(function ($attachment) use ($userName, $adminName) {
+                $permalink = route('signups.show', [$this->post->signup_id], true);
+
+                $attachment->title($userName . '\'s submission for "' . $this->post->campaign->internal_title . '"', $permalink)
                         ->fields([
                             'Caption' => str_limit($this->post->text, 140),
                             'Why Participated' => str_limit($this->post->signup->why_participated),

--- a/app/Notifications/SlackTagNotification.php
+++ b/app/Notifications/SlackTagNotification.php
@@ -57,7 +57,7 @@ class SlackTagNotification extends Notification
             ->attachment(function ($attachment) {
                 $attachment->title('Click here for more details in Rogue! We\'ll be adding member info. in Slack soon.', route('signups.show', [$this->post->signup_id], true))
                         ->fields([
-                            'Caption' => str_limit($this->post->caption, 140),
+                            'Caption' => str_limit($this->post->text, 140),
                             'Why Participated' => str_limit($this->post->signup->why_participated),
                         ])
                         ->color(array_random(['#FCD116', '#23b7fb', '#4e2b63']))

--- a/app/Notifications/SlackTagNotification.php
+++ b/app/Notifications/SlackTagNotification.php
@@ -50,7 +50,7 @@ class SlackTagNotification extends Notification
      *
      * @return void
      */
-    public function __construct(Post $post, Tag $tag, string $adminId)
+    public function __construct(Post $post, Tag $tag, $adminId)
     {
         $this->post = $post;
         $this->tag = $tag;
@@ -83,7 +83,7 @@ class SlackTagNotification extends Notification
         // Get the user & reviewer's names for the notification:
         $data = app(GraphQL::class)->query(SLACK_NOTIFICATION_QUERY, [
             'userId' => $this->post->northstar_id,
-            'adminId' => $this->adminId
+            'adminId' => $this->adminId,
         ]);
 
         $userName = $data['user']['displayName'];

--- a/app/Notifications/SlackTagNotification.php
+++ b/app/Notifications/SlackTagNotification.php
@@ -61,7 +61,7 @@ class SlackTagNotification extends Notification
                             'Why Participated' => str_limit($this->post->signup->why_participated),
                         ])
                         ->color(array_random(['#FCD116', '#23b7fb', '#4e2b63']))
-                        ->image($this->post->url);
+                        ->image($this->post->getMediaUrl());
             });
     }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes two issues with the notifications in `#notify-badass-members`: images were no longer showing up after DoSomething/infrastructure#213 removed public access to this app's S3 bucket & captions had not been showing up since we renamed `caption` to `text` [last year](https://github.com/DoSomething/rogue/pull/636). Yikes!

I also took this opportunity to fill in missing information about the user & campaign, since we've claimed we'd be "adding member info. in Slack soon" and it's been, well, a while:

![Screen Shot 2019-10-23 at 2 15 09 PM](https://user-images.githubusercontent.com/583202/67422775-1907eb80-f5a1-11e9-9398-9e01a71e83c6.png)


#### How should this be reviewed?
I'd recommend reviewing commit-by-commit to get the context of each change.

#### Any background context you want to provide?
📸

#### Relevant tickets
[#169324963](https://www.pivotaltracker.com/story/show/169324963)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
