### PR TITLE
Use "counter caches" for pending count instead of heavy query.

### DIFF
--- a/app/Console/Commands/RecountPostsCommand.php
+++ b/app/Console/Commands/RecountPostsCommand.php
@@ -5,14 +5,14 @@ namespace Rogue\Console\Commands;
 use Rogue\Models\Campaign;
 use Illuminate\Console\Command;
 
-class RefreshCampaignCounts extends Command
+class RecountPostsCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'rogue:refresh-counts';
+    protected $signature = 'rogue:recount';
 
     /**
      * The console command description.

--- a/app/Console/Commands/RefreshCampaignCounts.php
+++ b/app/Console/Commands/RefreshCampaignCounts.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Campaign;
+use Illuminate\Console\Command;
+
+class RefreshCampaignCounts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'campaign:refresh-counts';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Refresh post counts for all campaigns.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        foreach (Campaign::cursor() as $campaign) {
+            $this->line('Refreshing cached post counts for ' . $campaign->id . '.');
+            $campaign->refreshCounts();
+        }
+    }
+}

--- a/app/Console/Commands/RefreshCampaignCounts.php
+++ b/app/Console/Commands/RefreshCampaignCounts.php
@@ -12,7 +12,7 @@ class RefreshCampaignCounts extends Command
      *
      * @var string
      */
-    protected $signature = 'campaign:refresh-counts';
+    protected $signature = 'rogue:refresh-counts';
 
     /**
      * The console command description.

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -45,13 +45,6 @@ class CampaignsController extends ApiController
             }
         }
 
-        // Attach counts for total posts & pending posts:
-        $includePendingCount = str_contains($request->query('include'), 'pending_count')
-            || str_contains($request->query('orderBy'), 'pending_count');
-        if ($includePendingCount && is_staff_user()) {
-            $query->withPendingPostCount();
-        }
-
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):
         if ($cursor = array_get($request->query('cursor'), 'after')) {
             $query->whereAfterCursor($cursor);

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -23,6 +23,7 @@ class CampaignTransformer extends TransformerAbstract
             'is_open' => $campaign->isOpen(),
             'impact_doc' => $campaign->impact_doc,
             'cause' => $campaign->cause,
+            'accepted_count' => $campaign->accepted_count,
             'pending_count' => is_staff_user() ? $campaign->pending_count : null,
             'cause_names' => $campaign->getCauseNames(),
             'created_at' => $campaign->created_at->toIso8601String(),

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -23,7 +23,7 @@ class CampaignTransformer extends TransformerAbstract
             'is_open' => $campaign->isOpen(),
             'impact_doc' => $campaign->impact_doc,
             'cause' => $campaign->cause,
-            'pending_count' => $campaign->pending_count,
+            'pending_count' => is_staff_user() ? $campaign->pending_count : null,
             'cause_names' => $campaign->getCauseNames(),
             'created_at' => $campaign->created_at->toIso8601String(),
             'updated_at' => $campaign->updated_at->toIso8601String(),

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -99,21 +99,6 @@ class Campaign extends Model
     }
 
     /**
-     * Attach count of pending posts to a query.
-     */
-    public function scopeWithPendingPostCount($query)
-    {
-        // Get a "pure" query, without eager loads/counts:
-        $posts = (new Post)->newModelQuery();
-
-        $counts = $posts->selectRaw('campaign_id, count(*) as pending_count')
-                ->whereReviewable()->where('status', 'pending')
-                ->groupBy('campaign_id');
-
-        return $query->leftJoinSub($counts, 'counts', 'campaigns.id', '=', 'counts.campaign_id');
-    }
-
-    /**
      * Should we accept new signups & posts for this campaign?
      *
      * @return bool

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -44,7 +44,7 @@ class Campaign extends Model
      *
      * @var array
      */
-    public static $sortable = ['id', 'pending_count'];
+    public static $sortable = ['id', 'accepted_count', 'pending_count'];
 
     /**
      * Get the signups associated with this campaign.

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -71,6 +71,17 @@ class Campaign extends Model
     }
 
     /**
+     * Run a quick 'COUNT(*)' query to get the count of pending and accepted
+     * posts for this campaign (so we can use this efficiently later).
+     */
+    public function refreshCounts()
+    {
+        $this->pending_count = Post::getPostCount($this, 'pending');
+        $this->accepted_count = Post::getPostCount($this, 'accepted');
+        $this->save();
+    }
+
+    /**
      * Scope a query to only include "open" campaigns.
      */
     public function scopeWhereOpen($query)

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -536,7 +536,7 @@ class Post extends Model
      */
     public static function getPostCount(Campaign $campaign, string $status)
     {
-        return (new Post)->newModelQuery()
+        return (new self)->newModelQuery()
             ->where('campaign_id', $campaign->id)
             ->where('status', $status)
             ->whereReviewable()

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -275,8 +275,7 @@ class Post extends Model
         $campaign_cause = optional($this->signup->campaign)->getAttributes()['cause'];
 
         // Fetch Campaign Website information via GraphQL.
-        // $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
-        $campaignWebsite = ['title' => null, 'slug' => null];
+        $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
 
         // The associated Action for this post.
         $action = $this->actionModel;

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -275,7 +275,8 @@ class Post extends Model
         $campaign_cause = optional($this->signup->campaign)->getAttributes()['cause'];
 
         // Fetch Campaign Website information via GraphQL.
-        $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
+        // $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
+        $campaignWebsite = ['title' => null, 'slug' => null];
 
         // The associated Action for this post.
         $action = $this->actionModel;
@@ -526,5 +527,19 @@ class Post extends Model
         }
 
         return false;
