### PR TITLE
Fix order of operations for updating Campaign post counts

### DIFF
--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -55,11 +55,9 @@ class ModelServiceProvider extends ServiceProvider
             ]);
         });
 
-        // When Reviews are saved create an event for them.
+        // When a Review is saved, create an event.
         Review::saved(function ($review) {
             info('review', ['campaign' => $review->post->campaign_id]);
-            // Update the "counter cache" on this campaign:
-            $review->post->campaign->refreshCounts();
 
             $review->events()->create([
                 'content' => $review->toJson(),

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -55,7 +55,7 @@ class ModelServiceProvider extends ServiceProvider
             ]);
         });
 
-        // When a Review is saved, create an event.
+        // When Reviews are saved create an event for them.
         Review::saved(function ($review) {
             info('review', ['campaign' => $review->post->campaign_id]);
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -175,7 +175,7 @@ class PostRepository
     }
 
     /**
-     * Updates a post's status after being reviewed and updates aggregate information.
+     * Creates a Review for the Post, then updates Post status and re-aggregates.
      *
      * @param array Post $post
      * @param string $status

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -175,7 +175,7 @@ class PostRepository
     }
 
     /**
-     * Updates a post's status after being reviewed.
+     * Updates a post's status after being reviewed and updates aggregate information.
      *
      * @param array Post $post
      * @param string $status
@@ -200,7 +200,10 @@ class PostRepository
         $post->status = $status;
         $post->save();
 
-        // If the Post has a school ID, update School's aggregate impact for the Action.
+        // Update the "counter cache" on the Post Campaign:
+        $post->campaign->refreshCounts();
+
+        // If the Post has a School ID, upsert an ActionStat.
         if ($post->school_id && $post->action_id) {
             ActionStat::updateOrCreate(
                 ['action_id' => $post->action_id, 'school_id' => $post->school_id],

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -10,43 +10,70 @@ use Rogue\Jobs\SendReviewedPostToCustomerIo;
 class ReviewsTest extends TestCase
 {
     /**
-     * Test that a POST request to /reviews updates the post's status.
+     * Test that a POST request to /reviews updates the post's status and agggregate data.
      *
      * POST /reviews
      * @return void
      */
-    public function testPostingASingleReview()
+    public function testPostingReviews()
     {
         Bus::fake();
 
         // Create a post.
         $northstarId = $this->faker->northstar_id;
+        $schoolId = $this->faker->school_id;
 
-        $post = factory(Post::class)->create();
+        $firstPost = factory(Post::class)->create([
+            'school_id' => $schoolId,
+        ]);
+        $actionId = $firstPost->action_id;
+        $campaignId = $firstPost->campaign->id;
 
-        $response = $this->withAccessToken($northstarId, 'admin')->postJson('api/v3/posts/' . $post->id . '/reviews', [
+        $response = $this->withAccessToken($northstarId, 'admin')->postJson('api/v3/posts/' . $firstPost->id . '/reviews', [
             'status' => 'accepted',
-            'comment' => 'testing',
+            'comment' => 'Testing 1st review',
         ]);
 
         $response->assertStatus(201);
         Bus::assertDispatched(SendReviewedPostToCustomerIo::class);
 
-
-        $this->assertEquals('accepted', $post->fresh()->status);
+        $this->assertEquals('accepted', $firstPost->fresh()->status);
         $this->assertDatabaseHas('reviews', [
             'admin_northstar_id' => $northstarId,
-            'post_id' => $post->id,
-            'comment' => 'testing',
+            'post_id' => $firstPost->id,
+            'comment' => 'Testing 1st review',
         ]);
         $this->assertDatabaseHas('campaigns', [
-            'id' => $post->campaign->id,
+            'id' => $campaignId,
             'accepted_count' => 1,
+            'pending_count' => 0,
         ]);
         $this->assertDatabaseHas('action_stats', [
-            'action_id' => $post->action_id,
-            'accepted_quantity' => $post->quantity,
-            'school_id' => $post->school_id,
+            'action_id' => $actionId,
+            'accepted_quantity' => $firstPost->quantity,
+            'school_id' => $schoolId,
+        ]);
+
+        $secondPost = factory(Post::class)->create([
+            'action_id' => $actionId,
+            'campaign_id' => $campaignId,
+            'school_id' => $schoolId,
+        ]);
+
+        $response = $this->withAccessToken($northstarId, 'admin')->postJson('api/v3/posts/' . $secondPost->id . '/reviews', [
+            'status' => 'accepted',
+            'comment' => 'Testing 2nd review',
+        ]);
+
+        $this->assertDatabaseHas('campaigns', [
+            'id' => $campaignId,
+            'accepted_count' => 2,
+            'pending_count' => 0,
+        ]);
+        $this->assertDatabaseHas('action_stats', [
+            'action_id' => $actionId,
+            'accepted_quantity' => $firstPost->quantity + $secondPost->quantity,
+            'school_id' => $schoolId,
         ]);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request makes changes per https://github.com/DoSomething/rogue/pull/964#discussion_r354011950 to update aggregate campaign information in the same place we update aggregate school impact -- which is after the reviewed post's status has been updated.

It also adds unit tests for both aggregate calculations.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🌵 

### Relevant tickets

References [Pivotal #170111820](https://www.pivotaltracker.com/n/projects/2328687/stories/170111820).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
