### PR TITLE
Add school_id to posts

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -42,6 +42,7 @@ class PostRequest extends Request
             'text' => 'nullable|string|max:500',
             'location' => 'nullable|iso3166',
             'postal_code' => 'nullable|max:10',
+            'school_id' => 'nullable|string|max:255',
             'quantity' => 'nullable|integer',
             'file' => 'image|dimensions:min_width='.$minImageSize['width'].',min_height='.$minImageSize['height'].',max_width='.$maxImageSize['width'].',max_height='.$maxImageSize['height'],
             'status' => $this->getStatusRules($this->type),
@@ -62,6 +63,7 @@ class PostRequest extends Request
             'location' => 'nullable|iso3166',
             'quantity' => 'nullable|integer',
             'status' => $this->getStatusRules($this->post->type),
+            'school_id' => 'nullable|string|max:255',
         ];
     }
 

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -66,6 +66,7 @@ class PostTransformer extends TransformerAbstract
             $response['source_details'] = $post->source_details;
             $response['remote_addr'] = '0.0.0.0';
             $response['details'] = $post->details;
+            $response['school_id'] = $post->school_id;
         }
 
         return $response;

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -47,7 +47,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'location', 'postal_code'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'location', 'postal_code', 'school_id'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -308,6 +308,7 @@ class Post extends Model
             'source' => $this->source,
             'source_details' => $this->source_details,
             'details' => $this->details,
+            'school_id' => $this->school_id,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
             'deleted_at' => $this->deleted_at ? $this->deleted_at->toIso8601String() : null,

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -96,6 +96,7 @@ class PostRepository
             'text' => isset($data['text']) ? $data['text'] : null,
             'location' => isset($data['location']) ? $data['location'] : null,
             'postal_code' => isset($data['postal_code']) ? $data['postal_code'] : null,
+            'school_id' => isset($data['school_id']) ? $data['school_id'] : null,
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,

--- a/database/migrations/2019_11_18_101100_add_school_id_to_posts.php
+++ b/database/migrations/2019_11_18_101100_add_school_id_to_posts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSchoolIdToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('school_id', 255)->nullable()->after('postal_code')->nullable()->comment('The school ID the post is associated with.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('school_id');
+        });
+    }
+}

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -91,6 +91,7 @@ Example Response:
             "status": "accepted",
             "location": "US-NY",
             "location_name": "New York",
+            "school_id": null,
             "created_at": "2016-11-30T21:21:24+00:00",
             "updated_at": "2017-08-02T14:11:26+00:00"
         },
@@ -114,6 +115,7 @@ Example Response:
             "status": "accepted",
             "location": "US-NY",
             "location_name": "New York",
+            "school_id": null,
             "created_at": "2016-02-10T16:19:25+00:00",
             "updated_at": "2017-08-02T14:11:35+00:00"
             "action_details": {
@@ -179,6 +181,7 @@ Example Response:
     "status": "accepted",
     "location": "US-NY",
     "location_name": "New York",
+    "school_id": "3600052",
     "created_at": "2019-01-23T19:42:07+00:00",
     "updated_at": "2019-01-23T19:42:07+00:00"
     "action_details": {
@@ -232,6 +235,8 @@ Optional params:
   Option to set status upon creation if admin uploads post for user.
 - **location** (string).
   The The ISO 3166-2 region code this was submitted from, e.g. `US-NY`.
+- **school_id** (string).
+  The school ID this post should be associated with.
 - **details** (json).
   A JSON field to store extra details about a post.
 - **dont_send_to_blink** (boolean).
@@ -270,6 +275,7 @@ Example Response:
     "status": "pending",
     "location": "US-NY",
     "location_name": "New York",
+    "school_id": "3600052",
     "created_at": "2018-12-06T21:44:15+00:00",
     "updated_at": "2018-12-06T21:44:15+00:00",
     "tags": [],

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1219,15 +1219,14 @@ class PostTest extends TestCase
     }
 
     /**
-     * Test for updating a post successfully.
+     * Test for updating a post with invalid status.
      *
-     * PATCH /api/v3/posts/186
+     * PATCH /api/v3/posts/:id
      * @return void
      */
-    public function testUpdatingAPhotoWithBadStatus()
+    public function testUpdatingAPhotoWithInvalidStatus()
     {
         $post = factory(Post::class)->create();
-        $signup = $post->signup;
 
         $this->mock(Blink::class)->shouldReceive('userSignupPost');
 
@@ -1238,6 +1237,25 @@ class PostTest extends TestCase
         ]);
 
         $response->assertJsonValidationErrors(['status']);
+    }
+
+    /**
+     * Test for updating a post with invalid school_id.
+     *
+     * PATCH /api/v3/posts/:id
+     * @return void
+     */
+    public function testUpdatingAPhotoWithInvalidSchoolId()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
+            'school_id' => 8,
+        ]);
+
+        $response->assertJsonValidationErrors(['school_id']);
     }
 
     /**

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1190,7 +1190,7 @@ class PostTest extends TestCase
     /**
      * Test for updating a post successfully.
      *
-     * PATCH /api/v3/posts/186
+     * PATCH /api/v3/posts/:id
      * @return void
      */
     public function testUpdatingAPhotoPost()
