### PR TITLE
Fix issues with rotation API.

### DIFF
--- a/app/Http/Controllers/RotationController.php
+++ b/app/Http/Controllers/RotationController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rogue\Http\Controllers;
+
+use Storage;
+use Rogue\Models\Post;
+use Rogue\Services\Fastly;
+use Illuminate\Http\Request;
+use Rogue\Services\ImageStorage;
+use Rogue\Http\Transformers\PostTransformer;
+
+class RotationController extends Controller
+{
+    /**
+     * The Fastly API.
+     *
+     * @var Fastly
+     */
+    protected $fastly;
+
+    /**
+     * The image storage backend.
+     *
+     * @var ImageStorage
+     */
+    protected $storage;
+
+    /**
+     * @var PostTransformer;
+     */
+    protected $transformer;
+
+    /**
+     * Create a controller instance.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Fastly $fastly, ImageStorage $storage, PostTransformer $transformer)
+    {
+        $this->fastly = $fastly;
+        $this->storage = $storage;
+        $this->transformer = $transformer;
+
+        $this->middleware('auth', ['only' => 'update']);
+        $this->middleware('role:staff,admin', ['only' => 'update']);
+    }
+
+    /**
+     * Edits and overwrites an image based on given request parameters.
+     *
+     * @param  Post $post
+     * @param  Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Post $post, Request $request)
+    {
+        $validatedInput = $this->validate($request, [
+            'degrees' => 'required|int',
+        ]);
+
+        $image = $this->storage->get($post);
+
+        // We use clockwise degrees, but Intervention rotates images
+        // counter-clockwise <http://image.intervention.io/api/rotate>
+        $rotatedImage = $image->rotate(-1 * $validatedInput['degrees']);
+
+        // Overwrite with edited image & purge cache:
+        $this->storage->edit($post, $rotatedImage);
+        $this->fastly->purge($post);
+
+        return $this->item($post);
+    }
+}

--- a/app/Services/ImageStorage.php
+++ b/app/Services/ImageStorage.php
@@ -6,6 +6,7 @@ use Rogue\Models\Post;
 use Intervention\Image\Image;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\File\File;
+use Intervention\Image\Facades\Image as ImageManager;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
@@ -16,6 +17,19 @@ class ImageStorage
      * @param string
      */
     protected $base = 'uploads/reportback-items/';
+
+    /**
+     * Get image for the given post.
+     *
+     * @param Post $post
+     * @return Image
+     */
+    public function get(Post $post)
+    {
+        $contents = Storage::get($post->getMediaPath());
+
+        return ImageManager::make($contents);
+    }
 
     /**
      * Save a new image for the given signup ID.

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,9 @@ $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function (
     // tag
     $this->post('posts/{post}/tags', 'TagsController@store');
 
+    // images
+    $this->post('posts/{post}/rotate', 'RotationController@update');
+
     // events
     $this->get('events', 'EventsController@index');
 


### PR DESCRIPTION
#### What's this PR do?
This pull request updates our image rotation endpoint to live under the API namespace and require the `staff` or `admin` role (previously anyone could rotate posts). 🔒 I've tested this with the local filesystem driver & S3 driver and both seem to work swimmingly now.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I have not updated Rogue's admin interface to use this new `/api/v3/posts/{id}/rotate` endpoint, since I'm going to be swapping these out to use the new GraphQL powered component very soon.

#### Relevant tickets
[#169346181](https://www.pivotaltracker.com/story/show/169346181)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
