### PR TITLE
Updates timezone definition in campaign getter

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Models;
 
+use Carbon\Carbon;
 use Rogue\Types\Cause;
 use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
@@ -155,6 +156,21 @@ class Campaign extends Model
     }
 
     /**
+     * Accessor for getting the start_date field.
+     *
+     */
+    public function getStartDateAttribute()
+    {
+        $value = $this->attributes['start_date'];
+        if (!$value) {
+            return null;
+        }
+        $date = (new Carbon($value))->format('Y-m-d');
+
+        return new Carbon($date, 'America/New_York');
+    }
+
+    /**
      * Mutator for setting the start_date field.
      *
      * @param string|Carbon $value
@@ -162,6 +178,21 @@ class Campaign extends Model
     public function setStartDateAttribute($value)
     {
         $this->setArbitraryDateString('start_date', $value);
+    }
+
+    /**
+     * Accessor for getting the end_date field.
+     *
+     */
+    public function getEndDateAttribute()
+    {
+        $value = $this->attributes['end_date'];
+        if (!$value) {
+            return null;
+        }
+        $date = (new Carbon($value))->format('Y-m-d');
+
+        return new Carbon($date, 'America/New_York');
     }
 
     /**

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -165,7 +165,7 @@ class Campaign extends Model
             return null;
         }
         $date = (new Carbon($value))->format('Y-m-d');
-
+        //explicitly setting our timezone to EST to account for accurate end dates displayed on Phoenix
         return new Carbon($date, 'America/New_York');
     }
 
@@ -189,7 +189,7 @@ class Campaign extends Model
             return null;
         }
         $date = (new Carbon($value))->format('Y-m-d');
-
+        //explicitly setting our timezone to EST to account for accurate end dates displayed on Phoenix
         return new Carbon($date, 'America/New_York');
     }
 

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -157,12 +157,11 @@ class Campaign extends Model
 
     /**
      * Accessor for getting the start_date field.
-     *
      */
     public function getStartDateAttribute()
     {
         $value = $this->attributes['start_date'];
-        if (!$value) {
+        if (! $value) {
             return null;
         }
         $date = (new Carbon($value))->format('Y-m-d');
@@ -182,12 +181,11 @@ class Campaign extends Model
 
     /**
      * Accessor for getting the end_date field.
-     *
      */
     public function getEndDateAttribute()
     {
         $value = $this->attributes['end_date'];
-        if (!$value) {
+        if (! $value) {
             return null;
         }
         $date = (new Carbon($value))->format('Y-m-d');

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -149,15 +149,15 @@ $factory->define(Campaign::class, function (Generator $faker) {
         'cause' => $faker->randomElements(Cause::all(), rand(1, 5)),
         'impact_doc' => 'https://www.google.com/',
         // By default, we create an "open campaign".
-        'start_date' => $faker->dateTimeBetween('-6 months', 'now'),
-        'end_date' => $faker->dateTimeBetween('+1 months', '+6 months'),
+        'start_date' => $faker->dateTimeBetween('-6 months', 'now')->setTime(0, 0),
+        'end_date' => $faker->dateTimeBetween('+1 months', '+6 months')->setTime(0, 0),
     ];
 });
 
 $factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($factory) {
     return array_merge($factory->raw(Campaign::class), [
-        'start_date' => $faker->dateTimeBetween('-12 months', '-6 months'),
-        'end_date' => $faker->dateTimeBetween('-3 months', 'yesterday'),
+        'start_date' => $faker->dateTimeBetween('-12 months', '-6 months')->setTime(0, 0),
+        'end_date' => $faker->dateTimeBetween('-3 months', 'yesterday')->setTime(0, 0),
     ]);
 });
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -194,7 +194,7 @@ class CampaignTest extends Testcase
             'data' => [
                 'internal_title' => 'Updated Title',
                 'cause' => ['lgbtq-rights'],
-                'start_date' => '2018-01-01T00:00:00+00:00',
+                'start_date' => '2018-01-01T00:00:00-05:00',
             ],
         ]);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request updates the seeding for our faker factory to set the time to midnight when creating new campaign dates, as well as add getters for the start and end dates. These getters get our formatting set up and in the correct time zone.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Originally we approached this by updating our data type query in Graphql, but making the update here helps us to be more consistent and accurate in the dates and time zones we are using for both campaigns and scholarships.

### Relevant tickets

References [Pivotal # 170090422](https://www.pivotaltracker.com/story/show/170090422).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
