### PR TITLE
Extract signup "gallery" with pagination support.

### DIFF
--- a/resources/assets/components/SignupCard/index.js
+++ b/resources/assets/components/SignupCard/index.js
@@ -1,10 +1,32 @@
 import React from 'react';
-import PostTile from '../PostTile';
+import gql from 'graphql-tag';
 import { Link } from 'react-router-dom';
+
+import PostTile from '../PostTile';
 
 import './signup-card.scss';
 
 const POST_GALLERY_SIZE = 4;
+
+export const SignupCardFragment = gql`
+  fragment SignupCardFragment on Signup {
+    id
+    quantity
+    whyParticipated
+
+    campaign {
+      id
+      internalTitle
+      startDate
+    }
+
+    posts {
+      id
+      type
+      url(w: 200, h: 200)
+    }
+  }
+`;
 
 const SignupCard = ({ signup }) => {
   const campaign = signup.campaign || {};

--- a/resources/assets/components/SignupGallery.js
+++ b/resources/assets/components/SignupGallery.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { get, map } from 'lodash';
+import { useQuery } from '@apollo/react-hooks';
+
+import Empty from './Empty';
+import Shell from './utilities/Shell';
+import SignupCard, { SignupCardFragment } from './SignupCard';
+import { updateQuery } from '../helpers';
+
+const SIGNUP_GALLERY_QUERY = gql`
+  query SignupGalleryQuery($userId: String, $cursor: String) {
+    signups: paginatedSignups(userId: $userId, after: $cursor, first: 10) {
+      edges {
+        cursor
+        node {
+          ...SignupCardFragment
+        }
+      }
+
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+
+  ${SignupCardFragment}
+`;
+
+const SignupGallery = ({ userId }) => {
+  const { loading, error, data, fetchMore } = useQuery(SIGNUP_GALLERY_QUERY, {
+    variables: { userId },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  const signups = get(data, 'signups.edges', []);
+  const { endCursor, hasNextPage } = get(data, 'signups.pageInfo', {});
+
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery,
+    });
+  };
+
+  if (signups.length == 0) {
+    return loading ? (
+      <div className="h-content flex-center-xy">
+        <div className="spinner" />
+      </div>
+    ) : (
+      <div className="h-content flex-center-xy">
+        <Empty copy="This user has no signups yet." />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {map(signups, signup => (
+        <SignupCard key={signup.cursor} signup={signup.node} />
+      ))}
+      {loading ? (
+        <div className="container__block">
+          <div className="spinner margin-horizontal-auto margin-vertical" />
+        </div>
+      ) : null}
+      <div className="form-actions -padded">
+        {hasNextPage ? (
+          <button
+            className="button -tertiary"
+            onClick={handleViewMore}
+            disabled={loading}
+          >
+            view more...
+          </button>
+        ) : (
+          <p className="footnote margin-horizontal-auto">...and that's all!</p>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default SignupGallery;

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -66,7 +66,7 @@ const ShowUser = () => {
         <h2 className="heading -emphasized -padded">
           <span>Campaigns</span>
         </h2>
-        <SignupGallery userId={id} />
+        <SignupGallery userId={user.id} />
       </div>
     </Shell>
   );

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -4,8 +4,8 @@ import { map } from 'lodash';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
-import SignupCard from '../components/SignupCard';
 import Shell from '../components/utilities/Shell';
+import SignupGallery from '../components/SignupGallery';
 import MetaInformation from '../components/utilities/MetaInformation';
 import UserInformation, {
   UserInformationFragment,
@@ -17,24 +17,6 @@ const SHOW_USER_QUERY = gql`
       ...UserInformation
       permalink
       source
-    }
-
-    signups(userId: $id, orderBy: "created_at,desc") {
-      id
-      quantity
-      whyParticipated
-
-      campaign {
-        id
-        internalTitle
-        startDate
-      }
-
-      posts {
-        id
-        type
-        url(w: 200, h: 200)
-      }
     }
   }
 
@@ -58,7 +40,7 @@ const ShowUser = () => {
     return <Shell title={title} subtitle={subtitle} error={error} />;
   }
 
-  const { user, signups } = data;
+  const { user } = data;
 
   return (
     <Shell title={title} subtitle={subtitle}>
@@ -84,9 +66,7 @@ const ShowUser = () => {
         <h2 className="heading -emphasized -padded">
           <span>Campaigns</span>
         </h2>
-        {map(signups, signup => {
-          return <SignupCard key={signup.id} signup={signup} />;
-        })}
+        <SignupGallery userId={id} />
       </div>
     </Shell>
   );

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -4,6 +4,7 @@ import { map } from 'lodash';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
+import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import SignupGallery from '../components/SignupGallery';
 import MetaInformation from '../components/utilities/MetaInformation';
@@ -38,6 +39,10 @@ const ShowUser = () => {
 
   if (error) {
     return <Shell title={title} subtitle={subtitle} error={error} />;
+  }
+
+  if (!data.user) {
+    return <NotFound title={title} type="user" />;
   }
 
   const { user } = data;


### PR DESCRIPTION
### What's this PR do?

This pull request adds a "load more" button to request additional signups on a user's profile. This builds on the work done in #976 and DoSomething/graphql#185.

### How should this be reviewed?

I extracted a `SignupGallery` to handle the display of this interface element (following the patterns used in `ReviewablePostGallery`).

### Any background context you want to provide?

This is particularly helpful when viewing staff or power-user accounts, since otherwise folks were having to look up signup IDs in Looker in order to get to them from Rogue.

### Relevant tickets

References [Pivotal #170503307](https://www.pivotaltracker.com/story/show/170503307).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