+    }
+
+    /**
+     * Get the number of posts for the given campaign and status.
+     *
+     * @return int
+     */
+    public static function getPostCount(Campaign $campaign, string $status)
+    {
+        return (new Post)->newModelQuery()
+            ->where('campaign_id', $campaign->id)
+            ->where('status', $status)
+            ->whereReviewable()
+            ->count();
     }
 }

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -58,7 +58,8 @@ trait HasCursor
                         if (is_null($sortCursor)) {
                             $query->whereNull($column);
                         } else {
-                            $query->where($column, '=', $sortCursor);
+                            $query->where($column, '=', $sortCursor)
+                                ->orWhereNull($column);
                         }
 
                         $query->where('id', '>', $id);

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -54,7 +54,7 @@ trait HasCursor
                 $query->where($column, $operator, $sortCursor);
                 $query->orWhere([
                     [$column, '=', $sortCursor],
-                    ['id', '>', $id]
+                    ['id', '>', $id],
                 ]);
 
                 // @TODO: This gets a lot more complicated if the sorted column can have nulls...

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -55,10 +55,11 @@ trait HasCursor
                     ->orWhere(function ($query) use ($column, $sortCursor, $id) {
                         // If the sorted cursor is null, we need to use a `WHERE NULL`
                         // query, since MySQL's `WHERE =` won't compare with `NULL`.
-                        $query->where(function ($query) use ($column, $sortCursor) {
-                            $query->where($column, '=', $sortCursor)
-                                ->orWhereNull($column);
-                        });
+                        if (is_null($sortCursor)) {
+                            $query->whereNull($column);
+                        } else {
+                            $query->where($column, '=', $sortCursor);
+                        }
 
                         $query->where('id', '>', $id);
                     });

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -52,6 +52,10 @@ class ModelServiceProvider extends ServiceProvider
 
         // When Reviews are saved create an event for them.
         Review::saved(function ($review) {
+            info('review', ['campaign' => $review->post->campaign_id]);
+            // Update the "counter cache" on this campaign:
+            $review->post->campaign->refreshCounts();
+
             $review->events()->create([
                 'content' => $review->toJson(),
                 'user' => $review->admin_northstar_id,

--- a/database/migrations/2019_11_14_203229_add_pending_count_to_campaigns.php
+++ b/database/migrations/2019_11_14_203229_add_pending_count_to_campaigns.php
@@ -14,8 +14,8 @@ class AddPendingCountToCampaigns extends Migration
     public function up()
     {
         Schema::table('campaigns', function (Blueprint $table) {
-            $table->integer('pending_count')->default(0);
-            $table->integer('accepted_count')->default(0);
+            $table->integer('pending_count')->default(0)->after('end_date');
+            $table->integer('accepted_count')->default(0)->after('pending_count');
         });
     }
 

--- a/database/migrations/2019_11_14_203229_add_pending_count_to_campaigns.php
+++ b/database/migrations/2019_11_14_203229_add_pending_count_to_campaigns.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPendingCountToCampaigns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->integer('pending_count')->default(0);
+            $table->integer('accepted_count')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->dropColumn('pending_count');
+            $table->dropColumn('accepted_count');
+        });
+    }
+}

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -8,7 +8,7 @@
 
         <title>Rogue</title>
 
-        <link rel="icon" type="image/png" href="http://twooter.biz/Gifs/tonguecat.png">
+        <link rel="apple-touch-icon-precomposed" href="/assets/images/apple-touch-icon-precomposed.png">
         <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}">
     </head>
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -125,6 +125,9 @@ class CampaignTest extends Testcase
         $four = $this->createCampaignWithPosts(4);
         $five = $this->createCampaignWithPosts(5);
 
+        // We need these counter caches for this to work properly:
+        $this->artisan('campaign:refresh-counts');
+
         // First, let's get the three campaigns with the most pending posts:
         $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
         $response = $this->withAdminAccessToken()->getJson($endpoint);

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -126,7 +126,7 @@ class CampaignTest extends Testcase
         $five = $this->createCampaignWithPosts(5);
 
         // We need these counter caches for this to work properly:
-        $this->artisan('campaign:refresh-counts');
+        $this->artisan('rogue:recount');
 
         // First, let's get the three campaigns with the most pending posts:
         $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';


### PR DESCRIPTION
#### What's this PR do?
~This pull request (hopefully) fixes an issue introduced in #946. That pull request fixed the problem where campaigns with zero pending posts wouldn't be shown in the results, but introduced a new issue (only on QA! 🤔) where the list would "loop" around to the beginning like this:~

This pull request instead fixes the issue introduced in #946 by side-stepping it entirely!

This was all caused because `pending_count` would be null if there weren't yet any posts for a campaign (because we're applying this by doing a big old `SELECT COUNT(*)` on the posts table and left-joining it to campaigns). I tried a couple different ways to get `NULL` column cursors to work ([harder than you think!](https://github.com/DoSomething/rogue/pull/946)), and just couldn't get it to work. So instead I took a step back, and thought back to [this gem from Ruby on Rails](https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-counter-cache)...


So, this pull request adds a new `pending_count` (and `accepted_count`!) integer columns on each campaign, which are either updated by the `campaign:refresh-counts` scheduled job or immediately upon reviewing a post for campaign.

#### How should this be reviewed?
Ignore the first few commits! The fun stuff starts here:

🥞 Adds the `pending_count` and `accepted_count` columns to the database. d41a51b

📬 Adds model events & a scheduled job to actually write to them. 34a217c

#### Any background context you want to provide?
I snuck in an unrelated fix in eb2a61786ceb9feea0d7d157990b2f23816f7b33 to stop referencing an image on `twooter.biz` that was 1) 404ing and 2) prohibited since it's `http://` and we're `https://`.

#### Relevant tickets
[#169683587](https://www.pivotaltracker.com/story/show/169683587)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
