### PR TITLE
A few quality-of-life improvements for the campaign index.

### DIFF
--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -20,7 +20,10 @@ const Application = () => {
       <BrowserRouter>
         <Switch>
           <Route path="/campaigns" exact>
-            <CampaignIndex />
+            <CampaignIndex isOpen={true} />
+          </Route>
+          <Route path="/campaigns/closed" exact>
+            <CampaignIndex isOpen={false} />
           </Route>
           <Redirect from="/campaigns/:id" exact to="/campaigns/:id/accepted" />
           <Redirect from="/campaigns/:id/inbox" to="/campaigns/:id/pending" />

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -258,6 +258,10 @@ $accepted-green: #80e85d;
   color: $dark-gray !important;
 }
 
+.text-gray-500 {
+  color: $med-gray !important;
+}
+
 .text-red {
   color: $error-color !important;
 }
@@ -313,6 +317,10 @@ $accepted-green: #80e85d;
 }
 
 // Tailwind helpers:
+.underline {
+  text-decoration: underline !important;
+}
+
 .hover\:underline:hover {
   text-decoration: underline !important;
 }

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -313,6 +313,10 @@ $accepted-green: #80e85d;
 }
 
 // Tailwind helpers:
+.hover\:underline:hover {
+  text-decoration: underline !important;
+}
+
 .cursor-pointer {
   cursor: pointer !important;
 }

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -266,7 +266,7 @@ $accepted-green: #80e85d;
   color: $error-color !important;
 }
 
-.text-sm {
+.text-italic {
   font-style: italic !important;
 }
 

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -317,6 +317,10 @@ $accepted-green: #80e85d;
 }
 
 // Tailwind helpers:
+.text-center {
+  text-align: center !important;
+}
+
 .underline {
   text-decoration: underline !important;
 }

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -97,9 +97,9 @@ const CampaignsTable = ({ isOpen, filter }) => {
     });
   };
 
-  // If we've filtered all results & can load more, do so automatically:
+  // If we're filtering results & can load more, do so automatically:
   useEffect(() => {
-    if (noFilteredResults && hasNextPage) {
+    if (filter !== '' && hasNextPage) {
       handleViewMore();
     }
   }, [filter, endCursor]);

--- a/resources/assets/components/utilities/SortableHeading.js
+++ b/resources/assets/components/utilities/SortableHeading.js
@@ -17,7 +17,7 @@ const SortableHeading = ({ column, orderBy, onChange, label }) => {
 
   return (
     <td
-      className="cursor-pointer"
+      className="cursor-pointer hover:underline"
       onClick={() => onChange(`${column},${newDirection}`)}
     >
       <span className={sortClass}>{label}</span>

--- a/resources/assets/pages/CampaignIndex.js
+++ b/resources/assets/pages/CampaignIndex.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import Shell from '../components/utilities/Shell';
 import CampaignsTable from '../components/CampaignsTable';
 
-const CampaignIndex = () => {
-  const [showClosed, setShowClosed] = useState(false);
+const CampaignIndex = ({ isOpen }) => {
   const [filter, setFilter] = useState('');
 
   return (
@@ -22,33 +22,41 @@ const CampaignIndex = () => {
           New Campaign
         </a>
       </div>
-      <div className="container__block">
-        <h3>Open Campaigns</h3>
-        <p>These campaigns are currently accepting new submissions.</p>
-      </div>
-      <div className="container__block">
-        <CampaignsTable isOpen={true} filter={filter} />
-      </div>
-      {showClosed ? (
-        <>
-          <div className="container__block">
-            <h3>Closed Campaigns</h3>
-            <p>These campaigns are no longer accepting new submissions.</p>
-          </div>
-          <div className="container__block">
-            <CampaignsTable isOpen={false} filter={filter} />
-          </div>
-        </>
+      {isOpen ? (
+        <div className="container__block">
+          <h3>
+            Open Campaigns{' '}
+            <span className="text-gray-500">
+              {' / '}
+              <Link to="/campaigns/closed" className="text-gray-500 underline">
+                Closed Campaigns
+              </Link>
+            </span>
+          </h3>
+          <p>These campaigns are currently accepting new submissions.</p>
+        </div>
       ) : (
-        <div className="container__block form-actions">
-          <button
-            className="button -tertiary"
-            onClick={() => setShowClosed(true)}
-          >
-            show closed campaigns
-          </button>
+        <div className="container__block">
+          <h3>
+            <span className="text-gray-500">
+              <Link to="/campaigns" className="text-gray-500 underline">
+                Open Campaigns
+              </Link>
+              {' / '}
+            </span>
+            Closed Campaigns
+          </h3>
+          <p>These campaigns are no longer accepting new submissions.</p>
         </div>
       )}
+      <div className="container__block">
+        {/*  We keep two separate CampaignTable's so these can maintain independent state. */}
+        {isOpen ? (
+          <CampaignsTable isOpen={true} filter={filter} />
+        ) : (
+          <CampaignsTable isOpen={false} filter={filter} />
+        )}
+      </div>
     </Shell>
   );
 };

--- a/resources/assets/pages/CampaignIndex.js
+++ b/resources/assets/pages/CampaignIndex.js
@@ -49,6 +49,12 @@ const CampaignIndex = ({ isOpen }) => {
           <p>These campaigns are no longer accepting new submissions.</p>
         </div>
       )}
+      <div className="container__block text-center text-sm fade-in-up">
+        <mark>
+          <strong>New!</strong> You can now click table headings to sort this
+          list. Click again to sort in the opposite direction.
+        </mark>
+      </div>
       <div className="container__block">
         {/*  We keep two separate CampaignTable's so these can maintain independent state. */}
         {isOpen ? (


### PR DESCRIPTION
#### What's this PR do?
This pull request includes a few quality-of-life improvements to the campaign index:

![Screen Shot 2019-11-19 at 4 34 58 PM](https://user-images.githubusercontent.com/583202/69188601-d5929580-0aea-11ea-96a1-b766995752d8.png)

📑 Automatically loads all results when filtering, rather than stopping at the first page. This probably means we'll "over-query" more often, but fixes an awkward UX issue where it might seem like there are no results until you click "view more" a few times. 7c9db12

➖ Adds an "underline" to the table headings to better indicate that they're clickable. 08f1d67

📂 Moves the "open/closed" toggle to the top of the screen so it's not so easy to miss. 976b28c

💡 Adds a "new" callout for column sorting. Fixes [#169852017](https://www.pivotaltracker.com/story/show/169852017). 65ca1a3

✏️ Fixes a typo'd Tailwind-style classname. 445d5b6

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Hopefully this makes this a bit more user-friendly for folks.

#### Relevant tickets
[#169852017](https://www.pivotaltracker.com/story/show/169852017)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
