### PR TITLE
Don't default Cache-Control to 'private'.

### DIFF
--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -65,7 +65,7 @@ class ImagesController extends Controller
 
         // But we want browsers to always re-validate before serving this image from local
         // cache, so that image rotations/deletions are respected immediately:
-        $response->headers->set('Cache-Control', 'no-cache');
+        $response->headers->set('Cache-Control', 'no-cache, public');
 
         return $response;
     }


### PR DESCRIPTION
#### What's this PR do?
This header was getting defaulted to `Cache-Control: no-cache, private`, which [disables Fastly caching even when `Surrogate-Control` is provided](https://docs.fastly.com/en/guides/cache-control-tutorial#do-not-cache):

> Except for when the `Cache-Control` header is set to `private`, the `Surrogate-Control` header takes priority over `Cache-Control`, but unlike `Cache-Control` it is stripped so the browsers don't see it.

#### How should this be reviewed?
Hopefully this looks better on QA!

#### Any background context you want to provide?
This fixes a new issue introduced in #939 where all responses became cache misses.

#### Relevant tickets
Will create one momentarily!

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
