### PR TITLE
Allow users to choose how to sort campaigns.

### DIFF
--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -291,7 +291,32 @@ $accepted-green: #80e85d;
   }
 }
 
+// Arrow helpers:
+.arrow-up:after,
+.arrow-down:after {
+  content: '';
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
+.arrow-up:after {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 6px solid $med-gray;
+}
+
+.arrow-down:after {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid $med-gray;
+}
+
 // Tailwind helpers:
+.cursor-pointer {
+  cursor: pointer !important;
+}
+
 .mb-4 {
   margin-bottom: $base-spacing !important;
 }

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -1,17 +1,22 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { Link } from 'react-router-dom';
-import React, { useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+import React, { useState, useEffect } from 'react';
 
 import Empty from './Empty';
 import { updateQuery } from '../helpers';
+import OrderableHeading from './utilities/OrderableHeading';
 
 const CAMPAIGNS_QUERY = gql`
-  query CampaignsIndexQuery($isOpen: Boolean!, $cursor: String) {
+  query CampaignsIndexQuery(
+    $isOpen: Boolean!
+    $orderBy: String!
+    $cursor: String
+  ) {
     campaigns: paginatedCampaigns(
       isOpen: $isOpen
-      orderBy: "pending_count,desc"
+      orderBy: $orderBy
       after: $cursor
       first: 80
     ) {
@@ -73,8 +78,10 @@ const filterCampaigns = (data, filter) => {
  * @param {String} filter
  */
 const CampaignsTable = ({ isOpen, filter }) => {
+  const [orderBy, setOrderBy] = useState('pending_count,desc');
+
   const { error, loading, data, fetchMore } = useQuery(CAMPAIGNS_QUERY, {
-    variables: { isOpen },
+    variables: { isOpen, orderBy },
     notifyOnNetworkStatusChange: true,
   });
 
@@ -110,9 +117,24 @@ const CampaignsTable = ({ isOpen, filter }) => {
       <table className="table">
         <thead>
           <tr>
-            <td>Campaign</td>
-            <td>Pending</td>
-            <td>Accepted</td>
+            <OrderableHeading
+              column="id"
+              label="Campaign ID"
+              orderBy={orderBy}
+              onChange={setOrderBy}
+            />
+            <OrderableHeading
+              column="pending_count"
+              label="Pending"
+              orderBy={orderBy}
+              onChange={setOrderBy}
+            />
+            <OrderableHeading
+              column="accepted_count"
+              label="Accepted"
+              orderBy={orderBy}
+              onChange={setOrderBy}
+            />
             <td></td>
             <td></td>
           </tr>

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -6,7 +6,7 @@ import React, { useState, useEffect } from 'react';
 
 import Empty from './Empty';
 import { updateQuery } from '../helpers';
-import OrderableHeading from './utilities/OrderableHeading';
+import SortableHeading from './utilities/SortableHeading';
 
 const CAMPAIGNS_QUERY = gql`
   query CampaignsIndexQuery(
@@ -117,19 +117,19 @@ const CampaignsTable = ({ isOpen, filter }) => {
       <table className="table">
         <thead>
           <tr>
-            <OrderableHeading
+            <SortableHeading
               column="id"
               label="Campaign ID"
               orderBy={orderBy}
               onChange={setOrderBy}
             />
-            <OrderableHeading
+            <SortableHeading
               column="pending_count"
               label="Pending"
               orderBy={orderBy}
               onChange={setOrderBy}
             />
-            <OrderableHeading
+            <SortableHeading
               column="accepted_count"
               label="Accepted"
               orderBy={orderBy}

--- a/resources/assets/components/utilities/OrderableHeading.js
+++ b/resources/assets/components/utilities/OrderableHeading.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import classNames from 'classnames';
+
+const OrderableHeading = ({ column, orderBy, onChange, label }) => {
+  const [currentColumn, direction] = orderBy.split(',', 2);
+
+  // Determine if we should show an "arrow" indicator:
+  const isSorting = column == currentColumn;
+  const sortClass = classNames({
+    'arrow-up': isSorting && direction === 'asc',
+    'arrow-down': isSorting && direction === 'desc',
+  });
+
+  // If we click, should we swap direction?
+  const otherDirection = direction === 'asc' ? 'desc' : 'asc';
+  const newDirection = isSorting ? otherDirection : 'desc';
+
+  return (
+    <td
+      className="cursor-pointer"
+      onClick={() => onChange(`${column},${newDirection}`)}
+    >
+      <span className={sortClass}>{label}</span>
+    </td>
+  );
+};
+
+export default OrderableHeading;

--- a/resources/assets/components/utilities/SortableHeading.js
+++ b/resources/assets/components/utilities/SortableHeading.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const OrderableHeading = ({ column, orderBy, onChange, label }) => {
+const SortableHeading = ({ column, orderBy, onChange, label }) => {
   const [currentColumn, direction] = orderBy.split(',', 2);
 
   // Determine if we should show an "arrow" indicator:
@@ -25,4 +25,4 @@ const OrderableHeading = ({ column, orderBy, onChange, label }) => {
   );
 };
 
-export default OrderableHeading;
+export default SortableHeading;


### PR DESCRIPTION
#### What's this PR do?
This pull request adds the ability to choose the order that campaigns are sorted on the index (either by ID, pending count, or accepted count). This makes it easy to find, say, the newest campaigns (by sorting `id,desc`) or most popular campaigns (by sorting `accepted_count,desc`).

![sort-columns](https://user-images.githubusercontent.com/583202/68964201-c5a34a80-07a6-11ea-9e43-aac75c85930b.gif)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This was quick to add & should help address some of the issues campaign leads have raised with finding campaigns that aren't near the top of the list.

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
