### PR TITLE
Add "edit quantity" modal to GraphQL-backed post interface.

### DIFF
--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -58,10 +58,13 @@ class ImagesController extends Controller
 
         $response = $server->getImageResponse($post->getMediaPath(), $request->all());
 
-        // We want these to be cached in Fastly, but not in the user's browser, so we'll
-        // override 'Cache-Control' to use 's-max-age'. We can then use the 'Surrogate-Key'
-        // header to clear Fastly's cache if an image is rotated/deleted:
+        // We want these to be cached in Fastly, but not in the user's browser, since
+        // otherwise rotations/deletions won't take effect until the user clears their cache:
         $response->headers->set('Cache-Control', 's-max-age=31536000, public');
+        $response->headers->remove('Expires');
+
+        // We can then use the 'Surrogate-Key' to easily clear this from
+        // Fastly's cache if the post's image is modified later on:
         $response->headers->set('Surrogate-Key', 'post-'.$post->id);
 
         return $response;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9546,6 +9546,14 @@
         "scheduler": "^0.16.1"
       }
     },
+    "react-useportal": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/react-useportal/-/react-useportal-1.0.13.tgz",
+      "integrity": "sha512-83KpNTXUIHnRVTLeMberIblCtssvRSKCPnG/xT9NW60gDYfU13pQBNQKCVUF8MBK+7LnCQ/ZrOuXl8Mp+iXdXA==",
+      "requires": {
+        "use-ssr": "^1.0.19"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -11355,6 +11363,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-ssr": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.19.tgz",
+      "integrity": "sha512-Bkor42KtUZHTTuEot4Nma0Q9bccu+ZOGqukyNJI1A11uSymNag7VX3ub2Rzi2nLez4fUYUUROn0mEtil5KOsCg=="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
     "react-router": "^5.1.2",
-    "react-router-dom": "^5.1.2"
+    "react-router-dom": "^5.1.2",
+    "react-useportal": "^1.0.13"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -3,6 +3,11 @@ $forge-path: '~@dosomething/forge/assets/';
 // Import Forge.
 @import '~@dosomething/forge/scss/forge';
 
+// Fix 'button' styling in Forge's modal container:
+.modal-close-button {
+  border: 0;
+}
+
 // Fix awkward disabled styling on Forge's `.button.-tertiary`.
 .button.-tertiary:disabled,
 .button.-tertiary:disabled:hover {

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -5,6 +5,7 @@ $forge-path: '~@dosomething/forge/assets/';
 
 // Fix 'button' styling in Forge's modal container:
 .modal-close-button {
+  background-color: transparent;
   border: 0;
 }
 

--- a/resources/assets/components/Quantity/index.js
+++ b/resources/assets/components/Quantity/index.js
@@ -8,9 +8,9 @@ const Quantity = props => (
     </div>
     <div className="figure__body">
       {props.noun && props.verb ? (
-        <h4 className="reportback-noun-verb">
+        <strong>
           {props.noun} {props.verb}
-        </h4>
+        </strong>
       ) : null}
     </div>
   </div>

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import classNames from 'classnames';
+import usePortal from 'react-useportal';
 import { Link } from 'react-router-dom';
 import { parse, format } from 'date-fns';
 
 import Quantity from './Quantity';
 import PostTile from './PostTile';
 import TextBlock from './TextBlock';
+import Modal from './utilities/Modal';
 import PostCard from './utilities/PostCard';
 import DeleteButton from './utilities/DeleteButton';
 import { AllTagButtons, TagButtonFragment } from './utilities/TagButton';
+import QuantityForm, { QuantityFormFragment } from './utilities/QuantityForm';
 import MetaInformation from './MetaInformation';
 import {
   AcceptButton,
@@ -24,6 +26,7 @@ export const ReviewablePostFragment = gql`
   fragment ReviewablePost on Post {
     ...ReviewButton
     ...TagButton
+    ...QuantityForm
     quantity
     text
     type
@@ -58,10 +61,15 @@ export const ReviewablePostFragment = gql`
 
   ${ReviewButtonFragment}
   ${TagButtonFragment}
+  ${QuantityFormFragment}
   ${UserInformationFragment}
 `;
 
 const ReviewablePost = ({ post }) => {
+  var { openPortal, closePortal, isOpen, Portal } = usePortal({
+    bindTo: document.getElementById('modal-portal'),
+  });
+
   // If we have a 'deleted' flag, it means that we've deleted this
   // post since first viewing it & cannot make any further changes.
   if (post.deleted) {
@@ -99,7 +107,19 @@ const ReviewablePost = ({ post }) => {
             />
           ) : null}
 
-          {/* TODO: Need to re-implement the 'edit quantity' modal. */}
+          <div className="container -padded">
+            <button className="button -tertiary" onClick={openPortal}>
+              Edit Quantity
+            </button>
+
+            {isOpen ? (
+              <Portal>
+                <Modal onClose={closePortal}>
+                  <QuantityForm post={post} />
+                </Modal>
+              </Portal>
+            ) : null}
+          </div>
 
           <div className="container -padded">
             <TextBlock

--- a/resources/assets/components/utilities/LazyImage.js
+++ b/resources/assets/components/utilities/LazyImage.js
@@ -1,0 +1,40 @@
+/* global Image */
+
+import React, { useState, useEffect } from 'react';
+
+const EMPTY_IMAGE =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+const LazyImage = ({ className, alt, src }) => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let loader = new Image();
+    loader.onload = () => setLoading(false);
+
+    // Reset 'loading' to true if we change 'src':
+    setLoading(true);
+
+    // Only try to preload if we're given a 'src':
+    if (src) {
+      loader.src = src;
+    }
+
+    // Finally, clean up if this component dismounts:
+    return () => (loader = null);
+  }, [src]);
+
+  return (
+    <img
+      className={className}
+      alt={alt}
+      src={loading ? EMPTY_IMAGE : src}
+      style={{
+        transition: 'opacity 0.5s',
+        opacity: loading ? 0 : 1,
+      }}
+    />
+  );
+};
+
+export default LazyImage;

--- a/resources/assets/components/utilities/Modal.js
+++ b/resources/assets/components/utilities/Modal.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Modal = ({ children, onClose }) => (
+  <div className="modal-container">
+    <div className="modal">
+      <button onClick={onClose} className="modal-close-button">
+        &times;
+      </button>
+      {children}
+    </div>
+  </div>
+);
+
+export default Modal;

--- a/resources/assets/components/utilities/PostCard.js
+++ b/resources/assets/components/utilities/PostCard.js
@@ -2,6 +2,8 @@ import gql from 'graphql-tag';
 import React, { useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 
+import LazyImage from './LazyImage';
+
 const ROTATE_POST_MUTATION = gql`
   mutation RotatePostMutation($id: Int!) {
     rotatePost(id: $id) {
@@ -25,7 +27,7 @@ export const PostCard = ({ post }) => {
   return (
     <>
       {post.type == 'photo' ? (
-        <img className="post-tile" alt="post image" src={url} />
+        <LazyImage className="post-tile" alt="post image" src={url} />
       ) : (
         <div className="post-tile -fallback" />
       )}

--- a/resources/assets/components/utilities/QuantityForm.js
+++ b/resources/assets/components/utilities/QuantityForm.js
@@ -1,0 +1,74 @@
+import gql from 'graphql-tag';
+import classNames from 'classnames';
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+
+export const QuantityFormFragment = gql`
+  fragment QuantityForm on Post {
+    id
+    quantity
+    impact
+  }
+`;
+
+const UPDATE_QUANTITY_MUTATION = gql`
+  mutation UpdateQuantityMutation($id: Int!, $quantity: Int!) {
+    updatePostQuantity(id: $id, quantity: $quantity) {
+      ...QuantityForm
+    }
+
+    ${QuantityFormFragment}
+  }
+`;
+
+const isInteger = string => /^\d+$/.test(string);
+
+const QuantityForm = ({ post }) => {
+  const [newQuantity, setNewQuantity] = useState(post.quantity);
+  const [updateQuantity, { loading }] = useMutation(UPDATE_QUANTITY_MUTATION, {
+    variables: { id: post.id },
+  });
+
+  const handleSubmit = () =>
+    updateQuantity({ variables: { quantity: Number(newQuantity) } });
+
+  return (
+    <>
+      <div className="modal__block">
+        <h3>Edit Quantity</h3>
+      </div>
+      <div className="modal__block">
+        <div className="container__block -half">
+          <h4>Current Quantity</h4>
+          <input
+            type="text"
+            className="text-field"
+            value={post.impact}
+            disabled
+          />
+        </div>
+        <div className="container__block -half">
+          <h4>New Quantity</h4>
+          <div className="form-item">
+            <input
+              type="number"
+              onChange={event => setNewQuantity(event.target.value)}
+              className="text-field"
+              value={newQuantity}
+            />
+          </div>
+        </div>
+      </div>
+
+      <button
+        className={classNames('button -history', { 'is-loading': loading })}
+        disabled={!isInteger(newQuantity)}
+        onClick={handleSubmit}
+      >
+        Save
+      </button>
+    </>
+  );
+};
+
+export default QuantityForm;


### PR DESCRIPTION
#### What's this PR do?
This pull request adds the "edit quantity" modal to the GraphQL-powered post interface, which can currently be found at `/posts/:id`. This uses [react-useportal](https://github.com/alex-cory/react-useportal) to handle rendering the modal, and the new `updatePostQuantity` GraphQL mutation to update this field on the backend. (f4c8d2a)

It also includes two tiny fixes to the "rotate" functionality:

💤 Adds a (hook-powered) `LazyImage` component which lets us lazy-load images! f968ad7

💣 Removes the `Expires` header from Glide images so browsers don't cache them! I missed this in #934 but hopefully this should sort everything out for us! 5b77545

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This gets us pretty much to feature-parity with the old implementation, nice!

#### Relevant tickets
[#169512736](https://www.pivotaltracker.com/story/show/169512736), [#169346181](https://www.pivotaltracker.com/story/show/169346181)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
