### PR TITLE
Adds school name to Blink payload for campaign posts

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -278,6 +278,11 @@ class Post extends Model
         // Fetch Campaign Website information via GraphQL.
         $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
 
+        // Fetch School information via GraphQL.
+        if ($this->school_id) {
+            $school = app(GraphQL::class)->getSchoolById($this->school_id);
+        }
+
         // The associated Action for this post.
         $action = $this->actionModel;
 
@@ -310,6 +315,7 @@ class Post extends Model
             'source_details' => $this->source_details,
             'details' => $this->details,
             'school_id' => $this->school_id,
+            'school_name' => isset($school) ? $school['name'] : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
             'deleted_at' => $this->deleted_at ? $this->deleted_at->toIso8601String() : null,

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -63,8 +63,6 @@ class GraphQL
      */
     public function getSchoolById($schoolId)
     {
-        info('getSchoolById '.$schoolId);
-
         $query = '
         query GetSchoolById($schoolId: String!) {
           school(id: $schoolId) {

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -54,4 +54,28 @@ class GraphQL
 
         return $this->query($query, $variables)['campaignWebsiteByCampaignId'];
     }
+
+    /**
+     * Query for a School by ID.
+     *
+     * @param  $schoolId String
+     * @return array
+     */
+    public function getSchoolById($schoolId)
+    {
+        info('getSchoolById '.$schoolId);
+
+        $query = '
+        query GetSchoolById($schoolId: String!) {
+          school(id: $schoolId) {
+            name
+          }
+        }';
+
+        $variables = [
+            'schoolId' => $schoolId,
+        ];
+
+        return $this->query($query, $variables)['school'];
+    }
 }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -50,6 +50,7 @@ $factory->define(Post::class, function (Generator $faker) {
         'url' => $url,
         'text' => $faker->sentence(),
         'location' => 'US-'.$faker->stateAbbr(),
+        'school_id' => $faker->word(),
         'source' => 'phpunit',
         'status' => 'pending',
         'quantity' => $faker->randomNumber(2),
@@ -80,6 +81,7 @@ $factory->defineAs(Post::class, 'text', function (Generator $faker) {
         'northstar_id' => $this->faker->northstar_id,
         'text' => $faker->sentence(),
         'location' => 'US-'.$faker->stateAbbr(),
+        'school_id' => $faker->word(),
         'source' => 'phpunit',
         'status' => 'pending',
     ];

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -63,6 +63,8 @@ class PostModelTest extends TestCase
         $post = factory(Post::class)->create();
         $result = $post->toBlinkPayload();
 
+        $this->assertEquals($result['campaign_slug'], 'test-example-campaign');
+        $this->assertEquals($result['campaign_title'], 'Test Example Campaign');
         $this->assertEquals($result['school_name'], 'San Dimas High School');
     }
 }

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -52,4 +52,25 @@ class PostModelTest extends TestCase
         $this->assertCount(3, $post->siblings);
         $this->assertEquals($post->signup_id, $post->siblings[0]->signup_id);
     }
+
+    /**
+     * Test expected payload for Blink.
+     *
+     * @return void
+     */
+    public function testBlinkPayload()
+    {
+        factory(Signup::class, 5)->create()
+            ->each(function ($signup) {
+                $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->create());
+            });
+
+        // Grab any old post.
+        $post = Signup::all()->first()->posts->first();
+
+        $result = $post->toBlinkPayload();
+        info('test payload', $result);
+
+        $this->assertEquals($result['school_name'], 'San Dimas High School');
+    }
 }

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -60,16 +60,8 @@ class PostModelTest extends TestCase
      */
     public function testBlinkPayload()
     {
-        factory(Signup::class, 5)->create()
-            ->each(function ($signup) {
-                $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->create());
-            });
-
-        // Grab any old post.
-        $post = Signup::all()->first()->posts->first();
-
+        $post = factory(Post::class)->create();
         $result = $post->toBlinkPayload();
-        info('test payload', $result);
 
         $this->assertEquals($result['school_name'], 'San Dimas High School');
     }

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -52,7 +52,9 @@ trait WithMocks
         // GraphQL Mock
         $this->graphqlMock = $this->mock(GraphQL::class);
         $this->graphqlMock->shouldReceive('getCampaignWebsiteByCampaignId')->andReturn(null);
-        $this->graphqlMock->shouldReceive('getSchoolById')->andReturn(null);
+        $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([
+            'name' => 'San Dimas High School',
+        ]);
     }
 
     /**

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -52,6 +52,7 @@ trait WithMocks
         // GraphQL Mock
         $this->graphqlMock = $this->mock(GraphQL::class);
         $this->graphqlMock->shouldReceive('getCampaignWebsiteByCampaignId')->andReturn(null);
+        $this->graphqlMock->shouldReceive('getSchoolById')->andReturn(null);
     }
 
     /**

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -51,7 +51,10 @@ trait WithMocks
 
         // GraphQL Mock
         $this->graphqlMock = $this->mock(GraphQL::class);
-        $this->graphqlMock->shouldReceive('getCampaignWebsiteByCampaignId')->andReturn(null);
+        $this->graphqlMock->shouldReceive('getCampaignWebsiteByCampaignId')->andReturn([
+            'title' => 'Test Example Campaign',
+            'slug' => 'test-example-campaign',
+        ]);
         $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([
             'name' => 'San Dimas High School',
         ]);


### PR DESCRIPTION
#### What's this PR do?

This PR modifies the Post `toBlinkPayload` to query GraphQL for a school's name if the post `school_id` is set, to add field into Customer.io as `school_name`.

#### How should this be reviewed?

A new (minimal) automated test! 👀 

#### Any background context you want to provide?

Coming soon: we need to abstract this GraphQL client into our PHP Gateway to get the school name over to a Customer.io user profile in Northstar.

#### Relevant tickets

https://www.pivotaltracker.com/story/show/169745644
