### PR TITLE
Fix some exceptions.

### DIFF
--- a/app/Http/Controllers/Web/CampaignIdsController.php
+++ b/app/Http/Controllers/Web/CampaignIdsController.php
@@ -30,6 +30,16 @@ class CampaignIdsController extends Controller
     }
 
     /**
+     * Display a listing of the resource.
+     *
+     * @param \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request) {
+        return redirect('campaigns/');
+    }
+
+    /**
      * Create a new campaign.
      */
     public function create()

--- a/app/Http/Controllers/Web/CampaignIdsController.php
+++ b/app/Http/Controllers/Web/CampaignIdsController.php
@@ -35,7 +35,8 @@ class CampaignIdsController extends Controller
      * @param \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request) {
+    public function index(Request $request)
+    {
         return redirect('campaigns/');
     }
 

--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -10,6 +10,7 @@ use League\Flysystem\Memory\MemoryAdapter;
 use League\Flysystem\Filesystem as Flysystem;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use League\Glide\Responses\LaravelResponseFactory;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ImagesController extends Controller
 {
@@ -41,7 +42,7 @@ class ImagesController extends Controller
      */
     public function show(string $hash, Request $request)
     {
-        $post = Post::fromHash($hash);
+        $post = Post::findByHashOrFail($hash);
 
         $server = ServerFactory::create([
             'response' => new LaravelResponseFactory($request),

--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -44,6 +44,10 @@ class ImagesController extends Controller
     {
         $post = Post::findByHashOrFail($hash);
 
+        if ($post->type !== 'photo') {
+            throw new ModelNotFoundException;
+        }
+
         $server = ServerFactory::create([
             'response' => new LaravelResponseFactory($request),
             'cache' => new Flysystem(new MemoryAdapter()),

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -87,7 +87,7 @@ class Post extends Model
         $result = app(Hashids::class)->decode($hash);
 
         if (empty($result)) {
-            return null;
+            throw new ModelNotFoundException;
         }
 
         return self::findOrFail($result[0]);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class Post extends Model
 {
@@ -82,7 +83,7 @@ class Post extends Model
      * @param string $hash
      * @return Post
      */
-    public static function fromHash($hash)
+    public static function findByHashOrFail($hash)
     {
         $result = app(Hashids::class)->decode($hash);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,9 +19,8 @@ $router->get('logout', 'AuthController@getLogout');
 
 // Create, update, delete campaigns via Rogue.
 // @TODO: Merge into CampaignsController, above.
-$router->resource('campaign-ids', 'CampaignIdsController', ['except' => ['index']]);
+$router->resource('campaign-ids', 'CampaignIdsController');
 $router->get('campaign-ids/{id}/actions/create', 'ActionsController@create');
-$router->redirect('campaign-ids', 'campaigns/');
 
 // Actions
 $router->resource('actions', 'ActionsController');

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,8 +19,9 @@ $router->get('logout', 'AuthController@getLogout');
 
 // Create, update, delete campaigns via Rogue.
 // @TODO: Merge into CampaignsController, above.
-$router->resource('campaign-ids', 'CampaignIdsController');
+$router->resource('campaign-ids', 'CampaignIdsController', ['except' => ['index']]);
 $router->get('campaign-ids/{id}/actions/create', 'ActionsController@create');
+$router->redirect('campaign-ids', 'campaigns/');
 
 // Actions
 $router->resource('actions', 'ActionsController');


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes some exceptions that were cluttering up our logs:

↪️ Adds a redirect from the removed `campaign-ids/` to `campaigns/`. ~e54aba2~ Tricky! The built-in `Route::redirect` captures on _any_ HTTP method, so this was messing up campaign creation. I swapped to a normal `redirect()` in the controller instead in 92cb651.

💥 Throw a "not found" exception instead of returning `null` when an invalid hash is provided. This fixes up the `Call to a member function getMediaPath() on null` errors we've been seeing. b975444

✏️ Renames `fromHash` to `findByHashOrFail` to make functionality clearer. a3dbc3e

👻 Check if a post is a photo before trying to render. If not, 404! 02dad2e

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This should reduce some noise from these alerts!

#### Relevant tickets
[#169874505](https://www.pivotaltracker.com/story/show/169874505)

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
