### PR TITLE
Add school permalink

### DIFF
--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -8,6 +8,7 @@ import ShowPost from './pages/ShowPost';
 import ShowUser from './pages/ShowUser';
 import UserIndex from './pages/UserIndex';
 import ShowSignup from './pages/ShowSignup';
+import ShowSchool from './pages/ShowSchool';
 import ShowCampaign from './pages/ShowCampaign';
 import CampaignIndex from './pages/CampaignIndex';
 
@@ -37,6 +38,9 @@ const Application = () => {
           </Route>
           <Route path="/signups/:id">
             <ShowSignup />
+          </Route>
+          <Route path="/schools/:id">
+            <ShowSchool />
           </Route>
         </Switch>
       </BrowserRouter>

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -50,6 +50,12 @@ export const ReviewablePostFragment = gql`
       internalTitle
     }
 
+    schoolId
+    school {
+      id
+      name
+    }
+
     signupId
     signup {
       id
@@ -190,6 +196,7 @@ const ReviewablePost = ({ post }) => {
               Source: post.source,
               Location: post.location,
               Submitted: format(parse(post.createdAt), 'M/D/YYYY h:m:s'),
+              School: post.school ? post.school.name : '-',
             }}
           />
         </div>

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -197,7 +197,7 @@ const ReviewablePost = ({ post }) => {
               Location: post.location,
               Submitted: format(parse(post.createdAt), 'M/D/YYYY h:m:s'),
               School: post.school ? (
-                <Link to={`/schools/${post.schoolId}`}>{post.school.name}</Link>
+                <Link to={`/schools/${post.schoolId}`}>{post.schoolId}</Link>
               ) : (
                 '-'
               ),

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -196,7 +196,11 @@ const ReviewablePost = ({ post }) => {
               Source: post.source,
               Location: post.location,
               Submitted: format(parse(post.createdAt), 'M/D/YYYY h:m:s'),
-              School: post.school ? post.school.name : '-',
+              School: post.school ? (
+                <Link to={`/schools/${post.schoolId}`}>{post.school.name}</Link>
+              ) : (
+                '-'
+              ),
             }}
           />
         </div>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -19,7 +19,6 @@ const SHOW_SCHOOL_QUERY = gql`
 
 const ShowSchool = () => {
   const { id } = useParams();
-  console.log('school id', id);
   const history = useHistory();
 
   const { loading, error, data } = useQuery(SHOW_SCHOOL_QUERY, {

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import React, { useState } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import Shell from '../components/utilities/Shell';
@@ -19,7 +19,6 @@ const SHOW_SCHOOL_QUERY = gql`
 
 const ShowSchool = () => {
   const { id } = useParams();
-  const history = useHistory();
 
   const { loading, error, data } = useQuery(SHOW_SCHOOL_QUERY, {
     variables: { id },

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -1,0 +1,51 @@
+import gql from 'graphql-tag';
+import React, { useState } from 'react';
+import { useParams, useHistory } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+
+import Shell from '../components/utilities/Shell';
+import MetaInformation from '../components/utilities/MetaInformation';
+
+const SHOW_SCHOOL_QUERY = gql`
+  query ShowSchoolQuery($id: String!) {
+    school(id: $id) {
+      id
+      name
+      city
+      state
+    }
+  }
+`;
+
+const ShowSchool = () => {
+  const { id } = useParams();
+  console.log('school id', id);
+  const history = useHistory();
+
+  const { loading, error, data } = useQuery(SHOW_SCHOOL_QUERY, {
+    variables: { id },
+  });
+
+  if (error) {
+    return <Shell error={error} />;
+  }
+
+  if (loading) {
+    return <Shell title="School" loading />;
+  }
+
+  return (
+    <Shell
+      title={data.school.name}
+      subtitle={`${data.school.city}, ${data.school.state}`}
+    >
+      <div className="container__row">
+        <div className="container__block -third">
+          <MetaInformation details={{ ID: id }} />
+        </div>
+      </div>
+    </Shell>
+  );
+};
+
+export default ShowSchool;

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,9 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Posts
     Route::view('posts/{id}', 'app')->name('posts.show');
 
+    // Schools
+    Route::view('schools/{id}', 'app')->name('schools.show');
+
     // Signups
     Route::view('signups/{id}', 'app')->name('signups.show');
 });


### PR DESCRIPTION
#### What's this PR do?

This PR adds a  `schools/:id` view that shows an individual school, and links to it from a post view if the post has a school ID set (refs #951). 
#### How should this be reviewed?

* Edit existing post with a valid `school_id` e.g. `'600022'`
* Verify expected result for school permalink (e.g. rogue.test/schools/600022)

<img width="1063" alt="Screen Shot 2019-11-19 at 10 45 14 AM" src="https://user-images.githubusercontent.com/1236811/69176639-f3e09d00-0aba-11ea-8aef-bc354f04a2f7.png">

#### Any background context you want to provide?
Eventually this page can allow us to view the school's aggregate quantity per action, which we need to display in v2 School Finder (refs https://www.pivotaltracker.com/n/projects/2401401/stories/169659230)


#### Relevant tickets
https://www.pivotaltracker.com/story/show/169549658


https://www.pivotaltracker.com/n/projects/2401401/stories/169659230

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
