### PR TITLE
Add redirects for old `/campaign-ids` routes.

### DIFF
--- a/app/Http/Controllers/Web/ActionsController.php
+++ b/app/Http/Controllers/Web/ActionsController.php
@@ -32,16 +32,6 @@ class ActionsController extends Controller
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @return \Illuminate\View\View
-     */
-    public function show()
-    {
-        return response()->view('app', ['actions.show']);
-    }
-
-    /**
      * Create a new action.
      */
     public function create($campaignId)

--- a/app/Http/Controllers/Web/CampaignsController.php
+++ b/app/Http/Controllers/Web/CampaignsController.php
@@ -29,16 +29,6 @@ class CampaignsController extends Controller
     }
 
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        return response()->view('app', ['campaigns.index']);
-    }
-
-    /**
      * Create a new campaign.
      */
     public function create()
@@ -63,16 +53,6 @@ class CampaignsController extends Controller
         info('campaign_created', ['id' => $campaign->id]);
 
         return redirect()->route('campaigns.show', $campaign->id);
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @return \Illuminate\View\View
-     */
-    public function show()
-    {
-        return response()->view('app', ['campaigns.show']);
     }
 
     /**

--- a/app/Http/Controllers/Web/CampaignsController.php
+++ b/app/Http/Controllers/Web/CampaignsController.php
@@ -102,4 +102,17 @@ class CampaignsController extends Controller
 
         // @TODO: redirect to campaign deleted page
     }
+
+    /**
+     * Handle redirects for old routes.
+     *
+     * @param string  $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function redirect($id = '')
+    {
+        // We can't use Laravel's built-in Route::redirect here
+        // since it doesn't support redirecting with parameters:
+        return redirect('campaigns/' . $id);
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,3 +47,6 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
 Route::post('images/{postId}', 'ImagesController@update');
 Route::get('originals/{post}', 'OriginalsController@show');
 
+// Redirects for old routes:
+Route::get('campaign-ids', 'CampaignsController@redirect');
+Route::get('campaign-ids/{id}', 'CampaignsController@redirect');

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,29 +5,28 @@
  * routes are loaded by the RouteServiceProvider within a group which
  * contains the "web" middleware group. Now create something great!
  *
- * @var \Illuminate\Routing\Router $router
  * @see \Rogue\Providers\RouteServiceProvider
  */
 
 // Homepage & FAQ
-$router->view('/', 'pages.home')->middleware('guest')->name('login');
-$router->view('faq', 'pages.faq');
+Route::view('/', 'pages.home')->middleware('guest')->name('login');
+Route::view('faq', 'pages.faq');
 
 // Authentication
-$router->get('login', 'AuthController@getLogin');
-$router->get('logout', 'AuthController@getLogout');
+Route::get('login', 'AuthController@getLogin');
+Route::get('logout', 'AuthController@getLogout');
 
-// Actions
-$router->resource('actions', 'ActionsController');
-$router->get('campaigns/{id}/actions/create', 'ActionsController@create');
-
-// Campaigns
-$router->resource('campaigns', 'CampaignsController');
+// Server-rendered routes:
+// @TODO: These should be updated to client-side routes!
+Route::resource('actions', 'ActionsController', ['except' => 'show']);
+Route::get('campaigns/{id}/actions/create', 'ActionsController@create');
+Route::resource('campaigns', 'CampaignsController', ['except' => ['index', 'show']]);
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Campaigns
-    Route::view('campaigns', 'app')->name('campaigns.index');
+    Route::view('campaigns', 'app');
+    Route::view('campaigns/{id}', 'app');
     Route::view('campaigns/{id}/{status}', 'app');
 
     // Users
@@ -44,6 +43,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     Route::view('signups/{id}', 'app')->name('signups.show');
 });
 
-// Images
-$router->post('images/{postId}', 'ImagesController@update');
-$router->get('originals/{post}', 'OriginalsController@show');
+// Admin image routes:
+Route::post('images/{postId}', 'ImagesController@update');
+Route::get('originals/{post}', 'OriginalsController@show');
+


### PR DESCRIPTION
### What's this PR do?

This pull request includes some cleanup & adds redirects for the old `/campaign-ids` and `/campaign-ids/:id` routes that were refactored in #960. (They're still linked from Contentful & folks may have bookmarks saved on their machines).

### How should this be reviewed?

I did some cleanup in 0d2d5d0 (moving exclusively client-side routes so they're solely in `routes/web.php` and grouping the few remaining server-side routes). I also updated this file to use Laravel's standard `Route` facade to match the framework documentation.

Then the bug fix is in c0f333b! 🐞

### Any background context you want to provide?

I wanted to use Laravel's [`Route::redirect`](https://laravel.com/docs/5.5/routing#redirect-routes) here, but it doesn't support route arguments (for the `/campaign-ids/:id` to `/campaigns/:id` redirect). Bummer!

### Relevant tickets

References [Pivotal #170082975](https://www.pivotaltracker.com/story/show/170082975).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
