### PR TITLE
Add 'cursor[after]' support to 'api/v3/posts'.

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -52,6 +52,7 @@ class PostTransformer extends TransformerAbstract
             'location_name' => $post->location_name,
             'created_at' => $post->created_at->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
+            'cursor' => $post->getCursor(),
         ];
 
         // If this post is for an anonymous action (and viewer is not owner/staff), hide the user ID.

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -3,13 +3,14 @@
 namespace Rogue\Models;
 
 use Rogue\Types\Cause;
+use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Campaign extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, HasCursor;
 
     /**
      * The attributes that should be mutated to dates.
@@ -208,58 +209,5 @@ class Campaign extends Model
         }
 
         $this->attributes[$attribute] = $this->fromDateTime($value);
-    }
-
-    /**
-     * Create a cursor for this item.
-     *
-     * @return string
-     */
-    public function getCursor()
-    {
-        $sortCursor = '';
-
-        // If we're ordering results, we need to include that column's
-        // value in the cursor (so we can say "get me things after this"):
-        if ($orderBy = request()->query('orderBy')) {
-            [ $column, $direction ] = explode(',', $orderBy, 2);
-
-            // Check that it's okay to expose this column in the cursor:
-            if (in_array($column, self::$sortable)) {
-                $sortCursor = '.' . $this->{$column};
-            }
-        }
-
-        return base64_encode($this->id . $sortCursor);
-    }
-
-    /**
-     * Scope a query to only include items after the given cursor.
-     */
-    public function scopeWhereAfterCursor($query, $cursor)
-    {
-        $cursor = explode('.', base64_decode($cursor), 2);
-
-        $id = $cursor[0];
-        $sortCursor = isset($cursor[1]) ? $cursor[1] : null;
-
-        $orderBy = request()->query('orderBy');
-        if ($orderBy && $sortCursor) {
-            // If we're sorting by a column, things get a lil' tricky:
-            [ $column, $direction ] = explode(',', $orderBy, 2);
-            $operator = $direction === 'asc' ? '>' : '<';
-
-            // Check that we're allowed to sort by this column:
-            if (in_array($column, self::$sortable)) {
-                $query->where($column, $operator, $sortCursor)
-                    ->orWhere(function ($query) use ($column, $operator, $sortCursor, $id) {
-                        $query->where($column, $operator.'=', $sortCursor)
-                            ->where('id', '>', $id);
-                    });
-            }
-        } else {
-            // Otherwise, treat as a plain ID cursor... easy!
-            $query->where('id', '>', $id);
-        }
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace Rogue\Models;
 use Hashids\Hashids;
 use Rogue\Services\GraphQL;
 use Rogue\Events\PostTagged;
+use Rogue\Models\Traits\HasCursor;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
@@ -12,7 +13,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, HasCursor;
+
     /**
      * The attributes that should be mutated to dates.
      *
@@ -56,6 +58,16 @@ class Post extends Model
      * @var array
      */
     public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'action_id', 'northstar_id', 'status', 'created_at', 'source', 'location'];
