### PR TITLE
Display action stats on School, Action permalinks

### DIFF
--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -321,6 +321,10 @@ $accepted-green: #80e85d;
   text-align: center !important;
 }
 
+.capitalize {
+  text-transform: capitalize;
+}
+
 .underline {
   text-decoration: underline !important;
 }

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -321,10 +321,6 @@ $accepted-green: #80e85d;
   text-align: center !important;
 }
 
-.capitalize {
-  text-transform: capitalize;
-}
-
 .underline {
   text-decoration: underline !important;
 }

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import React, { useState } from 'react';
+import { parse, format } from 'date-fns';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -21,6 +22,7 @@ const SHOW_ACTION_QUERY = gql`
           state
         }
         acceptedQuantity
+        updatedAt
       }
     }
   }
@@ -65,7 +67,7 @@ const ShowAction = () => {
           <table className="table">
             <thead>
               <tr>
-                <td>School Name</td>
+                <td>School</td>
                 <td>Location</td>
                 <td className="capitalize">
                   {noun} {verb}
@@ -87,6 +89,10 @@ const ShowAction = () => {
                   </td>
                   <td>
                     <strong>{item.acceptedQuantity}</strong>
+                    <div className="text-sm">
+                      Last reviewed{' '}
+                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm:s')}
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -9,6 +9,7 @@ import Action, { ActionFragment } from '../components/Action';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
 
+// @TODO: Add support for paging through schoolActionStats once posts with school get reviewed.
 const SHOW_ACTION_QUERY = gql`
   query ShowActionQuery($id: Int!) {
     action(id: $id) {

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -12,6 +12,18 @@ const SHOW_ACTION_QUERY = gql`
   query ShowActionQuery($id: Int!) {
     action(id: $id) {
       ...ActionFragment
+      schoolActionStats {
+        id
+        schoolId
+        school {
+          id
+          name
+          city
+          state
+        }
+        acceptedQuantity
+        updatedAt
+      }
     }
   }
   ${ActionFragment}
@@ -37,7 +49,7 @@ const ShowAction = () => {
     return <NotFound title={title} type="action" />;
   }
 
-  const { campaign, name } = data.action;
+  const { campaign, name, noun, schoolActionStats, verb } = data.action;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -49,6 +61,41 @@ const ShowAction = () => {
           </a>
         </li>
       </ul>
+      {schoolActionStats.length ? (
+        <div className="mb-4">
+          <h2>Schools</h2>
+          <table className="table">
+            <thead>
+              <tr>
+                <td>School Name</td>
+                <td>Location</td>
+                <td>
+                  {noun} {verb}
+                </td>
+              </tr>
+            </thead>
+            <tbody>
+              {schoolActionStats.map(item => (
+                <tr key={item.id}>
+                  <td>
+                    <strong>
+                      <a href={`/schools/${item.school.id}`}>
+                        {item.school.name}
+                      </a>
+                    </strong>
+                  </td>
+                  <td>
+                    {item.school.city}, {item.school.state}
+                  </td>
+                  <td>
+                    <strong>{item.acceptedQuantity}</strong>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
     </Shell>
   );
 };

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -69,7 +69,7 @@ const ShowAction = () => {
               <tr>
                 <td>School Name</td>
                 <td>Location</td>
-                <td>
+                <td className="capitalize">
                   {noun} {verb}
                 </td>
               </tr>

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -91,7 +91,7 @@ const ShowAction = () => {
                     <strong>{item.acceptedQuantity}</strong>
                     <div className="text-sm">
                       Last reviewed{' '}
-                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm:s')}
+                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
                     </div>
                   </td>
                 </tr>

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -32,6 +32,7 @@ const SHOW_ACTION_QUERY = gql`
 const ShowAction = () => {
   const { id } = useParams();
   const title = `Action #${id}`;
+  document.title = title;
 
   const { loading, error, data } = useQuery(SHOW_ACTION_QUERY, {
     variables: { id: Number(id) },

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -13,7 +13,6 @@ const SHOW_ACTION_QUERY = gql`
     action(id: $id) {
       ...ActionFragment
       schoolActionStats {
-        id
         schoolId
         school {
           id
@@ -22,7 +21,6 @@ const SHOW_ACTION_QUERY = gql`
           state
         }
         acceptedQuantity
-        updatedAt
       }
     }
   }
@@ -76,7 +74,7 @@ const ShowAction = () => {
             </thead>
             <tbody>
               {schoolActionStats.map(item => (
-                <tr key={item.id}>
+                <tr key={item.school.id}>
                   <td>
                     <strong>
                       <a href={`/schools/${item.school.id}`}>

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -90,8 +90,7 @@ const ShowAction = () => {
                   <td>
                     <strong>{item.acceptedQuantity}</strong>
                     <div className="text-sm">
-                      Last reviewed{' '}
-                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
+                      Updated {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
                     </div>
                   </td>
                 </tr>

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -64,14 +64,18 @@ const ShowAction = () => {
       </ul>
       {schoolActionStats.length ? (
         <div className="mb-4">
-          <h2>Schools</h2>
+          <h3>School Leaderboard</h3>
+          <p className="mb-4">
+            These totals are updated any time a Review is created for a Post
+            that is associated with this Action and the User's School.
+          </p>
           <table className="table">
             <thead>
               <tr>
                 <td>School</td>
                 <td>Location</td>
-                <td className="capitalize">
-                  {noun} {verb}
+                <td className="text-center">
+                  Total approved {noun} {verb}
                 </td>
               </tr>
             </thead>
@@ -88,7 +92,7 @@ const ShowAction = () => {
                   <td>
                     {item.school.city}, {item.school.state}
                   </td>
-                  <td>
+                  <td className="text-center">
                     <strong>{item.acceptedQuantity}</strong>
                     <div className="text-sm">
                       Updated {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}

--- a/resources/assets/pages/ShowCampaign.js
+++ b/resources/assets/pages/ShowCampaign.js
@@ -25,6 +25,7 @@ const ShowCampaign = () => {
   const [tag, setTag] = useState('');
   const history = useHistory();
   const title = `Campaign #${id}`;
+  document.title = title;
 
   const setStatus = value => {
     history.replace(`/campaigns/${id}/${value}`);

--- a/resources/assets/pages/ShowPost.js
+++ b/resources/assets/pages/ShowPost.js
@@ -31,6 +31,7 @@ const SHOW_POST_QUERY = gql`
 const ShowPost = () => {
   const { id } = useParams();
   const title = `Post #${id}`;
+  document.title = title;
 
   const { loading, error, data } = useQuery(SHOW_POST_QUERY, {
     variables: { id: Number(id) },

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -80,7 +80,7 @@ const ShowSchool = () => {
               <tr>
                 <td>Action</td>
                 <td>Campaign</td>
-                <td className="text-center">Total Approved Quantity</td>
+                <td className="text-center">Total approved quantity</td>
               </tr>
             </thead>
             <tbody>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -8,6 +8,7 @@ import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
 
+// @TODO: Add support for paging through schoolActionStats once more actions collect school.
 const SHOW_SCHOOL_QUERY = gql`
   query ShowSchoolQuery($id: String!) {
     school(id: $id) {

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import React, { useState } from 'react';
+import { parse, format } from 'date-fns';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -14,6 +15,16 @@ const SHOW_SCHOOL_QUERY = gql`
       name
       city
       state
+      schoolActionStats {
+        action {
+          id
+          name
+          noun
+          verb
+        }
+        acceptedQuantity
+        updatedAt
+      }
     }
   }
 `;
@@ -36,17 +47,53 @@ const ShowSchool = () => {
 
   if (!data.school) return <NotFound title={title} type="school" />;
 
+  const { city, name, schoolActionStats, state } = data.school;
+
   return (
-    <Shell title={title} subtitle={data.school.name}>
+    <Shell title={title} subtitle={name}>
       <div className="container__row">
-        <div className="container__block -third">
+        <div className="container__block">
           <MetaInformation
             details={{
               ID: id,
-              City: data.school.city,
-              State: data.school.state,
+              City: city,
+              State: state,
             }}
           />
+        </div>
+      </div>
+      <div className="container__row">
+        <div className="container__block">
+          <h2>Actions</h2>
+          <table className="table">
+            <thead>
+              <tr>
+                <td>Action</td>
+                <td>Impact</td>
+              </tr>
+            </thead>
+            <tbody>
+              {schoolActionStats.map(item => (
+                <tr key={item.action.id}>
+                  <td>
+                    <strong>
+                      <a href={`/actions/${item.action.id}`}>
+                        {item.action.name}
+                      </a>
+                    </strong>
+                  </td>
+                  <td>
+                    <strong>{item.acceptedQuantity}</strong> {item.action.noun}{' '}
+                    {item.action.verb}
+                    <div className="text-sm">
+                      Last reviewed{' '}
+                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm:s')}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </Shell>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -87,7 +87,7 @@ const ShowSchool = () => {
                     {item.action.verb}
                     <div className="text-sm">
                       Last reviewed{' '}
-                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm:s')}
+                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
                     </div>
                   </td>
                 </tr>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -86,8 +86,7 @@ const ShowSchool = () => {
                     <strong>{item.acceptedQuantity}</strong> {item.action.noun}{' '}
                     {item.action.verb}
                     <div className="text-sm">
-                      Last reviewed{' '}
-                      {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
+                      Updated {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
                     </div>
                   </td>
                 </tr>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -32,6 +32,7 @@ const SHOW_SCHOOL_QUERY = gql`
 const ShowSchool = () => {
   const { id } = useParams();
   const title = `School #${id}`;
+  document.title = title;
 
   const { loading, error, data } = useQuery(SHOW_SCHOOL_QUERY, {
     variables: { id },

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -21,6 +21,10 @@ const SHOW_SCHOOL_QUERY = gql`
           name
           noun
           verb
+          campaign {
+            id
+            internalTitle
+          }
         }
         acceptedQuantity
         updatedAt
@@ -65,25 +69,33 @@ const ShowSchool = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <h2>Actions</h2>
+          <h3>Aggregate Impact</h3>
+          <p className="mb-4">
+            These totals are updated any time a Review is created for a Post
+            that is associated with this School.
+          </p>
           <table className="table">
             <thead>
               <tr>
                 <td>Action</td>
-                <td>Impact</td>
+                <td>Campaign</td>
+                <td className="text-center">Total Approved Quantity</td>
               </tr>
             </thead>
             <tbody>
               {schoolActionStats.map(item => (
                 <tr key={item.action.id}>
                   <td>
-                    <strong>
-                      <a href={`/actions/${item.action.id}`}>
-                        {item.action.name}
-                      </a>
-                    </strong>
+                    <a href={`/actions/${item.action.id}`}>
+                      {item.action.name}
+                    </a>
                   </td>
                   <td>
+                    <a href={`/campaigns/${item.action.campaign.id}`}>
+                      {item.action.campaign.internalTitle}
+                    </a>
+                  </td>
+                  <td className="text-center">
                     <strong>{item.acceptedQuantity}</strong> {item.action.noun}{' '}
                     {item.action.verb}
                     <div className="text-sm">


### PR DESCRIPTION
### What's this PR do?

This pull request uses the `schoolActionStats` GraphQL queries introduced over in https://github.com/DoSomething/graphql/pull/182 to display a School Leaderboard for Actions, and an Aggregate Impact section for Schools.

It also gets started on changing the HTML document title for the different page views, to help remember why you have 13 tabs that say "Rogue" open.

### How should this be reviewed?

👀 

Action permalink:

<img width="1213" alt="Screen Shot 2019-12-06 at 11 15 11 AM" src="https://user-images.githubusercontent.com/1236811/70349526-b9486580-1819-11ea-97bb-7f7abeaf6064.png">

School permalink:

<img width="1211" alt="Screen Shot 2019-12-06 at 11 16 18 AM" src="https://user-images.githubusercontent.com/1236811/70349597-dc731500-1819-11ea-919b-ffacee4c6ce1.png">


### Any background context you want to provide?

Eventually want to add fake `ActionStat` data into our `db:seed` Artisan command, which will make it a lot easier to 👀 locally. (I've been manually reviewing reportbacks locally to populate the `action-stats` table)

### Relevant tickets

References [Pivotal #169659230](https://www.pivotaltracker.com/story/show/169659230).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