@@ -1204,7 +1204,7 @@ class PostTest extends TestCase
             'text' => 'new caption',
             'quantity' => 8,
             'status' => 'accepted',
-            'school_id' => '200426'
+            'school_id' => '200426',
         ]);
 
         $response->assertStatus(200);
@@ -1261,7 +1261,7 @@ class PostTest extends TestCase
     /**
      * Test for updating a post without activity scope.
      *
-     * PATCH /api/v3/posts/186
+     * PATCH /api/v3/posts/:id
      * @return void
      */
     public function testUpdatingAPostWithoutActivityScope()
@@ -1282,7 +1282,7 @@ class PostTest extends TestCase
     /**
      * Test validation for updating a post.
      *
-     * PATCH /api/v3/posts/195
+     * PATCH /api/v3/posts/:id
      * @return void
      */
     public function testValidationUpdatingAPost()
@@ -1299,7 +1299,7 @@ class PostTest extends TestCase
 
     /**
      * Test that a user can update their own post, but can't
-     * change it's review status.
+     * change its review status.
      *
      * @return void
      */

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -41,6 +41,7 @@ class PostTest extends TestCase
                 'status',
                 'details',
                 'location',
+                'school_id',
                 'source',
                 'remote_addr',
                 'created_at',
@@ -63,6 +64,7 @@ class PostTest extends TestCase
         $why_participated = $this->faker->paragraph;
         $text = $this->faker->sentence;
         $location = 'US-'.$this->faker->stateAbbr();
+        $school_id =  $this->faker->word;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Create an action to refer to.
@@ -83,6 +85,7 @@ class PostTest extends TestCase
             'why_participated' => $why_participated,
             'text'             => $text,
             'location'         => $location,
+            'school_id'        => $school_id,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
         ]);
@@ -105,6 +108,7 @@ class PostTest extends TestCase
             'action_id' => $action->id,
             'status' => 'pending',
             'location' => $location,
+            'school_id' => $school_id,
             'quantity' => $quantity,
             'details' => json_encode($details),
         ]);
@@ -294,10 +298,11 @@ class PostTest extends TestCase
             'campaign_id' => 'dog', // This should be a numeric ID.
             'signup_id' => $signup->id, // This one is okay.
             'location' => 'the world', // This should be an ISO-3166-2 code.
+            'school_id' => 234, // This should be a string.
             // and we've omitted the required 'type' and 'action' fields!
         ]);
 
-        $response->assertJsonValidationErrors(['campaign_id', 'location', 'type', 'action']);
+        $response->assertJsonValidationErrors(['campaign_id', 'location', 'type', 'action', 'school_id']);
     }
 
     /**

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1204,13 +1204,15 @@ class PostTest extends TestCase
             'text' => 'new caption',
             'quantity' => 8,
             'status' => 'accepted',
+            'school_id' => '200426'
         ]);
 
         $response->assertStatus(200);
 
-        // Make sure that the posts's new status and text gets persisted in the database.
+        // Make sure that the post's new status, text, and school_id gets persisted in the database.
         $this->assertEquals($post->fresh()->text, 'new caption');
         $this->assertEquals($post->fresh()->quantity, 8);
+        $this->assertEquals($post->fresh()->school_id, '200426');
 
         // Make sure the signup's quantity gets updated.
         $this->assertEquals($signup->fresh()->quantity, 8);

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -64,7 +64,7 @@ class PostTest extends TestCase
         $why_participated = $this->faker->paragraph;
         $text = $this->faker->sentence;
         $location = 'US-'.$this->faker->stateAbbr();
-        $school_id =  $this->faker->word;
+        $school_id = $this->faker->word;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
         // Create an action to refer to.


### PR DESCRIPTION
#### What's this PR do?

Adds a new `school_id` column, to the Posts table as well as API support to write, update, and view.

#### How should this be reviewed?

Create a post with `school_id` to verify it works. What was really tripping me up is that I can't get `PATCH /v3/posts` to work within Postman at all, but the tests are passing.

#### Any background context you want to provide?

I've been thinking about adding a field to the Actions table to indicate whether the post should collect `school_id`. It seems like the better place to save this information vs anywhere in Phoenix. This gets me thinking that perhaps the Post create/update requests would lookup the Action and only save the `school_id` value if `should_collect_school_id` is set to true ... and that way Phoenix or any other client could send `school_id` without needing to make the lookup to see if the action accepts a `school_id`. 

Another tangent is that I was trying to get a [`FakerSchoolId` class to work](https://github.com/DoSomething/rogue/commit/e51e762327b444d2875d3f6a73c93bbabd86f266), but kept getting an `InvalidArgumentException: Unknown formatter "school_id"` when I'd try to call the `$this->faker->school_id` . I left it out for now to work on figuring out how/when to send over the user school from Phoenix, but it was a bummer as it looked like this should've worked (refs  https://github.com/DoSomething/rogue/pull/352)

#### Relevant tickets
https://www.pivotaltracker.com/story/show/169549658

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
