### PR TITLE
Allow bulk-reviewing trashed signups.

### DIFF
--- a/app/Console/Commands/ReviewSignup.php
+++ b/app/Console/Commands/ReviewSignup.php
@@ -48,7 +48,7 @@ class ReviewSignup extends Command
      */
     public function handle()
     {
-        $signup = Signup::findOrFail($this->argument('signup'));
+        $signup = Signup::withTrashed()->findOrFail($this->argument('signup'));
         $status = $this->argument('status');
         $posts = $signup->posts;
         $admin = $this->option('admin');


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `rogue:reviewsignup` command to support bulk-reviewing posts for a signup that has been soft-deleted. Otherwise, the script fails with this error:

```
In Builder.php line 331:

  No query results for model [Rogue\Models\Signup] 11303803
```

### How should this be reviewed?

👀

### Any background context you want to provide?

This is a quick fix to fix an issue caused by [an overwhelming number of Cobalt submissions to a sponsored campaign](https://dosomething.slack.com/archives/C09ANFQLA/p1576519120019900). Unfortunately, the signup was soft-deleted as an attempt to "bulk review" these posts, which meant the script as-is wouldn't work.

### Relevant tickets

References [Pivotal #170320843](https://www.pivotaltracker.com/story/show/170320843).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
