### PR TITLE
Support using machine-name to tag/untag a post.

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -51,11 +51,18 @@ class TagsController extends ApiController
             'tag_name' => 'required|string',
         ]);
 
+        // If a tag slug is sent in, change to the tag name.
+        // @TODO: This controller/model should really deal in slugs...
+        $tag = $request->tag_name;
+        if (str_contains($tag, '-')) {
+            $tag = ucwords(str_replace('-', ' ', $tag));
+        }
+
         // If the post already has the tag, remove it. Otherwise, add the tag to the post.
-        if ($post->tagNames()->contains($request->tag_name)) {
-            $updatedPost = $this->post->untag($post, $request->tag_name);
+        if ($post->tagNames()->contains($tag)) {
+            $updatedPost = $this->post->untag($post, $tag);
         } else {
-            $updatedPost = $this->post->tag($post, $request->tag_name);
+            $updatedPost = $this->post->tag($post, $tag);
         }
 
         return $this->item($updatedPost);


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for sending the machine-name for a tag (e.g. `good-photo` instead of `Good Photo`) to the `api/v3/post/{id}/tags` endpoint.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I think it's worth spending a little time to clean up this endpoint in the future:
- It should deal in machine-friendly identifiers (in this case, the "slugs"), rather than human-friendly formatted labels (that could change in the future).
- It probably doesn't make sense to store the human-friendly names for every single tag (since it takes up unnecessary space & makes it harder to change the tag's human-friendly name later).
- It should validate input! We should have a list of allowed tags (like we do for causes, etc).

#### Relevant tickets
[#169512736](https://www.pivotaltracker.com/story/show/169512736)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
