### PR TITLE
Add `cursor` and experimental `?after=` query param to Campaigns API.

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -46,7 +46,8 @@ class CampaignsController extends ApiController
         }
 
         // Attach counts for total posts & pending posts:
-        $includePendingCount = str_contains($request->query('include'), 'pending_count');
+        $includePendingCount = str_contains($request->query('include'), 'pending_count')
+            || str_contains($request->query('orderBy'), 'pending_count');
         if ($includePendingCount && is_staff_user()) {
             $query->withPendingPostCount();
         }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -51,6 +51,14 @@ class CampaignsController extends ApiController
             $query->withPendingPostCount();
         }
 
+        // Experimental: Allow paginating by cursor (e.g. `?after=OTAxNg==`):
+        if ($after = $request->query('after')) {
+            $query->where('id', '>', base64_decode($after));
+
+            // Using 'after' implies cursor pagination:
+            $this->useCursorPagination = true;
+        }
+
         // Allow ordering results:
         $orderBy = $request->query('orderBy');
         $query = $this->orderBy($query, $orderBy, ['id', 'pending_count']);

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -83,6 +83,11 @@ trait FiltersRequests
             if (in_array($column, $indexes)) {
                 $query = $query->orderBy($column, $direction);
             }
+        } else {
+            // If we don't specify an ordering in the query, we should default
+            // to order by ID. (Fun fact: MySQL makes no guarantees of ordering
+            // if we don't include this in the query!)
+            $query->orderBy('id', 'asc');
         }
 
         return $query;

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -107,16 +107,17 @@ trait TransformsRequests
             $transformer = $this->transformer;
         }
 
-        $pages = (int) $request->query('limit', 20);
+        // You can request up to 100 items per page (default 20).
+        $pages = min((int) $request->query('limit', 20), 100);
 
         // Is cursor pagination enabled for this route? (Or opted-in using
         // the `?pagination=cursor` query param?)
         $fastMode = ! empty($this->useCursorPagination) || $request->query('pagination') === 'cursor';
 
         if ($fastMode) {
-            $paginator = $query->simplePaginate(min($pages, 100));
+            $paginator = $query->simplePaginate($pages);
         } else {
-            $paginator = $query->paginate(min($pages, 100));
+            $paginator = $query->paginate($pages);
         }
 
         $queryParams = array_diff_key($request->query(), array_flip(['page']));

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -27,6 +27,7 @@ class CampaignTransformer extends TransformerAbstract
             'cause_names' => $campaign->getCauseNames(),
             'created_at' => $campaign->created_at->toIso8601String(),
             'updated_at' => $campaign->updated_at->toIso8601String(),
+            'cursor' => base64_encode($campaign->id),
         ];
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request adds some API support for DoSomething/graphql#142:

👇 Adds a `cursor` field to the campaign transformer, which is just the Base-64 encoded ID of the campaign. This is suggested in GraphQL's documentation, and makes sense to me:

> Using cursors for pagination gives additional flexibility if the pagination model changes in the future. As a reminder that the cursors are opaque and that their format should not be relied upon, we suggest base64 encoding them.

↪️ Adds an experimental `?after=` query parameter to `/api/v3/campaigns`, which accepts the cursor that we generate in the transformer. This allows us to say "get me all the items after this one" and sidestep some bugs we could encounter with traditional `?page=#` pagination.



#### How should this be reviewed?
tell us, how can we review, to test that this works

#### Any background context you want to provide?
what else?

#### Relevant tickets
Fixes #

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
