### PR TITLE
Rogue Admin cleanup

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -27,7 +27,6 @@ class RouteServiceProvider extends ServiceProvider
 
         Route::model('post', \Rogue\Models\Post::class);
         Route::model('signup', \Rogue\Models\Signup::class);
-        Route::model('campaign_id', \Rogue\Models\Campaign::class);
     }
 
     /**

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 // Post Factory
 $factory->define(Post::class, function (Generator $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
+    $faker->addProvider(new FakerSchoolId($faker));
 
     $uploadPath = $faker->file(storage_path('fixtures'));
     $upload = new UploadedFile($uploadPath, basename($uploadPath), 'image/jpeg');
@@ -50,7 +51,8 @@ $factory->define(Post::class, function (Generator $faker) {
         'url' => $url,
         'text' => $faker->sentence(),
         'location' => 'US-'.$faker->stateAbbr(),
-        'school_id' => $faker->word(),
+        // @TODO: Only set school if the action is set to collect school ID.
+        'school_id' => $this->faker->school_id,
         'source' => 'phpunit',
         'status' => 'pending',
         'quantity' => $faker->randomNumber(2),
@@ -60,6 +62,7 @@ $factory->define(Post::class, function (Generator $faker) {
 // @TODO: These should all extend a photo-less "base" post, instead.
 $factory->defineAs(Post::class, 'text', function (Generator $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
+    $faker->addProvider(new FakerSchoolId($faker));
 
     return [
         'type' => 'text',
@@ -81,7 +84,8 @@ $factory->defineAs(Post::class, 'text', function (Generator $faker) {
         'northstar_id' => $this->faker->northstar_id,
         'text' => $faker->sentence(),
         'location' => 'US-'.$faker->stateAbbr(),
-        'school_id' => $faker->word(),
+        // @TODO: Only set school if the action is set to collect school ID.
+        'school_id' => $this->faker->school_Id,
         'source' => 'phpunit',
         'status' => 'pending',
     ];

--- a/database/faker/FakerSchoolId.php
+++ b/database/faker/FakerSchoolId.php
@@ -1,0 +1,34 @@
+<?php
+
+use Faker\Provider\Base;
+
+class FakerSchoolId extends Base
+{
+    /**
+     * A selection of schools from GraphQL
+     *
+     * @var array
+     */
+    protected static $ids = [
+        '3401166',
+        '3401452',
+        '3401451',
+        '3401457',
+        '3401450',
+        '3401460',
+        '4802532',
+        '4811718',
+        '4820400',
+        '4825422',
+    ];
+
+    /**
+     * Return a random School ID.
+     *
+     * @return mixed
+     */
+    public function school_id()
+    {
+        return static::randomElement(static::$ids);
+    }
+}

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -40,6 +40,7 @@ export const ReviewablePostFragment = gql`
     deleted
 
     actionDetails {
+      id
       name
       noun
       verb
@@ -51,10 +52,6 @@ export const ReviewablePostFragment = gql`
     }
 
     schoolId
