### PR TITLE
Add action permalink

### DIFF
--- a/app/Http/Controllers/Web/ActionsController.php
+++ b/app/Http/Controllers/Web/ActionsController.php
@@ -31,6 +31,18 @@ class ActionsController extends Controller
         ];
     }
 
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\View\View
+     */
+    public function show($id, Request $request)
+    {
+        return response()->view('app', ['actions.show']);
+    }
+
     /**
      * Create a new action.
      */

--- a/app/Http/Controllers/Web/ActionsController.php
+++ b/app/Http/Controllers/Web/ActionsController.php
@@ -31,14 +31,12 @@ class ActionsController extends Controller
         ];
     }
 
-
     /**
      * Display the specified resource.
      *
-     * @param  int  $id
      * @return \Illuminate\View\View
      */
-    public function show($id, Request $request)
+    public function show(Request $request)
     {
         return response()->view('app', ['actions.show']);
     }

--- a/app/Http/Controllers/Web/ActionsController.php
+++ b/app/Http/Controllers/Web/ActionsController.php
@@ -121,7 +121,7 @@ class ActionsController extends Controller
         // Log that an action was updated.
         info('action_updated', ['id' => $action->id]);
 
-        return redirect()->route('campaign-ids.show', $action->campaign_id);
+        return redirect()->route('actions.show', $action->id);
     }
 
     /**

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -7,6 +7,7 @@ import graphql from './graphql';
 import ShowPost from './pages/ShowPost';
 import ShowUser from './pages/ShowUser';
 import UserIndex from './pages/UserIndex';
+import ShowAction from './pages/ShowAction';
 import ShowSignup from './pages/ShowSignup';
 import ShowSchool from './pages/ShowSchool';
 import ShowCampaign from './pages/ShowCampaign';
@@ -19,6 +20,9 @@ const Application = () => {
     <ApolloProvider client={graphql(endpoint)}>
       <BrowserRouter>
         <Switch>
+          <Route path="/actions/:id">
+            <ShowAction />
+          </Route>
           <Route path="/campaigns" exact>
             <CampaignIndex isOpen={true} />
           </Route>

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -15,9 +15,11 @@ class Action extends React.Component {
 
     return (
       <div className="container__action">
-        <div className="container__row">
-          <h2>{action.name}</h2>
-        </div>
+        {!this.props.isPermalink ? (
+          <div className="container__row">
+            <h2>{action.name}</h2>
+          </div>
+        ) : null}
         <div className="container__row">
           <ul>
             <li>
@@ -137,12 +139,14 @@ class Action extends React.Component {
               Edit Action
             </a>
 
-            <button
-              className="button delete -tertiary"
-              onClick={e => this.props.deleteAction(action.id, e)}
-            >
-              Delete Action
-            </button>
+            {!this.props.isPermalink ? (
+              <button
+                className="button delete -tertiary"
+                onClick={e => this.props.deleteAction(action.id, e)}
+              >
+                Delete Action
+              </button>
+            ) : null}
           </div>
         )}
       </div>
@@ -152,6 +156,11 @@ class Action extends React.Component {
 
 Action.propTypes = {
   action: PropTypes.object.isRequired,
+  permalink: PropTypes.bool,
+};
+
+Action.defaultProps = {
+  permalink: false,
 };
 
 export default Action;

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -17,13 +17,15 @@ class Action extends React.Component {
       <div className="container__action">
         {!this.props.isPermalink ? (
           <div className="container__row">
-            <h2>{action.name}</h2>
+            <h2>
+              <a href={`/actions/${action.id}`}>{action.name}</a>
+            </h2>
           </div>
         ) : null}
         <div className="container__row">
           <ul>
             <li>
-              <h4>ID</h4>
+              <h4>ACTION ID</h4>
               <p>{action.id}</p>
             </li>
             {action.post_type === 'phone-call' ? (

--- a/resources/assets/pages/NotFound.js
+++ b/resources/assets/pages/NotFound.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import Shell from '../components/utilities/Shell';
+
+const NotFound = ({ title, type }) => {
+  return (
+    <Shell title={title} subtitle="Not found!">
+      <div className="container__block">
+        We couldn't find that {type}. Maybe it was deleted?
+      </div>
+    </Shell>
+  );
+};
+
+export default NotFound;

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -41,7 +41,7 @@ const ShowAction = () => {
         <a href={`/campaign-ids/${campaignId}`}>{`Campaign ${campaignId}`}</a>
       }
     >
-      <Action action={data.action} campaign={{ id: campaignId }} />
+      <Action action={data.action} campaign={{ id: campaignId }} isPermalink />
     </Shell>
   );
 };

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
+import NotFound from './NotFound';
 import Action from '../components/Action';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
@@ -19,6 +20,7 @@ const SHOW_ACTION_QUERY = gql`
 
 const ShowAction = () => {
   const { id } = useParams();
+  const title = `Action #${id}`;
 
   const { loading, error, data } = useQuery(SHOW_ACTION_QUERY, {
     variables: { id: Number(id) },
@@ -29,7 +31,11 @@ const ShowAction = () => {
   }
 
   if (loading) {
-    return <Shell title="Action" loading />;
+    return <Shell title={title} loading />;
+  }
+
+  if (!data.action) {
+    return <NotFound title={title} type="action" />;
   }
 
   const { campaignId, name } = data.action;

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -1,0 +1,49 @@
+import gql from 'graphql-tag';
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+
+import Action from '../components/Action';
+import Shell from '../components/utilities/Shell';
+import MetaInformation from '../components/utilities/MetaInformation';
+
+const SHOW_ACTION_QUERY = gql`
+  query ShowActionQuery($id: Int!) {
+    action(id: $id) {
+      id
+      name
+      campaignId
+    }
+  }
+`;
+
+const ShowAction = () => {
+  const { id } = useParams();
+
+  const { loading, error, data } = useQuery(SHOW_ACTION_QUERY, {
+    variables: { id: Number(id) },
+  });
+
+  if (error) {
+    return <Shell error={error} />;
+  }
+
+  if (loading) {
+    return <Shell title="Action" loading />;
+  }
+
+  const { campaignId, name } = data.action;
+
+  return (
+    <Shell
+      title={name}
+      subtitle={
+        <a href={`/campaign-ids/${campaignId}`}>{`Campaign ${campaignId}`}</a>
+      }
+    >
+      <Action action={data.action} campaign={{ id: campaignId }} />
+    </Shell>
+  );
+};
+
+export default ShowAction;

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -35,13 +35,15 @@ const ShowAction = () => {
   const { campaignId, name } = data.action;
 
   return (
-    <Shell
-      title={name}
-      subtitle={
-        <a href={`/campaign-ids/${campaignId}`}>{`Campaign ${campaignId}`}</a>
-      }
-    >
+    <Shell title={name}>
       <Action action={data.action} campaign={{ id: campaignId }} isPermalink />
+      <ul className="form-actions margin-vertical">
+        <li>
+          <a className="button -tertiary" href={`/campaign-ids/${campaignId}`}>
+            View all Actions for Campaign {campaignId}
+          </a>
+        </li>
+      </ul>
     </Shell>
   );
 };

--- a/resources/assets/pages/ShowPost.js
+++ b/resources/assets/pages/ShowPost.js
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
+import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import ReviewablePost, {
   ReviewablePostFragment,
@@ -43,14 +44,7 @@ const ShowPost = () => {
     return <Shell error={error} />;
   }
 
-  if (!data.post)
-    return (
-      <Shell title={title} subtitle="Not found!">
-        <div className="container__block">
-          We couldn't find that post. Maybe it was deleted?
-        </div>
-      </Shell>
-    );
+  if (!data.post) return <NotFound title={title} type="post" />;
 
   const { post } = data;
   const subtitle = `${post.user.displayName} / ${post.campaign.internalTitle}`;

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -2,12 +2,14 @@
 
 @section('main_content')
 
-    @include('layouts.header', ['header' => 'Edit an Action'])
+    @include('layouts.header', ['header' => 'Edit Action'])
 
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -narrow">
-                <h1>Edit {{ $action->name }}</h1>
+                <h1>
+                    <a href="/actions/{{ $action->id }}">{{ $action->name }}</a>
+                </h1>
 
                 <form method="POST" action="{{ route('actions.update', $action->id) }}">
                     {{ csrf_field()}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,14 +23,10 @@ $router->resource('campaign-ids', 'CampaignIdsController');
 $router->get('campaign-ids/{id}/actions/create', 'ActionsController@create');
 
 // Actions
-$router->get('actions/{id}/edit', 'ActionsController@edit');
-$router->post('actions/{id}/edit', 'ActionsController@update');
+$router->resource('actions', 'ActionsController');
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
-    // Actions
-    Route::view('actions/{id}', 'app')->name('actions.show');
-
     // Campaigns
     Route::view('campaigns', 'app')->name('campaigns.index');
     Route::view('campaigns/{id}', 'app');

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,10 +23,14 @@ $router->resource('campaign-ids', 'CampaignIdsController');
 $router->get('campaign-ids/{id}/actions/create', 'ActionsController@create');
 
 // Actions
-$router->resource('actions', 'ActionsController');
+$router->get('actions/{id}/edit', 'ActionsController@edit');
+$router->post('actions/{id}/edit', 'ActionsController@update');
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
+    // Actions
+    Route::view('actions/{id}', 'app')->name('actions.show');
+
     // Campaigns
     Route::view('campaigns', 'app')->name('campaigns.index');
     Route::view('campaigns/{id}', 'app');


### PR DESCRIPTION
#### What's this PR do?

Adds a web `/actions/:id` route and a `ShowAction` page component to render a permalink view of an action. I kept navigating to this path to spot check which action I was selecting while creating different submission content types over in Phoenix for testing `school_id` collection.

<img width="1187" alt="Screen Shot 2019-11-26 at 1 46 56 PM" src="https://user-images.githubusercontent.com/1236811/69675343-40941d00-1053-11ea-8e09-72f165147067.png">


#### How should this be reviewed?
👀 

#### Any background context you want to provide?

It'd be useful to add an `Action.campaign` nested property over in GraphQL to display the campaign's internal title as well as ID

#### Relevant tickets
https://www.pivotaltracker.com/story/show/169549621/comments/209139906

#### How to deploy
https://github.com/DoSomething/rogue/blob/master/docs/development/deployments.md
