### PR TITLE
Add cursor support to signups index.

### DIFF
--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -103,7 +103,15 @@ class SignupsController extends ApiController
         }
 
         $orderBy = $request->query('orderBy');
-        $query = $this->orderBy($query, $orderBy, Signup::$indexes);
+        $query = $this->orderBy($query, $orderBy, Signup::$sortable);
+
+        // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):
+        if ($cursor = array_get($request->query('cursor'), 'after')) {
+            $query->whereAfterCursor($cursor);
+
+            // Using 'cursor' implies cursor pagination:
+            $this->useCursorPagination = true;
+        }
 
         return $this->paginatedCollection($query, $request);
     }

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -34,6 +34,7 @@ class SignupTransformer extends TransformerAbstract
             'quantity' => $signup->quantity,
             'created_at' => $signup->created_at->toIso8601String(),
             'updated_at' => $signup->updated_at->toIso8601String(),
+            'cursor' => $signup->getCursor(),
         ];
 
         if (Gate::allows('viewAll', $signup)) {

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -3,12 +3,13 @@
 namespace Rogue\Models;
 
 use Rogue\Services\GraphQL;
+use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Signup extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, HasCursor;
 
     /**
      * The attributes that should be cast to native types.
@@ -42,6 +43,20 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
+        'campaign_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source',
+    ];
+
+    /**
+     * Attributes that we can sort by with the '?orderBy' query parameter. These
+     * should not contain any sensitive or private data (as they'll be encoded
+     * in cursors).
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $sortable = [
         'campaign_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source',
     ];
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for using `?cursor[after]=` to paginate through signups.

### How should this be reviewed?

This is a pre-requisite for DoSomething/graphql#185, which in turn is a pre-requisite for adding pagination to a user's list of signups here. 🐢

### Any background context you want to provide?

This follows the same pattern established in #930 and #937.

The [GraphQL Pagination RFC](https://github.com/DoSomething/rfcs/pull/6) has more context on why we're approaching pagination in this way.

### Relevant tickets

References [Pivotal #170503307](https://www.pivotaltracker.com/story/show/170503307).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