-    school {
-      id
-      name
-    }
 
     signupId
     signup {
@@ -183,12 +180,12 @@ const ReviewablePost = ({ post }) => {
             details={{
               ID: <Link to={`/posts/${post.id}`}>{post.id}</Link>,
               Campaign: (
-                <a href={`/campaign-ids/${post.campaign.id}`}>
+                <a href={`/campaigns/${post.campaign.id}`}>
                   {post.campaign.internalTitle}
                 </a>
               ),
               Action: (
-                <a href={`/campaign-ids/${post.campaign.id}#actions`}>
+                <a href={`/actions/${post.actionDetails.id}`}>
                   {post.actionDetails.name}
                 </a>
               ),
@@ -196,7 +193,7 @@ const ReviewablePost = ({ post }) => {
               Source: post.source,
               Location: post.location,
               Submitted: format(parse(post.createdAt), 'M/D/YYYY h:m:s'),
-              School: post.school ? (
+              School: post.schoolId ? (
                 <Link to={`/schools/${post.schoolId}`}>{post.schoolId}</Link>
               ) : (
                 '-'

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -60,6 +60,7 @@ export const ReviewablePostFragment = gql`
       source
     }
 
+    userId
     user {
       id
       ...UserInformation
@@ -105,7 +106,11 @@ const ReviewablePost = ({ post }) => {
       </div>
 
       <div className="container__block -third">
-        <UserInformation user={post.user} linkSignup={post.signupId}>
+        <UserInformation
+          user={post.user}
+          userId={post.userId}
+          linkSignup={post.signupId}
+        >
           {post.quantity ? (
             <Quantity
               quantity={post.quantity}
@@ -206,7 +211,7 @@ const ReviewablePost = ({ post }) => {
             title="Signup Information"
             details={{
               ID: <a href={`/signups/${post.signupId}`}>{post.signupId}</a>,
-              User: <Link to={`/users/${post.user.id}`}>{post.user.id}</Link>,
+              User: <Link to={`/users/${post.userId}`}>{post.userId}</Link>,
               Source: post.signup ? post.signup.source : '–',
             }}
           />

--- a/resources/assets/components/utilities/UserInformation.js
+++ b/resources/assets/components/utilities/UserInformation.js
@@ -53,7 +53,7 @@ const UserName = ({ user, link }) => {
   return <span>{displayName}</span>;
 };
 
-const UserInformation = ({ user, linkSignup, children }) => (
+const UserInformation = ({ user, userId, linkSignup, children }) => (
   <div>
     {!isEmpty(user) ? (
       <div className="mb-4">
@@ -81,8 +81,17 @@ const UserInformation = ({ user, linkSignup, children }) => (
           <UserLocation user={user} />
         </p>
       </div>
-    ) : null}
-
+    ) : (
+      <div className="mb-4">
+        <h2 className="heading">
+          {linkSignup ? (
+            <a href={`/signups/${linkSignup}`}>{userId}</a>
+          ) : (
+            <span>{userId}</span>
+          )}
+        </h2>
+      </div>
+    )}
     {children}
   </div>
 );

--- a/resources/assets/pages/ShowCampaign.js
+++ b/resources/assets/pages/ShowCampaign.js
@@ -4,6 +4,7 @@ import { useParams, useHistory } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import { STATUSES, TAGS } from '../helpers';
+import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import Select from '../components/utilities/Select';
 import Campaign from '../components/Campaign';
@@ -23,6 +24,7 @@ const ShowCampaign = () => {
   const { id, status } = useParams();
   const [tag, setTag] = useState('');
   const history = useHistory();
+  const title = `Campaign #${id}`;
 
   const setStatus = value => {
     history.replace(`/campaigns/${id}/${value}`);
@@ -37,12 +39,16 @@ const ShowCampaign = () => {
   }
 
   if (loading) {
-    return <Shell title="Campaign" loading />;
+    return <Shell title={title} loading />;
+  }
+
+  if (!data.campaign) {
+    return <NotFound title={title} type="campaign" />;
   }
 
   if (!status) {
     return (
-      <Shell title="Campaign" subtitle={data.campaign.internalTitle}>
+      <Shell title={title} subtitle={data.campaign.internalTitle}>
         <div className="container__row">
           <Campaign id={data.campaign.id} />
         </div>
@@ -51,7 +57,7 @@ const ShowCampaign = () => {
   }
 
   return (
-    <Shell title="Campaign" subtitle={data.campaign.internalTitle}>
+    <Shell title={title} subtitle={data.campaign.internalTitle}>
       <div className="container__row">
         <div className="container__block -third">
           <h4>Filter by status...</h4>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -37,13 +37,16 @@ const ShowSchool = () => {
   if (!data.school) return <NotFound title={title} type="school" />;
 
   return (
-    <Shell
-      title={data.school.name}
-      subtitle={`${data.school.city}, ${data.school.state}`}
-    >
+    <Shell title={title} subtitle={data.school.name}>
       <div className="container__row">
         <div className="container__block -third">
-          <MetaInformation details={{ ID: id }} />
+          <MetaInformation
+            details={{
+              ID: id,
+              City: data.school.city,
+              State: data.school.state,
+            }}
+          />
         </div>
       </div>
     </Shell>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
+import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
 
@@ -19,6 +20,7 @@ const SHOW_SCHOOL_QUERY = gql`
 
 const ShowSchool = () => {
   const { id } = useParams();
+  const title = `School #${id}`;
 
   const { loading, error, data } = useQuery(SHOW_SCHOOL_QUERY, {
     variables: { id },
@@ -29,8 +31,10 @@ const ShowSchool = () => {
   }
 
   if (loading) {
-    return <Shell title="School" loading />;
+    return <Shell title={title} loading />;
   }
+
+  if (!data.school) return <NotFound title={title} type="school" />;
 
   return (
     <Shell

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,14 +24,13 @@ Route::resource('campaigns', 'CampaignsController', ['except' => ['index', 'show
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
+    // Actions
+    Route::view('actions/{id}', 'app');
+
     // Campaigns
     Route::view('campaigns', 'app');
     Route::view('campaigns/{id}', 'app');
     Route::view('campaigns/{id}/{status}', 'app');
-
-    // Users
-    Route::view('users', 'app')->name('users.index');
-    Route::view('users/{id}', 'app')->name('users.show');
 
     // Posts
     Route::view('posts/{id}', 'app')->name('posts.show');
@@ -41,6 +40,10 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
 
     // Signups
     Route::view('signups/{id}', 'app')->name('signups.show');
+
+    // Users
+    Route::view('users', 'app')->name('users.index');
+    Route::view('users/{id}', 'app')->name('users.show');
 });
 
 // Admin image routes:

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -32,6 +32,7 @@ trait WithMocks
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
         $this->faker->addProvider(new \FakerNorthstarId($this->faker));
+        $this->faker->addProvider(new \FakerSchoolId($this->faker));
 
         // Northstar Mock
         $this->northstarMock = $this->mock(Northstar::class);


### PR DESCRIPTION
### What's this PR do?

This pull request fixes some few bugs and adds a few enhancements:

* Adds missing `/actions/:id` route - removed in #965 

* Removes deprecated `Route::model` for `campaign_id`, fixes Post links to campaigns - removed in #960 

* Adds link to the Action permalink to a Post view 

* Removes `school` field from our Post gallery GraphQL and checks for `post.schoolId` instead

* Display `NotFound` component for Campaign, School pages when invalid ID

* Adds a `FakerSchoolId` to use valid school ID's from GraphQL when creating fake posts

* Adds a `userId` prop to the `UserInformation` to use if the `user` prop is empty. The posts we generate are using fake user ID's from our dev Northstar database, but we may not have those ID's locally when working in GraphQL.

### How should this be reviewed?

👀 

### Any background context you want to provide?

The `/signup/:id` permalink also breaks when viewing activity for users that don't exist in your local Northstar DB (which they won't, once you seed your local DB with test data) -- but holding off on fixing that to keep this easier to review (and manually test).

### Relevant tickets

References https://www.pivotaltracker.com/story/show/169549761

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