+
+    /**
+     * Attributes that can be sorted by.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $sortable = ['created_at'];
 
     /**
      * The tags prefixed with 'good' that will send a post to Slack.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -60,7 +60,7 @@ class Post extends Model
     public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'action_id', 'northstar_id', 'status', 'created_at', 'source', 'location'];
 
     /**
-     * Attributes that can be sorted by.
+     * Attributes that we can sort by with the '?orderBy' query parameter.
      *
      * This array is manually maintained. It does not necessarily mean that
      * any of these are actual indexes on the database... but they should be!

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -38,16 +38,19 @@ trait HasCursor
         $sortCursor = isset($cursor[1]) ? $cursor[1] : null;
 
         $orderBy = request()->query('orderBy');
-        if ($orderBy && $sortCursor) {
+        if ($orderBy && $orderBy !== 'id,asc' && $sortCursor) {
             // If we're sorting by a column, things get a lil' tricky:
             [ $column, $direction ] = explode(',', $orderBy, 2);
             $operator = $direction === 'asc' ? '>' : '<';
 
-            // Check that we're allowed to sort by this column:
+            // First, check that we're allowed to sort by this column:
             if (in_array($column, self::$sortable)) {
+                // We'll check if there are any posts "after" the sorted column,
+                // or "equal" to it but with a higher ID (since that's our
+                // stable secondary sort).
                 $query->where($column, $operator, $sortCursor)
-                    ->orWhere(function ($query) use ($column, $operator, $sortCursor, $id) {
-                        $query->where($column, $operator.'=', $sortCursor)
+                    ->orWhere(function ($query) use ($column, $sortCursor, $id) {
+                        $query->where($column, '=', $sortCursor)
                             ->where('id', '>', $id);
                     });
             }
@@ -55,4 +58,5 @@ trait HasCursor
             // Otherwise, treat as a plain ID cursor... easy!
             $query->where('id', '>', $id);
         }
+    }
 }

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rogue\Models\Traits;
+
+trait HasCursor
+{
+    /**
+     * Create a cursor for this item.
+     *
+     * @return string
+     */
+    public function getCursor()
+    {
+        $sortCursor = '';
+
+        // If we're ordering results, we need to include that column's
+        // value in the cursor (so we can say "get me things after this"):
+        if ($orderBy = request()->query('orderBy')) {
+            [ $column, $direction ] = explode(',', $orderBy, 2);
+
+            // Check that it's okay to expose this column in the cursor:
+            if (in_array($column, self::$sortable)) {
+                $sortCursor = '.' . $this->{$column};
+            }
+        }
+
+        return base64_encode($this->id . $sortCursor);
+    }
+
+    /**
+     * Scope a query to only include items after the given cursor.
+     */
+    public function scopeWhereAfterCursor($query, $cursor, $defaultSort = 'id,desc')
+    {
+        $cursor = explode('.', base64_decode($cursor), 2);
+
+        $id = $cursor[0];
+        $sortCursor = isset($cursor[1]) ? $cursor[1] : null;
+
+        $orderBy = request()->query('orderBy');
+        if ($orderBy && $sortCursor) {
+            // If we're sorting by a column, things get a lil' tricky:
+            [ $column, $direction ] = explode(',', $orderBy, 2);
+            $operator = $direction === 'asc' ? '>' : '<';
+
+            // Check that we're allowed to sort by this column:
+            if (in_array($column, self::$sortable)) {
+                $query->where($column, $operator, $sortCursor)
+                    ->orWhere(function ($query) use ($column, $operator, $sortCursor, $id) {
+                        $query->where($column, $operator.'=', $sortCursor)
+                            ->where('id', '>', $id);
+                    });
+            }
+        } else {
+            // Otherwise, treat as a plain ID cursor... easy!
+            $query->where('id', '>', $id);
+        }
+}


### PR DESCRIPTION
#### What's this PR do?
This pull request extracts the experimental cursor methods from #930 into a `HasCursor` trait so that we can try it out for posts as well. I also ran into a bug with the "sorted" cursor logic and fixed it up in b262123 (see below).

#### How should this be reviewed?
I'd recommend reviewing this one commit-by-commit (mainly because extracting the trait adds a lot of noise that's not "really" there).

#### Any background context you want to provide?
The bug in c6ff2ba occurs when the "sorted" column (e.g. `created_at` or `pending_posts`) has items with the same value. In that case, we want either items after the primary sort column (so `created_at < cursor.created_at` for example) or, if the primary sort has duplicates, after the secondary sort (so `created_at == cursor.created_at && id > cursor.id`).

Previously, I'd been checking for `created_at <= cursor.created_at && id > cursor.id` which applies the secondary sort in cases where we don't want it.

(I believe the reason this bug didn't appear with campaigns in #930 because we only ran this "secondary sort" logic at the "end" of the list when we were sorting by `pending_count,desc`, and so there was no opportunity for the `id > cursor.id` to mess things up).

Anyways, [yikes](https://media.giphy.com/media/5QMPpCzH6yxEqhev5A/giphy.gif).

#### Relevant tickets
[#169216351](https://www.pivotaltracker.com/story/show/169216351)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
