### PR TITLE
Fix Fastly caching issues.

### DIFF
--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -63,9 +63,9 @@ class ImagesController extends Controller
         $response->headers->set('Surrogate-Control', 'max-age=31536000');
         $response->headers->set('Surrogate-Key', 'post-'.$post->id);
 
-        // But we want browsers to always re-validate before serving this image from local
-        // cache, so that image rotations/deletions are respected immediately:
-        $response->headers->set('Cache-Control', 'no-cache, public');
+        // And we want browsers to cache but re-validate with us before returning cached content
+        // on a subsequent load, so that image rotations/deletions are respected immediately:
+        $response->headers->set('Cache-Control', 'max-age=31536000, must-revalidate, no-cache, public');
 
         return $response;
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request… hopefully… fixes the caching issues I've been wrestling with today.

#### How should this be reviewed?
I think the easiest thing will just be testing this on QA! 🙃

#### Any background context you want to provide?
Frustratingly, Symfony (which Laravel's HTTP stack is built on) [forces certain `Cache-Control` headers](https://github.com/symfony/http-foundation/blob/d8f1bf9f099852ddd0c009589634ecadb7e4a9d8/ResponseHeaderBag.php#L255-L285), so we can't follow [Fastly's instructions](https://docs.fastly.com/en/guides/cache-control-tutorial#applying-different-cache-rules-for-fastly-and-browsers) without it being overridden with a `private` at the end (which disables Fastly caching).

I'm still not certain why #940 didn't solve our issues, but I've tested these headers in a [Fastly Fiddle](https://fiddle.fastlydemo.net/fiddle/bd6771fc) and confirmed that given the headers that are being output by my local app… this _should_ correctly cache in Fastly & the user's browser.

#### Relevant tickets
[#169690043](https://www.pivotaltracker.com/story/show/169690043)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
