### PR TITLE
Add "individual post" permalink (powered by GraphQL).

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -51,10 +51,10 @@ class TagsController extends ApiController
             'tag_name' => 'required|string',
         ]);
 
-        // If a tag slug is sent in, change to the tag name.
+        // If a tag slug is sent in (dashed or lowercase), change to the tag name.
         // @TODO: This controller/model should really deal in slugs...
         $tag = $request->tag_name;
-        if (str_contains($tag, '-')) {
+        if (str_contains($tag, '-') || ctype_lower($tag)) {
             $tag = ucwords(str_replace('-', ' ', $tag));
         }
 

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -89,6 +89,22 @@ button.delete {
   text-align: right !important;
 }
 
+.text-center {
+  text-align: center !important;
+}
+
+.text-sm {
+  font-size: $font-small !important;
+}
+
+.text-gray {
+  color: $dark-gray !important;
+}
+
+.text-sm {
+  font-style: italic !important;
+}
+
 .margin-vertical {
   margin-top: $base-spacing;
   margin-bottom: $base-spacing;

--- a/resources/assets/components/Application.js
+++ b/resources/assets/components/Application.js
@@ -4,6 +4,7 @@ import { ApolloProvider } from '@apollo/react-hooks';
 
 import { env } from '../helpers';
 import graphql from '../graphql';
+import ShowPost from './ShowPost';
 import UserIndex from './UserIndex';
 import UserOverview from './UserOverview';
 import CampaignIndex from './CampaignIndex';
@@ -23,6 +24,9 @@ const Application = () => {
           </Route>
           <Route path="/users/:id">
             <UserOverview />
+          </Route>
+          <Route path="/posts/:id">
+            <ShowPost />
           </Route>
         </Switch>
       </Router>

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -1,0 +1,163 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+import { parse, format } from 'date-fns';
+
+import Quantity from './Quantity';
+import PostTile from './PostTile';
+import TextBlock from './TextBlock';
+import PostCard from './utilities/PostCard';
+import { AllTagButtons, TagButtonFragment } from './utilities/TagButton';
+import MetaInformation from './MetaInformation';
+import {
+  AcceptButton,
+  RejectButton,
+  ReviewButtonFragment,
+} from './utilities/ReviewButton';
+import UserInformation, {
+  UserInformationFragment,
+} from './Users/UserInformation';
+
+export const ReviewablePostFragment = gql`
+  fragment ReviewablePost on Post {
+    ...ReviewButton
+    ...TagButton
+    quantity
+    text
+    type
+    url
+    createdAt
+    source
+    location(format: HUMAN_FORMAT)
+
+    actionDetails {
+      name
+      noun
+      verb
+    }
+
+    campaign {
+      id
+      internalTitle
+    }
+
+    signup {
+      id
+      whyParticipated
+      source
+    }
+
+    user {
+      id
+      ...UserInformation
+    }
+  }
+
+  ${ReviewButtonFragment}
+  ${TagButtonFragment}
+  ${UserInformationFragment}
+`;
+
+const ReviewablePost = ({ post }) => {
+  return (
+    <div className="post container__row">
+      <div className="container__block -third">
+        <PostCard post={post} />
+        <ul className="gallery -duo">
+          {[
+            /* todo */
+          ].map(siblingPost => (
+            <li key={siblingPost.id}>
+              <PostTile post={siblingPost} />
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="container__block -third">
+        <UserInformation user={post.user} linkSignup={post.signup.id}>
+          {post.quantity ? (
+            <Quantity
+              quantity={post.quantity}
+              noun={post.actionDetails.noun}
+              verb={post.actionDetails.verb}
+            />
+          ) : null}
+
+          {/* TODO: Need to re-implement the 'edit quantity' modal. */}
+
+          <div className="container -padded">
+            <TextBlock
+              title={post.type === 'photo' ? 'Caption' : 'Text'}
+              content={post.text}
+            />
+          </div>
+
+          <div className="container">
+            <TextBlock
+              title="Why Statement"
+              content={post.signup.whyParticipated}
+            />
+          </div>
+        </UserInformation>
+      </div>
+
+      <div className="container__block -third">
+        <div className="container__row">
+          <ul className="form-actions -inline">
+            <li>
+              <AcceptButton post={post} />
+            </li>
+            <li>
+              <RejectButton post={post} />
+            </li>
+          </ul>
+        </div>
+        {post.status !== 'PENDING' ? (
+          <div className="container__row">
+            <h4>
+              Tags
+              <a className="footnote" href="/faq#tags" target="_blank">
+                (see definitions)
+              </a>
+            </h4>
+            <AllTagButtons post={post} />
+          </div>
+        ) : null}
+        <div className="container__row">
+          <MetaInformation
+            title="Post Information"
+            details={{
+              ID: post.id,
+              Campaign: (
+                <a href={`/campaign-ids/${post.campaign.id}`}>
+                  {post.campaign.internalTitle}
+                </a>
+              ),
+              Action: (
+                <a href={`/campaign-ids/${post.campaign.id}#actions`}></a>
+              ),
+              Type: post.type,
+              Source: post.source,
+              Location: post.location,
+              Submitted: format(parse(post.createdAt), 'M/D/YYYY h:m:s'),
+            }}
+          />
+        </div>
+        <div className="container__row">
+          <MetaInformation
+            title="Signup Information"
+            details={{
+              ID: <a href={`/signups/${post.signup.id}`}>{post.signup.id}</a>,
+              User: <Link to={`/users/${post.user.id}`}>{post.user.id}</Link>,
+              Source: post.signup.source,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReviewablePost;

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -8,6 +8,7 @@ import Quantity from './Quantity';
 import PostTile from './PostTile';
 import TextBlock from './TextBlock';
 import PostCard from './utilities/PostCard';
+import DeleteButton from './utilities/DeleteButton';
 import { AllTagButtons, TagButtonFragment } from './utilities/TagButton';
 import MetaInformation from './MetaInformation';
 import {
@@ -30,6 +31,7 @@ export const ReviewablePostFragment = gql`
     createdAt
     source
     location(format: HUMAN_FORMAT)
+    deleted
 
     actionDetails {
       name
@@ -60,6 +62,18 @@ export const ReviewablePostFragment = gql`
 `;
 
 const ReviewablePost = ({ post }) => {
+  // If we have a 'deleted' flag, it means that we've deleted this
+  // post since first viewing it & cannot make any further changes.
+  if (post.deleted) {
+    return (
+      <div className="post container__row">
+        <p className="text-sm text-gray text-center italic">
+          This post (#{post.id}) has been deleted.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="post container__row">
       <div className="container__block -third">
@@ -111,6 +125,13 @@ const ReviewablePost = ({ post }) => {
             </li>
             <li>
               <RejectButton post={post} />
+            </li>
+          </ul>
+        </div>
+        <div className="container__row">
+          <ul className="form-actions -inline">
+            <li>
+              <DeleteButton post={post} />
             </li>
           </ul>
         </div>

--- a/resources/assets/components/ShowPost.js
+++ b/resources/assets/components/ShowPost.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+
+import Chrome from './utilities/Chrome';
+import PagePlaceholder from './PagePlaceholder';
+import ReviewablePost, { ReviewablePostFragment } from './ReviewablePost';
+
+const SHOW_POST_QUERY = gql`
+  query ShowPostQuery($id: Int!) {
+    post(id: $id) {
+      ...ReviewablePost
+
+      campaign {
+        id
+        internalTitle
+      }
+
+      user {
+        displayName
+      }
+    }
+  }
+
+  ${ReviewablePostFragment}
+`;
+
+const ShowPost = () => {
+  const { id } = useParams();
+  const title = `Post #${id}`;
+
+  const { loading, error, data } = useQuery(SHOW_POST_QUERY, {
+    variables: { id: Number(id) },
+  });
+
+  if (loading)
+    return (
+      <Chrome title={title} subtitle="...">
+        <PagePlaceholder />
+      </Chrome>
+    );
+
+  if (error)
+    return (
+      <Chrome title="Error" subtitle="oops!">
+        <div className="container__block">Error :(</div>
+      </Chrome>
+    );
+
+  if (!data.post)
+    return (
+      <Chrome title={title} subtitle="Not found!">
+        <div className="container__block">
+          We couldn't find that post. Maybe it was deleted?
+        </div>
+      </Chrome>
+    );
+
+  const { post } = data;
+  const subtitle = `${post.user.displayName} / ${post.campaign.internalTitle}`;
+
+  return (
+    <Chrome title={title} subtitle={subtitle}>
+      <ReviewablePost post={post} />
+      <ul className="form-actions margin-vertical">
+        <li>
+          <a
+            className="button -tertiary"
+            href={`/campaigns/${post.campaign.id}`}
+          >
+            more from "{post.campaign.internalTitle}"
+          </a>
+        </li>
+      </ul>
+    </Chrome>
+  );
+};
+
+export default ShowPost;

--- a/resources/assets/components/utilities/Chrome.js
+++ b/resources/assets/components/utilities/Chrome.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const Chrome = ({ title, subtitle, children }) => (
+  <div>
+    <header className="header" role="banner">
+      <div className="wrapper">
+        <h1 className="header__title">{title}</h1>
+        <p className="header__subtitle">{subtitle}</p>
+      </div>
+    </header>
+    <div className="container">
+      <div className="wrapper">{children}</div>
+    </div>
+  </div>
+);
+
+export default Chrome;

--- a/resources/assets/components/utilities/DeleteButton.js
+++ b/resources/assets/components/utilities/DeleteButton.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { useMutation } from '@apollo/react-hooks';
+
+const DELETE_POST_MUTATION = gql`
+  mutation DeletePostMutation($id: Int!) {
+    deletePost(id: $id) {
+      id
+      deleted
+    }
+  }
+`;
+
+const DeleteButton = ({ post }) => {
+  const [deletePost] = useMutation(DELETE_POST_MUTATION, {
+    variables: {
+      id: post.id,
+    },
+  });
+
+  const handleClick = () => {
+    const warning = 'Are you sure you want to permanently delete this post? 🔥';
+
+    if (confirm(warning)) {
+      deletePost();
+    }
+  };
+
+  return (
+    <button className="button delete -tertiary" onClick={handleClick}>
+      Delete
+    </button>
+  );
+};
+
+export default DeleteButton;

--- a/resources/assets/components/utilities/PostCard.js
+++ b/resources/assets/components/utilities/PostCard.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export const PostCard = ({ post }) => {
+  return (
+    <>
+      {post.type == 'photo' ? (
+        <img className="post-tile" alt="post image" src={url} />
+      ) : (
+        <div className="post-tile -fallback" />
+      )}
+
+      {post.type === 'photo' ? (
+        <div className="admin-tools">
+          <div className="admin-tools__links">
+            <a href={`/originals/${post.id}`} target="_blank">
+              Original Photo
+            </a>
+          </div>
+      ) : null}
+    </>
+  );
+};
+
+export default PostCard;

--- a/resources/assets/components/utilities/PostCard.js
+++ b/resources/assets/components/utilities/PostCard.js
@@ -1,6 +1,27 @@
-import React from 'react';
+import gql from 'graphql-tag';
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+
+const ROTATE_POST_MUTATION = gql`
+  mutation RotatePostMutation($id: Int!) {
+    rotatePost(id: $id) {
+      id
+      url
+    }
+  }
+`;
 
 export const PostCard = ({ post }) => {
+  const [cacheBuster, setCacheBuster] = useState('');
+  const [rotatePost, { loading }] = useMutation(ROTATE_POST_MUTATION, {
+    variables: { id: post.id },
+    onCompleted: () => setCacheBuster('?' + Date.now()),
+  });
+
+  // If we've rotated the post, use a "cache buster" to force
+  // the user's browser to reload the image from the edge.
+  const url = `${post.url}${cacheBuster}`;
+
   return (
     <>
       {post.type == 'photo' ? (
@@ -16,6 +37,14 @@ export const PostCard = ({ post }) => {
               Original Photo
             </a>
           </div>
+          <div className="admin-tools__rotate">
+            {loading ? (
+              <div className="spinner" />
+            ) : (
+              <a className="button -tertiary rotate" onClick={rotatePost} />
+            )}
+          </div>
+        </div>
       ) : null}
     </>
   );

--- a/resources/assets/components/utilities/ReviewButton.js
+++ b/resources/assets/components/utilities/ReviewButton.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import classNames from 'classnames';
+import { useMutation } from '@apollo/react-hooks';
+
+export const ReviewButtonFragment = gql`
+  fragment ReviewButton on Post {
+    id
+    status
+  }
+`;
+
+const REVIEW_POST_MUTATION = gql`
+  mutation ReviewPostMutation($id: Int!, $status: ReviewStatus!) {
+    reviewPost(id: $id, status: $status) {
+      ...ReviewButton
+    }
+
+    ${ReviewButtonFragment}
+  }
+`;
+
+const ReviewButton = ({ post, status, children }) => {
+  const [reviewPost] = useMutation(REVIEW_POST_MUTATION, {
+    variables: {
+      id: post.id,
+      status: status,
+    },
+  });
+
+  const statusClass = `-${status.toLowerCase()}`;
+
+  return (
+    <button
+      className={classNames('button', '-outlined-button', statusClass, {
+        'is-selected': post.status === status,
+      })}
+      onClick={reviewPost}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const AcceptButton = ({ post }) => (
+  <ReviewButton post={post} status="ACCEPTED">
+    Accept
+  </ReviewButton>
+);
+
+export const RejectButton = ({ post }) => (
+  <ReviewButton post={post} status="REJECTED">
+    Reject
+  </ReviewButton>
+);
+
+export default ReviewButton;

--- a/resources/assets/components/utilities/TagButton.js
+++ b/resources/assets/components/utilities/TagButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import { without } from 'lodash';
 import classNames from 'classnames';
 import { useMutation } from '@apollo/react-hooks';
 
@@ -21,16 +22,28 @@ const TAG_POST_MUTATION = gql`
 `;
 
 export const TagButton = ({ post, tag, label }) => {
+  const hasTag = post.tags.includes(tag);
+
   const [tagPost] = useMutation(TAG_POST_MUTATION, {
     variables: {
       id: post.id,
       tag: tag,
     },
+    // We'll optimistically update the interface with the given tag
+    // before waiting for the full network round-trip. Snappy!
+    optimisticResponse: {
+      __typename: 'Mutation',
+      tagPost: {
+        __typename: 'Post',
+        id: post.id,
+        tags: hasTag ? without(post.tags, tag) : [...post.tags, tag],
+      },
+    },
   });
 
   return (
     <button
-      className={classNames('tag', { 'is-active': post.tags.includes(tag) })}
+      className={classNames('tag', { 'is-active': hasTag })}
       onClick={tagPost}
     >
       {label}

--- a/resources/assets/components/utilities/TagButton.js
+++ b/resources/assets/components/utilities/TagButton.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import classNames from 'classnames';
+import { useMutation } from '@apollo/react-hooks';
+
+export const TagButtonFragment = gql`
+  fragment TagButton on Post {
+    id
+    tags
+  }
+`;
+
+const TAG_POST_MUTATION = gql`
+  mutation TagPostMutation($id: Int!, $tag: String!) {
+    tagPost(id: $id, tag: $tag) {
+      ...TagButton
+    }
+
+    ${TagButtonFragment}
+  }
+`;
+
+export const TagButton = ({ post, tag, label }) => {
+  const [tagPost] = useMutation(TAG_POST_MUTATION, {
+    variables: {
+      id: post.id,
+      tag: tag,
+    },
+  });
+
+  return (
+    <button
+      className={classNames('tag', { 'is-active': post.tags.includes(tag) })}
+      onClick={tagPost}
+    >
+      {label}
+    </button>
+  );
+};
+
+export const AllTagButtons = ({ post }) => (
+  <>
+    <TagButton post={post} tag="good-submission" label="Good Submission" />
+    <TagButton post={post} tag="good-quote" label="Good Quote" />
+    <TagButton post={post} tag="good-for-brand" label="Good For Brand" />
+    <TagButton post={post} tag="good-for-sponsor" label="Good For Sponsor" />
+    <TagButton post={post} tag="group-photo" label="Group Photo" />
+    <TagButton post={post} tag="hide-in-gallery" label="Hide In Gallery 👻" />
+    <TagButton post={post} tag="irrelevant" label="Irrelevant" />
+    <TagButton post={post} tag="inappropriate" label="Inappropriate" />
+    <TagButton
+      post={post}
+      tag="unrealistic-quantity"
+      label="Unrealistic Quantity"
+    />
+    <TagButton post={post} tag="test" label="Test" />
+    <TagButton post={post} tag="incomplete-action" label="Incomplete Action" />
+    <TagButton post={post} tag="bulk" label="Bulk" />
+  </>
+);
+
+export default TagButton;

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,9 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Users
     Route::view('users', 'app')->name('users.index');
     Route::view('users/{id}', 'app')->name('users.show');
+
+    // Posts
+    Route::view('posts/{id}', 'app')->name('posts.show');
 });
 
 // Images


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `post/{id}` view that shows an individual post. This interface fetches (and mutates!) data via GraphQL, allowing us to sidestep some of the complexity that's built up around doing this with REST & a custom in-memory store.

![Kapture 2019-11-05 at 17 47 53](https://user-images.githubusercontent.com/583202/68253002-d4df0700-fff4-11e9-8db5-29bc8cb6ee33.gif)

#### How should this be reviewed?
This relies on the mutations and field added in DoSomething/graphql#153. I've split this into individual commits for each feature, which may be helpful while reviewing.

#### Any background context you want to provide?
This adds a feature I've wanted for a long time (since otherwise the best we can do is link to a signup and say "look at the Nth one") and also makes it super-simple to build the campaign inbox!

#### Relevant tickets
[#169512736](https://www.pivotaltracker.com/story/show/169512736)