### PR TITLE
Action Stats cleanup

### DIFF
--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -33,6 +33,10 @@ class ActionStatsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, ActionStat::$indexes);
 
+       // Allow ordering results:
+        $orderBy = $request->query('orderBy');
+        $query = $this->orderBy($query, $orderBy, ActionStat::$sortable);
+
         return $this->paginatedCollection($query, $request);
     }
 }

--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -33,7 +33,7 @@ class ActionStatsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, ActionStat::$indexes);
 
-       // Allow ordering results:
+        // Allow ordering results:
         $orderBy = $request->query('orderBy');
         $query = $this->orderBy($query, $orderBy, ActionStat::$sortable);
 

--- a/app/Http/Transformers/ActionStatTransformer.php
+++ b/app/Http/Transformers/ActionStatTransformer.php
@@ -16,6 +16,7 @@ class ActionStatTransformer extends TransformerAbstract
     public function transform(ActionStat $actionStat)
     {
         return [
+            'id' => $actionStat->id,
             'action_id' => $actionStat->action_id,
             'school_id' => $actionStat->school_id,
             'accepted_quantity' => $actionStat->accepted_quantity,

--- a/app/Models/ActionStat.php
+++ b/app/Models/ActionStat.php
@@ -26,4 +26,14 @@ class ActionStat extends Model
      * @var array
      */
     public static $indexes = ['action_id', 'school_id'];
+
+    /**
+     * Attributes that can be sorted by.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $sortable = ['id', 'accepted_quantity'];
 }

--- a/database/migrations/2019_12_05_131200_add_compound_index_to_action_stats_with_accepted_quantity.php
+++ b/database/migrations/2019_12_05_131200_add_compound_index_to_action_stats_with_accepted_quantity.php
@@ -16,7 +16,6 @@ class AddCompoundIndexToActionStatsWithAcceptedQuantity extends Migration
         Schema::table('action_stats', function (Blueprint $table) {
             $table->index(['action_id', DB::raw('accepted_quantity desc')]);
         });
-
     }
 
     /**

--- a/database/migrations/2019_12_05_131200_add_compound_index_to_action_stats_with_accepted_quantity.php
+++ b/database/migrations/2019_12_05_131200_add_compound_index_to_action_stats_with_accepted_quantity.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCompoundIndexToActionStatsWithAcceptedQuantity extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_stats', function (Blueprint $table) {
+            $table->index(['action_id', DB::raw('accepted_quantity desc')]);
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_stats', function (Blueprint $table) {
+            $table->dropIndex(['action_id', DB::raw('accepted_quantity desc')]);
+        });
+    }
+}

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -60,3 +60,11 @@ These endpoints use OAuth 2 to authenticate. [More information here](https://git
 | -------------------------------- | ------------------------------------------------------ |
 | `GET /api/v3/actions`            | [Get actions](actions.md#retrieve-all-actions)         |
 | `GET /api/v3/actions/:action_id` | [Get an action](actions.md#retrieve-a-specific-action) |
+
+#### Action Stats
+
+| Endpoint                   | Functionality                       |
+| -------------------------- | ----------------------------------- |
+| `GET /api/v3/action-stats` | [Get action stats](action-stats.md) |
+
+|

--- a/docs/endpoints/action-stats.md
+++ b/docs/endpoints/action-stats.md
@@ -1,0 +1,51 @@
+## Action Stats
+
+Action stats are used to store aggregate calculations for an action and a school. They are created or updated per action and school when a post for the action that contains a school ID is reviewed.
+
+## Retrieve All Action Stats
+
+```
+GET /api/v3/action-stats
+```
+
+### Optional Query Parameters
+
+- **filter[column]** _(string)_
+  - Filter results by column. Supported columns: `action_id`, `school_id`
+  - Use commas to filter by multiple values in a column, e.g. `/actions?filter[action_id]=121,122`
+
+Example Response:
+
+```
+{
+  "data": [
+    {
+      "id": 1,
+      "action_id": 1,
+      "school_id": "3401457",
+      "accepted_quantity": 37,
+      "created_at": "2019-12-04T21:28:26+00:00",
+      "updated_at": "2019-12-04T22:33:03+00:00"
+    },
+    {
+      "id": 2,
+      "action_id": 1,
+      "school_id": "4802532",
+      "accepted_quantity": 43,
+      "created_at": "2019-12-04T22:05:29+00:00",
+      "updated_at": "2019-12-04T22:05:29+00:00"
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 2,
+      "count": 2,
+      "per_page": 20,
+      "current_page": 1,
+      "total_pages": 1,
+      "links": [
+
+      ]
+    }
+  }
+```

--- a/docs/endpoints/action-stats.md
+++ b/docs/endpoints/action-stats.md
@@ -1,6 +1,6 @@
 ## Action Stats
 
-Action stats are used to store aggregate calculations for an action and a school. They are created or updated per action and school when a post for the action that contains a school ID is reviewed.
+Action stats are used to store aggregate calculations for an action and a school. They are created or updated per action and school when a post that contains a school ID is reviewed.
 
 ## Retrieve All Action Stats
 
@@ -11,8 +11,13 @@ GET /api/v3/action-stats
 ### Optional Query Parameters
 
 - **filter[column]** _(string)_
+
   - Filter results by column. Supported columns: `action_id`, `school_id`
-  - Use commas to filter by multiple values in a column, e.g. `/actions?filter[action_id]=121,122`
+  - Use commas to filter by multiple values in a column, e.g. `/action-stats?filter[action_id]=121,122`
+
+- **orderBy** _(string)_
+  - Order results by column. Supported columns: `id`, `accepted_quantity`
+  - e.g. `/action-stats?orderBy=accepted_quantity,desc`
 
 Example Response:
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds documentation for the newly added `GET /action-stats` endpoint in #964, and makes a few tweaks:

* Returns the `id` auto-incrementing primary key. We need this for GraphQL to do its thing.

* Adds support to order by `id` and `accepted_quantity`

* Adds an index for `action_id` and descending `accepted_quantity`, which we'll want to display Action leaderboards 

### How should this be reviewed?

👀 

### Any background context you want to provide?

Will open a GraphQL PR shortly that makes use of these changes.

### Relevant tickets

References [Pivotal #169659230](https://www.pivotaltracker.com/story/show/169659230).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
