### PR TITLE
Fix some issues with counter cache.

### DIFF
--- a/app/Console/Commands/RecountPostsCommand.php
+++ b/app/Console/Commands/RecountPostsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Console\Commands;
 
+use Rogue\Models\Post;
 use Rogue\Models\Campaign;
 use Illuminate\Console\Command;
 
@@ -38,9 +39,32 @@ class RecountPostsCommand extends Command
      */
     public function handle()
     {
-        foreach (Campaign::cursor() as $campaign) {
-            $this->line('Refreshing cached post counts for ' . $campaign->id . '.');
-            $campaign->refreshCounts();
+        $pendingCounts = (new Post)->newModelQuery()
+            ->selectRaw('campaign_id, count(*) as count')
+            ->whereReviewable()->where('status', 'pending')
+            ->groupBy('campaign_id')
+            ->get();
+
+        foreach ($pendingCounts as $pending) {
+            $campaign = Campaign::find($pending->campaign_id);
+            if ($campaign) {
+                $campaign->pending_count = $pending->count;
+                $campaign->save();
+            }
+        }
+
+        $acceptedCounts = (new Post)->newModelQuery()
+            ->selectRaw('campaign_id, count(*) as count')
+            ->whereReviewable()->where('status', 'accepted')
+            ->groupBy('campaign_id')
+            ->get();
+
+        foreach ($acceptedCounts as $accepted) {
+            $campaign = Campaign::find($accepted->campaign_id);
+            if ($campaign) {
+                $campaign->accepted_count = $accepted->count;
+                $campaign->save();
+            }
         }
     }
 }

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -66,17 +66,8 @@ class CampaignsController extends ApiController
      * @param  \Rogue\Models\Campaign  $campaign
      * @return \Illuminate\Http\Response
      */
-    public function show($id, Request $request)
+    public function show(Campaign $campaign, Request $request)
     {
-        $query = $this->newQuery(Campaign::class);
-
-        $includePendingCount = str_contains($request->query('include'), 'pending_count');
-        if ($includePendingCount && is_staff_user()) {
-            $query->withPendingPostCount();
-        }
-
-        $campaign = $query->findOrFail($id);
-
         return $this->item($campaign);
     }
 }

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -41,7 +41,7 @@ trait HasCursor
 
         // If we're sorting by anything other than ID, things get a lil' tricky. First,
         // we'll extract the sorted column & direction from the `?orderBy` query string:
-        if ($orderBy && $orderBy !== 'id,asc' && $sortCursor) {
+        if ($orderBy && $orderBy !== 'id,asc' && ! is_null($sortCursor)) {
             [ $column, $direction ] = explode(',', $orderBy, 2);
             $operator = $direction === 'asc' ? '>' : '<';
 

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -140,14 +140,14 @@ const CampaignsTable = ({ isOpen, filter }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td colSpan="4">
+              <td colSpan="5">
                 <div className="spinner margin-horizontal-auto margin-vertical" />
               </td>
             </tr>
           ) : null}
           {hasNextPage ? (
             <tr>
-              <td colSpan="4">
+              <td colSpan="5">
                 <button
                   className="button -tertiary"
                   onClick={handleViewMore}

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -13,7 +13,7 @@ const CAMPAIGNS_QUERY = gql`
       isOpen: $isOpen
       orderBy: "pending_count,desc"
       after: $cursor
-      first: 15
+      first: 80
     ) {
       edges {
         cursor

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -21,6 +21,7 @@ const CAMPAIGNS_QUERY = gql`
           id
           internalTitle
           pendingCount
+          acceptedCount
           causes {
             name
           }
@@ -111,6 +112,7 @@ const CampaignsTable = ({ isOpen, filter }) => {
           <tr>
             <td>Campaign</td>
             <td>Pending</td>
+            <td>Accepted</td>
             <td></td>
             <td></td>
           </tr>
@@ -124,7 +126,8 @@ const CampaignsTable = ({ isOpen, filter }) => {
                   <code className="footnote">({node.id})</code>
                 </Link>
               </td>
-              <td>{node.pendingCount || 0}</td>
+              <td>{node.pendingCount}</td>
+              <td>{node.acceptedCount}</td>
               <td>
                 <Link to={`/campaigns/${node.id}/pending`}>review</Link>
               </td>

--- a/resources/assets/components/ReviewButton.js
+++ b/resources/assets/components/ReviewButton.js
@@ -26,6 +26,16 @@ const ReviewButton = ({ post, status, children }) => {
       id: post.id,
       status: status,
     },
+    // We'll optimistically update the interface with the given status
+    // before waiting for the full network round-trip. Snappy!
+    optimisticResponse: {
+      __typename: 'Mutation',
+      reviewPost: {
+        __typename: 'Post',
+        id: post.id,
+        status: status,
+      },
+    },
   });
 
   const statusClass = `-${status.toLowerCase()}`;


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes some issues with the new counter caches added in #947:

🔃 Fixes an issue where paginated lists would continually loop back to the beginning. This turned out to be a frustratingly simple bug – we were checking if the cursor was "truthy" (rather than just whether it existed), and so a cursor value of `0` was the same as saying "no cursor". 68c682e

🐎 The "recount" query for each campaign takes about a second to run, which is not too bad when re-calculating this for a single campaign when someone reviews a post… but [quite slow](https://my.papertrailapp.com/events?focus=1131997651941478401&q=program%3Aapp%2Fscheduler.7334&selected=1131997534979104772) when trying to do it for over 700 campaigns on a schedule!

🍃 It also removes the heavy query to include a on-demand `pending_count` on the `campaigns/:id` API endpoint, since we store this using the counter cache. 7e966a8


Finally, I included three quick quality-of-life improvements:

✅ Adds the count of "accepted" posts for each campaign to the index! We had to remove this a while back when performance was suffering, but we can now add it without a penalty. 8db90c0

🔢 Loads 80 campaigns per page instead of 15. This should make it quicker for campaign leads to find campaigns with less round-trip "search" queries to the backend. 02c245f

🚀 Optimistically render any changed "review" status (so a post will appear to be accepted or rejected immediately). This makes the interface feel a lot more snappy, especially since the real backend request now takes an extra 1-2 seconds to refresh the counter cache. 7b9eb73

#### How should this be reviewed?
I'd recommend reviewing these commit-by-commit (linked above).

#### Any background context you want to provide?
Hopefully this is the last of the Rogue fixes! 🤞

#### Relevant tickets
[#169683587](https://www.pivotaltracker.com/story/show/169683587)