### PR TITLE
Fix automatic pagination of campaigns.

### DIFF
--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -99,7 +99,7 @@ const CampaignsTable = ({ isOpen, filter }) => {
 
   // If we're filtering results & can load more, do so automatically:
   useEffect(() => {
-    if (filter !== '' && hasNextPage) {
+    if (filter !== '' && !loading && hasNextPage) {
       handleViewMore();
     }
   }, [filter, endCursor]);

--- a/resources/assets/pages/CampaignIndex.js
+++ b/resources/assets/pages/CampaignIndex.js
@@ -56,12 +56,7 @@ const CampaignIndex = ({ isOpen }) => {
         </mark>
       </div>
       <div className="container__block">
-        {/*  We keep two separate CampaignTable's so these can maintain independent state. */}
-        {isOpen ? (
-          <CampaignsTable isOpen={true} filter={filter} />
-        ) : (
-          <CampaignsTable isOpen={false} filter={filter} />
-        )}
+        <CampaignsTable isOpen={isOpen} filter={filter} />
       </div>
     </Shell>
   );


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue I'd introduced in #955 where the `useEffect` hook would fire _while_ we were still loading campaigns, so we'd load results after the same cursor twice. (bba0c84)

After more testing, I also realized that I didn't need separate `CampaignsTable` components for the "open" and "closed" list after all, since Apollo will maintain both these separately paginated queries for us. (02fc96f)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🙈

#### Relevant tickets
N/A

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
