### PR TITLE
Fix issue where rotated images would still load from cache.

### DIFF
--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -57,6 +57,11 @@ class ImagesController extends Controller
         ]);
 
         $response = $server->getImageResponse($post->getMediaPath(), $request->all());
+
+        // We want these to be cached in Fastly, but not in the user's browser, so we'll
+        // override 'Cache-Control' to use 's-max-age'. We can then use the 'Surrogate-Key'
+        // header to clear Fastly's cache if an image is rotated/deleted:
+        $response->headers->set('Cache-Control', 's-max-age=31536000, public');
         $response->headers->set('Surrogate-Key', 'post-'.$post->id);
 
         return $response;


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes an issue where Glide images would be cached in user's browsers indefinitely and so edits wouldn't appear without clearing cache or force-reloading the page.

This was happening because Glide uses `Cache-Control: max-age=31536000, public` by default, which tells Fastly _and_ everything else, like the user's browser, to cache that resource for up to a year. Instead, we should use `s-max-age` to tell Fastly to cache the resource without also telling browsers to do the same.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Here's [some documentation](https://docs.fastly.com/en/guides/cache-control-tutorial) from Fastly explaining how each of these headers can be used. We could have used `Surrogate-Control` instead of `s-max-age`, but then we'd have to also wipe the existing `Cache-Control` header.

#### Relevant tickets
Fixes #

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
