### PR TITLE
Fixes an issue with cursor pagination & sorted results.

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,10 +1,14 @@
 preset: laravel
 
+enabled:
+  - length_ordered_imports
+
 disabled:
- - concat_without_spaces
- - no_useless_return
- - simplified_null_return
- - phpdoc_no_package
- - phpdoc_summary
- - phpdoc_var_without_name
- - phpdoc_to_comment
+  - concat_without_spaces
+  - no_useless_return
+  - simplified_null_return
+  - phpdoc_no_package
+  - phpdoc_summary
+  - phpdoc_var_without_name
+  - phpdoc_to_comment
+  - alpha_ordered_imports

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -53,8 +53,8 @@ class CampaignsController extends ApiController
         }
 
         // Experimental: Allow paginating by cursor (e.g. `?after=OTAxNg==`):
-        if ($after = $request->query('after')) {
-            $query->where('id', '>', base64_decode($after));
+        if ($cursor = $request->query('after')) {
+            $query->whereAfterCursor($cursor);
 
             // Using 'after' implies cursor pagination:
             $this->useCursorPagination = true;

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -52,11 +52,11 @@ class CampaignsController extends ApiController
             $query->withPendingPostCount();
         }
 
-        // Experimental: Allow paginating by cursor (e.g. `?after=OTAxNg==`):
-        if ($cursor = $request->query('after')) {
+        // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):
+        if ($cursor = array_get($request->query('cursor'), 'after')) {
             $query->whereAfterCursor($cursor);
 
-            // Using 'after' implies cursor pagination:
+            // Using 'cursor' implies cursor pagination:
             $this->useCursorPagination = true;
         }
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -62,7 +62,7 @@ class CampaignsController extends ApiController
 
         // Allow ordering results:
         $orderBy = $request->query('orderBy');
-        $query = $this->orderBy($query, $orderBy, ['id', 'pending_count']);
+        $query = $this->orderBy($query, $orderBy, Campaign::$sortable);
 
         return $this->paginatedCollection($query, $request);
     }

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -82,6 +82,12 @@ trait FiltersRequests
 
             if (in_array($column, $indexes)) {
                 $query = $query->orderBy($column, $direction);
+
+                // If we have multiple items with the same '$column' value,
+                // use ID as a secondary sort column to ensure stable sort.
+                if ($column != 'id') {
+                    $query->orderBy('id', 'asc');
+                }
             }
         } else {
             // If we don't specify an ordering in the query, we should default

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -27,7 +27,7 @@ class CampaignTransformer extends TransformerAbstract
             'cause_names' => $campaign->getCauseNames(),
             'created_at' => $campaign->created_at->toIso8601String(),
             'updated_at' => $campaign->updated_at->toIso8601String(),
-            'cursor' => base64_encode($campaign->id),
+            'cursor' => $campaign->getCursor(),
         ];
     }
 }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -217,7 +217,20 @@ class Campaign extends Model
      */
     public function getCursor()
     {
-        return base64_encode($this->id);
+        $sortCursor = '';
+
+        // If we're ordering results, we need to include that column's
+        // value in the cursor (so we can say "get me things after this"):
+        if ($orderBy = request()->query('orderBy')) {
+            [ $column, $direction ] = explode(',', $orderBy, 2);
+
+            // Check that it's okay to expose this column in the cursor:
+            if (in_array($column, self::$sortable)) {
+                $sortCursor = '.' . $this->{$column};
+            }
+        }
+
+        return base64_encode($this->id . $sortCursor);
     }
 
     /**
@@ -225,6 +238,27 @@ class Campaign extends Model
      */
     public function scopeWhereAfterCursor($query, $cursor)
     {
-        $query->where('id', '>', base64_decode($cursor));
+        $cursor = explode('.', base64_decode($cursor), 2);
+
+        $id = $cursor[0];
+        $sortCursor = isset($cursor[1]) ? $cursor[1] : null;
+
+        $orderBy = request()->query('orderBy');
+        if ($orderBy && $sortCursor) {
+            // If we're sorting by a column, things get a lil' tricky:
+            [ $column, $direction ] = explode(',', $orderBy, 2);
+
+            // Check that we're allowed to sort by this column:
+            if (in_array($column, self::$sortable)) {
+                $query->where($column, '<', $sortCursor)
+                    ->orWhere(function ($query) use ($column, $sortCursor, $id) {
+                        $query->where($column, '<=', $sortCursor)
+                            ->where('id', '>', $id);
+                    });
+            }
+        } else {
+            // Otherwise, treat as a plain ID cursor... easy!
+            $query->where('id', '>', $id);
+        }
     }
 }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -36,6 +36,16 @@ class Campaign extends Model
     public static $indexes = ['id'];
 
     /**
+     * Attributes that can be sorted by.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $sortable = ['id', 'pending_count'];
+
+    /**
      * Get the signups associated with this campaign.
      */
     public function signup()

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -247,12 +247,13 @@ class Campaign extends Model
         if ($orderBy && $sortCursor) {
             // If we're sorting by a column, things get a lil' tricky:
             [ $column, $direction ] = explode(',', $orderBy, 2);
+            $operator = $direction === 'asc' ? '>' : '<';
 
             // Check that we're allowed to sort by this column:
             if (in_array($column, self::$sortable)) {
-                $query->where($column, '<', $sortCursor)
-                    ->orWhere(function ($query) use ($column, $sortCursor, $id) {
-                        $query->where($column, '<=', $sortCursor)
+                $query->where($column, $operator, $sortCursor)
+                    ->orWhere(function ($query) use ($column, $operator, $sortCursor, $id) {
+                        $query->where($column, $operator.'=', $sortCursor)
                             ->where('id', '>', $id);
                     });
             }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -199,4 +199,22 @@ class Campaign extends Model
 
         $this->attributes[$attribute] = $this->fromDateTime($value);
     }
+
+    /**
+     * Create a cursor for this item.
+     *
+     * @return string
+     */
+    public function getCursor()
+    {
+        return base64_encode($this->id);
+    }
+
+    /**
+     * Scope a query to only include items after the given cursor.
+     */
+    public function scopeWhereAfterCursor($query, $cursor)
+    {
+        $query->where('id', '>', base64_decode($cursor));
+    }
 }

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -103,7 +103,7 @@ class CampaignTest extends Testcase
 
         // Then, we'll use the last post's cursor to fetch the remaining two:
         $lastCursor = $json['data'][2]['cursor'];
-        $response = $this->withAdminAccessToken()->getJson($endpoint . '&after=' . $lastCursor);
+        $response = $this->withAdminAccessToken()->getJson($endpoint . '&cursor[after]=' . $lastCursor);
 
         $response->assertSuccessful();
         $json = $response->json();
@@ -136,7 +136,7 @@ class CampaignTest extends Testcase
 
         // Then, we'll use the last post's cursor to fetch the remaining two:
         $lastCursor = $response->json()['data'][2]['cursor'];
-        $response = $this->withAdminAccessToken()->getJson($endpoint . '&after=' . $lastCursor);
+        $response = $this->withAdminAccessToken()->getJson($endpoint . '&cursor[after]=' . $lastCursor);
         $data = $response->json()['data'];
 
         $this->assertArraySubset(['id' => $two->id, 'pending_count' => 2], $data[0]);

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -83,6 +83,33 @@ class CampaignTest extends Testcase
     }
 
     /**
+     * Test that we can use cursor pagination.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testCampaignCursor()
+    {
+        $campaigns = factory(Campaign::class, 5)->create();
+
+        // First, let's get the three campaigns with the most pending posts:
+        $endpoint = 'api/v3/campaigns?limit=3';
+        $response = $this->withAdminAccessToken()->getJson($endpoint);
+
+        $response->assertSuccessful();
+        $json = $response->json();
+        $this->assertCount(3, $json['data']);
+
+        // Then, we'll use the last post's cursor to fetch the remaining two:
+        $lastCursor = $json['data'][2]['cursor'];
+        $response = $this->withAdminAccessToken()->getJson($endpoint . '&after=' . $lastCursor);
+
+        $response->assertSuccessful();
+        $json = $response->json();
+        $this->assertCount(2, $json['data']);
+    }
+
+    /**
      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
      *
      * GET /api/v3/campaigns/:campaign_id

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Http;
 
 use Tests\TestCase;
+use Rogue\Models\Post;
 use Rogue\Models\Campaign;
 
 class CampaignTest extends Testcase
@@ -110,6 +111,39 @@ class CampaignTest extends Testcase
     }
 
     /**
+     * Test that we can use cursor pagination with ordered results.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testCampaignCursorWithOrderBy()
+    {
+        // Create campaigns with varied number of 'pending' posts:
+        $one = $this->createCampaignWithPosts(1);
+        $two = $this->createCampaignWithPosts(2);
+        $three = $this->createCampaignWithPosts(3);
+        $four = $this->createCampaignWithPosts(4);
+        $five = $this->createCampaignWithPosts(5);
+
+        // First, let's get the three campaigns with the most pending posts:
+        $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
+        $response = $this->withAdminAccessToken()->getJson($endpoint);
+        $data = $response->json()['data'];
+
+        $this->assertArraySubset(['id' => $five->id, 'pending_count' => 5], $data[0]);
+        $this->assertArraySubset(['id' => $four->id, 'pending_count' => 4], $data[1]);
+        $this->assertArraySubset(['id' => $three->id, 'pending_count' => 3], $data[2]);
+
+        // Then, we'll use the last post's cursor to fetch the remaining two:
+        $lastCursor = $response->json()['data'][2]['cursor'];
+        $response = $this->withAdminAccessToken()->getJson($endpoint . '&after=' . $lastCursor);
+        $data = $response->json()['data'];
+
+        $this->assertArraySubset(['id' => $two->id, 'pending_count' => 2], $data[0]);
+        $this->assertArraySubset(['id' => $one->id, 'pending_count' => 1], $data[1]);
+    }
+
+    /**
      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
      *
      * GET /api/v3/campaigns/:campaign_id
@@ -182,5 +216,20 @@ class CampaignTest extends Testcase
 
         $response->assertStatus(404);
         $this->assertEquals('That resource could not be found.', $decodedResponse['message']);
+    }
+
+    /**
+     * Create a campaign with the given number of pending posts.
+     *
+     * @return Campaign
+     */
+    public function createCampaignWithPosts($numberOfPosts)
+    {
+        $campaign = factory(Campaign::class)->create();
+        factory(Post::class, $numberOfPosts)->create([
+            'campaign_id' => $campaign->id,
+        ]);
+
+        return $campaign;
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes an issue with cursor pagination (introduced in #930). That implementation didn't take into account results that have `orderBy` (and so the ID alone wouldn't get us the proper position in the sorted results).

#### How should this be reviewed?
I did some refactoring in 9313d2f, 01059be, and 9af53c4. I added a passing test for `?after=` with a standard non-sorted response in 582b69e and a failing test in 04231d5. Finally, I fixed the issue with using `after` & `orderBy` together in c8749e7.

Finally, I renamed `after` to `cursor[after]` for clarity in 5792139.

#### Any background context you want to provide?
This [Shopify Engineering blog post](https://engineering.shopify.com/blogs/engineering/pagination-relative-cursors) includes a good explanation & visualization of this issue under the "Sorting and Skipping Records" heading. (Cursor pagination is also used by Facebook, [GitHub](https://developer.github.com/v4/object/repository/), and [Slack](https://slack.engineering/evolving-api-pagination-at-slack-1c1f644f8e12)).

#### Relevant tickets
[#169352891](https://www.pivotaltracker.com/story/show/169352891)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
