### PR TITLE
Signup import command updates

### DIFF
--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -70,7 +70,7 @@ class ImportSignupsCommand extends Command
                 $signup = Signup::create([
                     'northstar_id' => $missing_signup['northstar_id'],
                     'campaign_id' => $missing_signup['campaign_node_id'],
-                    'source' => 'phoenix-next',
+                    'source' => $missing_signup['source'],
                     'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp'] : Carbon::now(),
                 ]);
 

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -62,14 +62,14 @@ class ImportSignupsCommand extends Command
             // See if the signup exists
             $existing_signup = Signup::where([
                 ['northstar_id', $missing_signup['northstar_id']],
-                ['campaign_id', $missing_signup['campaign_node_id']],
+                ['campaign_id', $missing_signup['campaign_id']],
             ])->first();
 
             // Create a signup if there isn't one already
             if (! $existing_signup) {
                 $signup = Signup::create([
                     'northstar_id' => $missing_signup['northstar_id'],
-                    'campaign_id' => $missing_signup['campaign_node_id'],
+                    'campaign_id' => $missing_signup['campaign_id'],
                     'source' => $missing_signup['source'],
                     'created_at' => $missing_signup['signup_created_at_timestamp'] ? $missing_signup['signup_created_at_timestamp'] : Carbon::now(),
                 ]);

--- a/tests/Console/ImportSignupsCommandTest.php
+++ b/tests/Console/ImportSignupsCommandTest.php
@@ -20,7 +20,7 @@ class ImportSignupsCommandTest extends TestCase
         $this->assertDatabaseHas('signups', [
             'northstar_id' => '56e83a07469c64d8578b5ed4',
             'campaign_id' => '362',
-            'source' => 'phoenix-next',
+            'source' => 'sms',
             'created_at' => '2014-03-13 21:39:01',
         ]);
 

--- a/tests/Console/example-signups.csv
+++ b/tests/Console/example-signups.csv
@@ -1,4 +1,4 @@
-"drupal_id","campaign_run_id","campaign_node_id","signup_source","signup_created_at_timestamp","northstar_id"
-10,2341,362,"sms","2014-03-13 21:39:01","56e83a07469c64d8578b5ed4"
-10,2341,362,"sms","2014-03-13 21:39:01","56e83a07469c64d8578b5ed4"
-3526,5066,1144,"sms","2013-11-06 23:32:03","5589c9bb469c6475138b81f0"
+"campaign_id","source","signup_created_at_timestamp","northstar_id"
+362,"sms","2014-03-13 21:39:01","56e83a07469c64d8578b5ed4"
+362,"sms","2014-03-13 21:39:01","56e83a07469c64d8578b5ed4"
+1144,"phoenix-next","2013-11-06 23:32:03","5589c9bb469c6475138b81f0"


### PR DESCRIPTION
#### What's this PR do?
- Change column header from `campaign_node_id` to `campaign_id` because `campaign_node_id` is a thing of the distant past now!
- Don't hardcode the source as `phoenix-next`, but instead allow the signup's `source` to be set by the `source` column of the csv
- Update the test cases so that now one of them uses source `phoenix-next` and one of them uses source `sms` so we can be sure the sources are updating properly
- Wipe out some old data/columns that are not used anymore from the csv file used for the unit tests

#### How should this be reviewed?
Do the unit tests updates test the right things? Will this allow us to import signups and set user, campaign, source, and created_at?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/169095237)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
