### PR TITLE
Cleanup post factory

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -68,7 +68,7 @@ $factory->define(Post::class, function (Generator $faker) {
          * on behalf of their school (because they don't have a school_id set on their
          * Northstar profile).
          */
-        'school_id' => rand(0, 1) ? $this->faker->school_id : null,
+        'school_id' => $this->faker->optional()->school_id,
         'source' => 'phpunit',
     ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -65,7 +65,7 @@ $factory->defineAs(Post::class, 'photo-accepted', function () use ($factory) {
     ]);
 });
 
-$factory->defineAs(Post::class, 'photo-pending',  function () use ($factory) {
+$factory->defineAs(Post::class, 'photo-pending', function () use ($factory) {
     return array_merge($factory->raw(Post::class), [
         'status' => 'pending',
     ]);
@@ -79,7 +79,7 @@ $factory->defineAs(Post::class, 'photo-rejected', function () use ($factory) {
 
 $factory->defineAs(Post::class, 'text-accepted', function () use ($factory) {
     return array_merge($factory->raw(Post::class), [
-        'quantity' =>0,
+        'quantity' => 0,
         'status' => 'accepted',
         'type' => 'text',
         'url' => null,
@@ -91,7 +91,7 @@ $factory->defineAs(Post::class, 'text-pending', function () use ($factory) {
         'quantity' => 0,
         'status' => 'pending',
         'type' => 'text',
-        'url' => null,     
+        'url' => null,
     ]);
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -76,7 +76,7 @@ $factory->define(Post::class, function (Generator $faker) {
 /**
  * Post type factory states.
  */
-$factory->state(Post::class, 'photo', function (Generator $faker) use ($factory) {
+$factory->state(Post::class, 'photo', function (Generator $faker) {
     return [
         'type' => 'photo',
         'quantity' => $faker->randomNumber(2),
@@ -84,32 +84,24 @@ $factory->state(Post::class, 'photo', function (Generator $faker) use ($factory)
     ];
 });
 
-$factory->state(Post::class, 'text', function () use ($factory) {
-    return [
-        'type' => 'text',
-    ];
-});
+$factory->state(Post::class, 'text', [
+    'type' => 'text',
+]);
 
 /**
  * Post status factory states.
  */
-$factory->state(Post::class, 'accepted', function (Generator $faker) use ($factory) {
-    return [
-        'status' => 'pending',
-    ];
-});
+$factory->state(Post::class, 'accepted', [
+    'status' => 'accepted',
+]);
 
-$factory->state(Post::class, 'pending', function (Generator $faker) use ($factory) {
-    return [
-        'status' => 'pending',
-    ];
-});
+$factory->state(Post::class, 'pending', [
+    'status' => 'pending',
+]);
 
-$factory->state(Post::class, 'rejected', function (Generator $faker) use ($factory) {
-    return [
-        'status' => 'rejected',
-    ];
-});
+$factory->state(Post::class, 'rejected', [
+    'status' => 'rejected',
+]);
 
 // Signup Factory
 $factory->define(Signup::class, function (Generator $faker) {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -22,6 +22,24 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * @see https://laravel.com/docs/5.5/database-testing#writing-factories
  */
 
+// Action Factory
+$factory->define(Action::class, function (Generator $faker) {
+    return [
+        'name' => $this->faker->slug(),
+        'campaign_id' => factory(Campaign::class)->create()->id,
+        'post_type' => 'photo',
+        'action_type' => $this->faker->randomElement(ActionType::all()),
+        'time_commitment' => $this->faker->randomElement(TimeCommitment::all()),
+        'reportback' => true,
+        'civic_action' => true,
+        'scholarship_entry' => true,
+        'anonymous' => false,
+        'noun' => 'things',
+        'verb' => 'done',
+        'collect_school_id' => true,
+    ];
+});
+
 // Post Factory
 $factory->define(Post::class, function (Generator $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
@@ -52,8 +70,12 @@ $factory->define(Post::class, function (Generator $faker) {
         'text' => $faker->sentence(),
         'type' => 'photo',
         'location' => 'US-'.$faker->stateAbbr(),
-        // @TODO: Only set school if the action is set to collect school ID.
-        'school_id' => $this->faker->school_id,
+        /**
+         * Although our action models are set to collect school, not all users will create posts
+         * on behalf of their school (because they don't have a school_id set on their
+         * Northstar profile).
+         */
+        'school_id' => rand(0, 1) ? $this->faker->school_id : null,
         'source' => 'phpunit',
         'url' => $url,
     ];
@@ -153,7 +175,7 @@ $factory->define(Campaign::class, function (Generator $faker) {
         'internal_title' => title_case($faker->unique()->catchPhrase),
         'cause' => $faker->randomElements(Cause::all(), rand(1, 5)),
         'impact_doc' => 'https://www.google.com/',
-        // By default, we create an "open campaign".
+        // By default, we create an "open" campaign.
         'start_date' => $faker->dateTimeBetween('-6 months', 'now')->setTime(0, 0),
         'end_date' => $faker->dateTimeBetween('+1 months', '+6 months')->setTime(0, 0),
     ];
@@ -164,25 +186,4 @@ $factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($
         'start_date' => $faker->dateTimeBetween('-12 months', '-6 months')->setTime(0, 0),
         'end_date' => $faker->dateTimeBetween('-3 months', 'yesterday')->setTime(0, 0),
     ]);
-});
-
-// Action Factory
-$factory->define(Action::class, function (Generator $faker) {
-    return [
-        'name' => $faker->randomElement([
-            'default', 'action-1', 'action-page', 'sms', 'august-2018-turbovote',
-            'december-2018-turbovote', 'july-2018-turbovote', 'june-2018-turbovote',
-            'may-2018-rockthevote', 'november-2018-turbovote',
-        ]),
-        'campaign_id' => factory(Campaign::class)->create()->id,
-        'post_type' => 'photo',
-        'action_type' => $this->faker->randomElement(ActionType::all()),
-        'time_commitment' => $this->faker->randomElement(TimeCommitment::all()),
-        'reportback' => true,
-        'civic_action' => true,
-        'scholarship_entry' => true,
-        'anonymous' => false,
-        'noun' => 'things',
-        'verb' => 'done',
-    ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -23,7 +23,7 @@ use Rogue\Types\TimeCommitment;
 // Action Factory
 $factory->define(Action::class, function (Generator $faker) {
     return [
-        'name' => title_case($this->faker->unique()->words(3, true)), 
+        'name' => title_case($this->faker->unique()->words(3, true)),
         'campaign_id' => factory(Campaign::class)->create()->id,
         'post_type' => 'photo',
         'action_type' => $this->faker->randomElement(ActionType::all()),
@@ -105,7 +105,6 @@ $factory->defineAs(Post::class, 'photo-rejected', function (Generator $faker) us
  */
 $factory->defineAs(Post::class, 'text-accepted', function () use ($factory) {
     return array_merge($factory->raw(Post::class), [
-        'quantity' => 0,
         'status' => 'accepted',
         'type' => 'text',
     ]);
@@ -113,7 +112,6 @@ $factory->defineAs(Post::class, 'text-accepted', function () use ($factory) {
 
 $factory->defineAs(Post::class, 'text-pending', function () use ($factory) {
     return array_merge($factory->raw(Post::class), [
-        'quantity' => 0,
         'status' => 'pending',
         'type' => 'text',
     ]);
@@ -121,7 +119,6 @@ $factory->defineAs(Post::class, 'text-pending', function () use ($factory) {
 
 $factory->defineAs(Post::class, 'text-rejected', function () use ($factory) {
     return array_merge($factory->raw(Post::class), [
-        'quantity' => 0,
         'status' => 'rejected',
         'type' => 'text',
     ]);

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -47,56 +47,61 @@ $factory->define(Post::class, function (Generator $faker) {
                 'campaign_id' => $attributes['campaign_id'],
             ])->id;
         },
+        'quantity' => $faker->randomNumber(2),
         'northstar_id' => $this->faker->northstar_id,
-        'url' => $url,
         'text' => $faker->sentence(),
+        'type' => 'photo',
         'location' => 'US-'.$faker->stateAbbr(),
         // @TODO: Only set school if the action is set to collect school ID.
         'school_id' => $this->faker->school_id,
         'source' => 'phpunit',
-        'status' => 'pending',
-        'quantity' => $faker->randomNumber(2),
+        'url' => $url,
     ];
 });
 
-// @TODO: These should all extend a photo-less "base" post, instead.
-$factory->defineAs(Post::class, 'text', function (Generator $faker) {
-    $faker->addProvider(new FakerNorthstarId($faker));
-    $faker->addProvider(new FakerSchoolId($faker));
+$factory->defineAs(Post::class, 'photo-accepted', function () use ($factory) {
+    return array_merge($factory->raw(Post::class), [
+        'status' => 'accepted',
+    ]);
+});
 
-    return [
+$factory->defineAs(Post::class, 'photo-pending',  function () use ($factory) {
+    return array_merge($factory->raw(Post::class), [
+        'status' => 'pending',
+    ]);
+});
+
+$factory->defineAs(Post::class, 'photo-rejected', function () use ($factory) {
+    return array_merge($factory->raw(Post::class), [
+        'status' => 'rejected',
+    ]);
+});
+
+$factory->defineAs(Post::class, 'text-accepted', function () use ($factory) {
+    return array_merge($factory->raw(Post::class), [
+        'quantity' =>0,
+        'status' => 'accepted',
         'type' => 'text',
-        'campaign_id' => function () {
-            return factory(Campaign::class)->create()->id;
-        },
-        'signup_id' => function (array $attributes) {
-            // If a 'signup_id' is not provided, create one for the same Campaign & Northstar ID.
-            return factory(Signup::class)->create([
-                'campaign_id' => $attributes['campaign_id'],
-                'northstar_id' => $attributes['northstar_id'],
-            ])->id;
-        },
-        'action_id' => function (array $attributes) {
-            return factory(Action::class)->create([
-                'campaign_id' => $attributes['campaign_id'],
-            ])->id;
-        },
-        'northstar_id' => $this->faker->northstar_id,
-        'text' => $faker->sentence(),
-        'location' => 'US-'.$faker->stateAbbr(),
-        // @TODO: Only set school if the action is set to collect school ID.
-        'school_id' => $this->faker->school_Id,
-        'source' => 'phpunit',
+        'url' => null,
+    ]);
+});
+
+$factory->defineAs(Post::class, 'text-pending', function () use ($factory) {
+    return array_merge($factory->raw(Post::class), [
+        'quantity' => 0,
         'status' => 'pending',
-    ];
+        'type' => 'text',
+        'url' => null,     
+    ]);
 });
 
-$factory->defineAs(Post::class, 'accepted', function () use ($factory) {
-    return array_merge($factory->raw(Post::class), ['status' => 'accepted']);
-});
-
-$factory->defineAs(Post::class, 'rejected', function () use ($factory) {
-    return array_merge($factory->raw(Post::class), ['status' => 'rejected']);
+$factory->defineAs(Post::class, 'text-rejected', function () use ($factory) {
+    return array_merge($factory->raw(Post::class), [
+        'quantity' => 0,
+        'status' => 'rejected',
+        'type' => 'text',
+        'url' => null,
+    ]);
 });
 
 // Signup Factory

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -74,54 +74,41 @@ $factory->define(Post::class, function (Generator $faker) {
 });
 
 /**
- * Photo post factory states.
+ * Post type factory states.
  */
-$factory->defineAs(Post::class, 'photo-accepted', function (Generator $faker) use ($factory) {
-    return array_merge($factory->raw(Post::class), [
+$factory->state(Post::class, 'photo', function (Generator $faker) use ($factory) {
+    return [
+        'type' => 'photo',
         'quantity' => $faker->randomNumber(2),
-        'status' => 'accepted',
         'url' => $faker->post_url,
-    ]);
+    ];
 });
 
-$factory->defineAs(Post::class, 'photo-pending', function (Generator $faker) use ($factory) {
-    return array_merge($factory->raw(Post::class), [
-        'quantity' => $faker->randomNumber(2),
-        'status' => 'pending',
-        'url' => $faker->post_url,
-    ]);
-});
-
-$factory->defineAs(Post::class, 'photo-rejected', function (Generator $faker) use ($factory) {
-    return array_merge($factory->raw(Post::class), [
-        'quantity' => $faker->randomNumber(2),
-        'status' => 'rejected',
-        'url' => $faker->post_url,
-    ]);
+$factory->state(Post::class, 'text', function () use ($factory) {
+    return [
+        'type' => 'text',
+    ];
 });
 
 /**
- * Text post factory states.
+ * Post status factory states.
  */
-$factory->defineAs(Post::class, 'text-accepted', function () use ($factory) {
-    return array_merge($factory->raw(Post::class), [
-        'status' => 'accepted',
-        'type' => 'text',
-    ]);
-});
-
-$factory->defineAs(Post::class, 'text-pending', function () use ($factory) {
-    return array_merge($factory->raw(Post::class), [
+$factory->state(Post::class, 'accepted', function (Generator $faker) use ($factory) {
+    return [
         'status' => 'pending',
-        'type' => 'text',
-    ]);
+    ];
 });
 
-$factory->defineAs(Post::class, 'text-rejected', function () use ($factory) {
-    return array_merge($factory->raw(Post::class), [
+$factory->state(Post::class, 'pending', function (Generator $faker) use ($factory) {
+    return [
+        'status' => 'pending',
+    ];
+});
+
+$factory->state(Post::class, 'rejected', function (Generator $faker) use ($factory) {
+    return [
         'status' => 'rejected',
-        'type' => 'text',
-    ]);
+    ];
 });
 
 // Signup Factory

--- a/database/faker/FakerPostUrl.php
+++ b/database/faker/FakerPostUrl.php
@@ -1,0 +1,21 @@
+<?php
+
+use Faker\Provider\Base;
+use Rogue\Services\ImageStorage;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class FakerPostUrl extends Base
+{
+    /**
+     * Return a Post URL.
+     *
+     * @return string
+     */
+    public function post_url()
+    {
+        $uploadPath = $this->generator->file(storage_path('fixtures'));
+        $upload = new UploadedFile($uploadPath, basename($uploadPath), 'image/jpeg');
+
+        return app(ImageStorage::class)->put($this->generator->unique()->randomNumber(5), $upload);
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -29,21 +29,21 @@ class DatabaseSeeder extends Seeder
             // Create 10-20 signups with one accepted photo post & some pending photo and text posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
-                    $signup->posts()->save(factory(Post::class, 'photo-accepted')->create([
+                    $signup->posts()->save(factory(Post::class)->states('photo', 'accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, 'photo-pending', rand(2, 4))->create([
+                    $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('photo', 'pending')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, 'text-pending', rand(2, 4))->create([
+                    $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('text', 'pending')->create([
                         'action_id' => $textAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
@@ -54,14 +54,14 @@ class DatabaseSeeder extends Seeder
             // Create 5-10 signups with only accepted posts, from lil' angels!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
-                    $signup->posts()->save(factory(Post::class, 'photo-accepted')->create([
+                    $signup->posts()->save(factory(Post::class)->states('photo', 'accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, 'text-accepted', rand(2, 4))->create([
+                    $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('text', 'accepted')->create([
                         'action_id' => $textAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
@@ -72,7 +72,7 @@ class DatabaseSeeder extends Seeder
             // Create 5-10 signups with rejected posts, from troublemakers!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
-                    $signup->posts()->save(factory(Post::class, 'photo-rejected')->create([
+                    $signup->posts()->save(factory(Post::class)->states('photo', 'rejected')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -31,7 +31,7 @@ class DatabaseSeeder extends Seeder
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, 'photo-pending' rand(2, 4))->create([
+                    $signup->posts()->saveMany(factory(Post::class, 'photo-pending', rand(2, 4))->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -17,9 +17,14 @@ class DatabaseSeeder extends Seeder
     {
         // Create 10 campaigns with signups & posts.
         factory(Campaign::class, 10)->create()->each(function (Campaign $campaign) {
-            // Add a "default" action so this functions as expected in the "dev" environment.
-            $photoAction = factory(Action::class)->create(['post_type' => 'photo', 'campaign_id' => $campaign->id, 'name' => 'default']);
-            $textAction = factory(Action::class)->create(['post_type' => 'text', 'campaign_id' => $campaign->id, 'name' => 'default']);
+            $photoAction = factory(Action::class)->create([
+                'post_type' => 'photo',
+                'campaign_id' => $campaign->id,
+            ]);
+            $textAction = factory(Action::class)->create([
+                'post_type' => 'text',
+                'campaign_id' => $campaign->id,
+            ]);
 
             // Create 10-20 signups with one accepted photo post & some pending photo and text posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -24,21 +24,21 @@ class DatabaseSeeder extends Seeder
             // Create 10-20 signups with one accepted photo post & some pending photo and text posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
-                    $signup->posts()->save(factory(Post::class, 'accepted')->create([
+                    $signup->posts()->save(factory(Post::class, 'photo-accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->create([
+                    $signup->posts()->saveMany(factory(Post::class, 'photo-pending' rand(2, 4))->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, 'text', rand(2, 4))->create([
+                    $signup->posts()->saveMany(factory(Post::class, 'text-pending', rand(2, 4))->create([
                         'action_id' => $textAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
@@ -49,15 +49,14 @@ class DatabaseSeeder extends Seeder
             // Create 5-10 signups with only accepted posts, from lil' angels!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
-                    $signup->posts()->save(factory(Post::class, 'accepted')->create([
+                    $signup->posts()->save(factory(Post::class, 'photo-accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
                     ]));
 
-                    $signup->posts()->saveMany(factory(Post::class, 'text', rand(2, 4))->create([
-                        'status' => 'accepted', // @TODO: We should have an "accepted" variant of the text factory!
+                    $signup->posts()->saveMany(factory(Post::class, 'text-accepted', rand(2, 4))->create([
                         'action_id' => $textAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
@@ -68,7 +67,7 @@ class DatabaseSeeder extends Seeder
             // Create 5-10 signups with rejected posts, from troublemakers!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
-                    $signup->posts()->save(factory(Post::class, 'rejected')->create([
+                    $signup->posts()->save(factory(Post::class, 'photo-rejected')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,

--- a/tests/Http/EventTest.php
+++ b/tests/Http/EventTest.php
@@ -118,7 +118,7 @@ class EventTest extends TestCase
      */
     public function testDeletingPostViaApiEvent()
     {
-        $post = factory(Post::class)->create();
+        $post = factory(Post::class, 'photo-accepted')->create();
 
         // Delete the post via the API.
         $this->mockTime('8/4/2017 18:02:00');

--- a/tests/Http/EventTest.php
+++ b/tests/Http/EventTest.php
@@ -118,7 +118,7 @@ class EventTest extends TestCase
      */
     public function testDeletingPostViaApiEvent()
     {
-        $post = factory(Post::class, 'photo-accepted')->create();
+        $post = factory(Post::class)->states('photo', 'accepted')->create();
 
         // Delete the post via the API.
         $this->mockTime('8/4/2017 18:02:00');

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -15,7 +15,7 @@ class ImagesTest extends TestCase
     public function testImagesThrottle()
     {
         // Make a post to view
-        $posts = factory(Post::class, 10)->create();
+        $posts = factory(Post::class, 'photo-accepted', 10)->create();
 
         // View the post 60 times (using 3 different versions)
         for ($i = 0; $i < 5; $i++) {

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -15,7 +15,7 @@ class ImagesTest extends TestCase
     public function testImagesThrottle()
     {
         // Make a post to view
-        $posts = factory(Post::class, 'photo-accepted', 10)->create();
+        $posts = factory(Post::class, 10)->states('photo', 'accepted')->create();
 
         // View the post 60 times (using 3 different versions)
         for ($i = 0; $i < 5; $i++) {

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -757,8 +757,8 @@ class PostTest extends TestCase
     public function testPostsIndexAsNonAdminNonOwner()
     {
         // Anonymous requests should only see accepted posts.
-        factory(Post::class, 'accepted', 10)->create();
-        factory(Post::class, 'rejected', 5)->create();
+        factory(Post::class, 'photo-accepted', 10)->create();
+        factory(Post::class, 'photo-rejected', 5)->create();
 
         $response = $this->getJson('api/v3/posts');
 
@@ -808,13 +808,13 @@ class PostTest extends TestCase
     {
         // Create an accepted post.
         $this->mockTime('8/3/2017 14:00:00');
-        $regularPost = factory(Post::class, 'accepted')->create([
+        $regularPost = factory(Post::class, 'photo-accepted')->create([
             'northstar_id' => $this->faker->unique()->northstar_id,
         ]);
 
         // And then later, create an anonymous post from another user.
         $this->mockTime('8/3/2017 17:30:00');
-        $anonymousPost = factory(Post::class, 'accepted')->create([
+        $anonymousPost = factory(Post::class, 'photo-accepted')->create([
             'northstar_id' => $this->faker->unique()->northstar_id,
         ]);
         $anonymousPost->actionModel->anonymous = 1;
@@ -875,9 +875,9 @@ class PostTest extends TestCase
     public function testPostsIndexAsNonAdminNonOwnerHiddenPosts()
     {
         // Anonymous requests should only see posts that are not tagged with "Hide In Gallery."
-        factory(Post::class, 'accepted', 10)->create();
+        factory(Post::class, 'photo-accepted', 10)->create();
 
-        $hiddenPost = factory(Post::class, 'accepted')->create();
+        $hiddenPost = factory(Post::class, 'photo-accepted')->create();
         $hiddenPost->tag('Hide In Gallery');
 
         $response = $this->getJson('api/v3/posts');
@@ -896,8 +896,8 @@ class PostTest extends TestCase
     public function testPostsIndexAsAdmin()
     {
         // Admins should see all posts.
-        factory(Post::class, 'accepted', 10)->create();
-        factory(Post::class, 'rejected', 5)->create();
+        factory(Post::class, 'photo-accepted', 10)->create();
+        factory(Post::class, 'photo-rejected', 5)->create();
 
         $response = $this->withAdminAccessToken()->getJson('api/v3/posts');
 
@@ -951,9 +951,9 @@ class PostTest extends TestCase
     public function testPostsIndexAsAdminHiddenPosts()
     {
         // Admins should see all posts.
-        factory(Post::class, 'accepted', 10)->create();
+        factory(Post::class, 'photo-accepted', 10)->create();
 
-        $hiddenPost = factory(Post::class, 'accepted')->create();
+        $hiddenPost = factory(Post::class, 'photo-accepted')->create();
         $hiddenPost->tag('Hide In Gallery');
 
         $response = $this->withAdminAccessToken()->getJson('api/v3/posts');
@@ -971,11 +971,11 @@ class PostTest extends TestCase
     public function testPostsIndexAsOwner()
     {
         $userId = $this->faker->unique()->northstar_id;
-        factory(Post::class, 2)->create(['northstar_id' => $userId]);
-        factory(Post::class, 'rejected', 1)->create(['northstar_id' => $userId]);
+        factory(Post::class, 'photo-pending', 2)->create(['northstar_id' => $userId]);
+        factory(Post::class, 'photo-rejected', 1)->create(['northstar_id' => $userId]);
 
         $otherId = $this->faker->unique()->northstar_id;
-        factory(Post::class, 'rejected', 4)->create(['northstar_id' => $otherId]);
+        factory(Post::class, 'photo-rejected', 4)->create(['northstar_id' => $otherId]);
 
         // Owners should be able to see their own posts of any status, but
         // not pending or rejected posts from other users.
@@ -1034,15 +1034,15 @@ class PostTest extends TestCase
         $ownerId = $this->faker->unique()->northstar_id;
 
         // Create posts and associate to this $ownerId.
-        $posts = factory(Post::class, 'accepted', 2)->create(['northstar_id' => $ownerId]);
+        $posts = factory(Post::class, 'photo-accepted', 2)->create(['northstar_id' => $ownerId]);
 
         // Create a hidden post from the same $ownerId.
-        $hiddenPost = factory(Post::class, 'accepted')->create(['northstar_id' => $ownerId]);
+        $hiddenPost = factory(Post::class, 'photo-accepted')->create(['northstar_id' => $ownerId]);
         $hiddenPost->tag('Hide In Gallery');
         $hiddenPost->save();
 
         // Create anothter hidden post by different user.
-        $secondHiddenPost = factory(Post::class, 'accepted')->create([
+        $secondHiddenPost = factory(Post::class, 'photo-accepted')->create([
             'northstar_id' => $this->faker->unique()->northstar_id,
         ]);
         $secondHiddenPost->tag('Hide In Gallery');
@@ -1069,13 +1069,13 @@ class PostTest extends TestCase
         $response->assertStatus(403);
 
         // Anon user should not be able to see a rejected post if it doesn't belong to them and if they're not an admin.
-        $post = factory(Post::class, 'rejected')->create();
+        $post = factory(Post::class, 'photo-rejected')->create();
         $response = $this->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(403);
 
         // Anon user is able to see an accepted post even if it doesn't belong to them and if they're not an admin.
-        $post = factory(Post::class, 'accepted')->create();
+        $post = factory(Post::class, 'photo-accepted')->create();
         $response = $this->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
@@ -1172,7 +1172,7 @@ class PostTest extends TestCase
     public function testPostShowWithReactions()
     {
         $viewer = $this->randomUserId();
-        $post = factory(Post::class, 'accepted')->create();
+        $post = factory(Post::class, 'photo-accepted')->create();
 
         // Create two reactions for this post!
         Reaction::withTrashed()->firstOrCreate(['northstar_id' => $viewer, 'post_id' => $post->id]);

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -757,8 +757,8 @@ class PostTest extends TestCase
     public function testPostsIndexAsNonAdminNonOwner()
     {
         // Anonymous requests should only see accepted posts.
-        factory(Post::class, 'photo-accepted', 10)->create();
-        factory(Post::class, 'photo-rejected', 5)->create();
+        factory(Post::class, 10)->states('photo', 'accepted')->create();
+        factory(Post::class, 5)->states('photo', 'rejected')->create();
 
         $response = $this->getJson('api/v3/posts');
 
@@ -808,13 +808,13 @@ class PostTest extends TestCase
     {
         // Create an accepted post.
         $this->mockTime('8/3/2017 14:00:00');
-        $regularPost = factory(Post::class, 'photo-accepted')->create([
+        $regularPost = factory(Post::class)->states('photo', 'accepted')->create([
             'northstar_id' => $this->faker->unique()->northstar_id,
         ]);
 
         // And then later, create an anonymous post from another user.
         $this->mockTime('8/3/2017 17:30:00');
-        $anonymousPost = factory(Post::class, 'photo-accepted')->create([
+        $anonymousPost = factory(Post::class)->states('photo', 'accepted')->create([
             'northstar_id' => $this->faker->unique()->northstar_id,
         ]);
         $anonymousPost->actionModel->anonymous = 1;
@@ -875,9 +875,9 @@ class PostTest extends TestCase
     public function testPostsIndexAsNonAdminNonOwnerHiddenPosts()
     {
         // Anonymous requests should only see posts that are not tagged with "Hide In Gallery."
-        factory(Post::class, 'photo-accepted', 10)->create();
+        factory(Post::class, 10)->states('photo', 'accepted')->create();
 
-        $hiddenPost = factory(Post::class, 'photo-accepted')->create();
+        $hiddenPost = factory(Post::class)->states('photo', 'accepted')->create();
         $hiddenPost->tag('Hide In Gallery');
 
         $response = $this->getJson('api/v3/posts');
@@ -896,8 +896,8 @@ class PostTest extends TestCase
     public function testPostsIndexAsAdmin()
     {
         // Admins should see all posts.
-        factory(Post::class, 'photo-accepted', 10)->create();
-        factory(Post::class, 'photo-rejected', 5)->create();
+        factory(Post::class, 10)->states('photo', 'accepted')->create();
+        factory(Post::class, 5)->states('photo', 'rejected')->create();
 
         $response = $this->withAdminAccessToken()->getJson('api/v3/posts');
 
@@ -951,9 +951,9 @@ class PostTest extends TestCase
     public function testPostsIndexAsAdminHiddenPosts()
     {
         // Admins should see all posts.
-        factory(Post::class, 'photo-accepted', 10)->create();
+        factory(Post::class, 10)->states('photo', 'accepted')->create();
 
-        $hiddenPost = factory(Post::class, 'photo-accepted')->create();
+        $hiddenPost = factory(Post::class)->states('photo', 'accepted')->create();
         $hiddenPost->tag('Hide In Gallery');
 
         $response = $this->withAdminAccessToken()->getJson('api/v3/posts');
@@ -971,11 +971,11 @@ class PostTest extends TestCase
     public function testPostsIndexAsOwner()
     {
         $userId = $this->faker->unique()->northstar_id;
-        factory(Post::class, 'photo-pending', 2)->create(['northstar_id' => $userId]);
-        factory(Post::class, 'photo-rejected', 1)->create(['northstar_id' => $userId]);
+        factory(Post::class, 2)->states('photo', 'pending')->create(['northstar_id' => $userId]);
+        factory(Post::class)->states('photo', 'rejected')->create(['northstar_id' => $userId]);
 
         $otherId = $this->faker->unique()->northstar_id;
-        factory(Post::class, 'photo-rejected', 4)->create(['northstar_id' => $otherId]);
+        factory(Post::class, 4)->states('photo', 'rejected')->create(['northstar_id' => $otherId]);
 
         // Owners should be able to see their own posts of any status, but
         // not pending or rejected posts from other users.
@@ -1034,15 +1034,15 @@ class PostTest extends TestCase
         $ownerId = $this->faker->unique()->northstar_id;
 
         // Create posts and associate to this $ownerId.
-        $posts = factory(Post::class, 'photo-accepted', 2)->create(['northstar_id' => $ownerId]);
+        $posts = factory(Post::class, 2)->states('photo', 'accepted')->create(['northstar_id' => $ownerId]);
 
         // Create a hidden post from the same $ownerId.
-        $hiddenPost = factory(Post::class, 'photo-accepted')->create(['northstar_id' => $ownerId]);
+        $hiddenPost = factory(Post::class)->states('photo', 'accepted')->create(['northstar_id' => $ownerId]);
         $hiddenPost->tag('Hide In Gallery');
         $hiddenPost->save();
 
         // Create anothter hidden post by different user.
-        $secondHiddenPost = factory(Post::class, 'photo-accepted')->create([
+        $secondHiddenPost = factory(Post::class)->states('photo', 'accepted')->create([
             'northstar_id' => $this->faker->unique()->northstar_id,
         ]);
         $secondHiddenPost->tag('Hide In Gallery');
@@ -1069,13 +1069,13 @@ class PostTest extends TestCase
         $response->assertStatus(403);
 
         // Anon user should not be able to see a rejected post if it doesn't belong to them and if they're not an admin.
-        $post = factory(Post::class, 'photo-rejected')->create();
+        $post = factory(Post::class)->states('photo', 'rejected')->create();
         $response = $this->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(403);
 
         // Anon user is able to see an accepted post even if it doesn't belong to them and if they're not an admin.
-        $post = factory(Post::class, 'photo-accepted')->create();
+        $post = factory(Post::class)->states('photo', 'accepted')->create();
         $response = $this->getJson('api/v3/posts/' . $post->id);
 
         $response->assertStatus(200);
@@ -1172,7 +1172,7 @@ class PostTest extends TestCase
     public function testPostShowWithReactions()
     {
         $viewer = $this->randomUserId();
-        $post = factory(Post::class, 'photo-accepted')->create();
+        $post = factory(Post::class)->states('photo', 'accepted')->create();
 
         // Create two reactions for this post!
         Reaction::withTrashed()->firstOrCreate(['northstar_id' => $viewer, 'post_id' => $post->id]);

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -23,7 +23,7 @@ class ReviewsTest extends TestCase
         $northstarId = $this->faker->northstar_id;
         $schoolId = $this->faker->school_id;
 
-        $firstPost = factory(Post::class, 'photo-pending')->create([
+        $firstPost = factory(Post::class)->states('photo', 'pending')->create([
             'school_id' => $schoolId,
         ]);
         $actionId = $firstPost->action_id;
@@ -54,7 +54,7 @@ class ReviewsTest extends TestCase
             'school_id' => $schoolId,
         ]);
 
-        $secondPost = factory(Post::class, 'photo-pending')->create([
+        $secondPost = factory(Post::class)->states('photo', 'pending')->create([
             'action_id' => $actionId,
             'campaign_id' => $campaignId,
             'school_id' => $schoolId,

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -23,7 +23,7 @@ class ReviewsTest extends TestCase
         $northstarId = $this->faker->northstar_id;
         $schoolId = $this->faker->school_id;
 
-        $firstPost = factory(Post::class)->create([
+        $firstPost = factory(Post::class, 'photo-pending')->create([
             'school_id' => $schoolId,
         ]);
         $actionId = $firstPost->action_id;
@@ -54,7 +54,7 @@ class ReviewsTest extends TestCase
             'school_id' => $schoolId,
         ]);
 
-        $secondPost = factory(Post::class)->create([
+        $secondPost = factory(Post::class, 'photo-pending')->create([
             'action_id' => $actionId,
             'campaign_id' => $campaignId,
             'school_id' => $schoolId,

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -60,7 +60,9 @@ class PostModelTest extends TestCase
      */
     public function testBlinkPayload()
     {
-        $post = factory(Post::class)->create();
+        $post = factory(Post::class)->create([
+            'school_id' => 'Example School ID',
+        ]);
         $result = $post->toBlinkPayload();
 
         $this->assertEquals($result['campaign_slug'], 'test-example-campaign');

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -41,7 +41,7 @@ class PostModelTest extends TestCase
     {
         factory(Signup::class, 5)->create()
             ->each(function ($signup) {
-                $signup->posts()->saveMany(factory(Post::class, 'photo-accepted', 3)->create());
+                $signup->posts()->saveMany(factory(Post::class, 3)->states('photo', 'accepted')->create());
             });
 
         // Grab any old post.
@@ -65,8 +65,16 @@ class PostModelTest extends TestCase
         ]);
         $result = $post->toBlinkPayload();
 
+        // Test expected data was retrieved from GraphQL.
         $this->assertEquals($result['campaign_slug'], 'test-example-campaign');
         $this->assertEquals($result['campaign_title'], 'Test Example Campaign');
         $this->assertEquals($result['school_name'], 'San Dimas High School');
+
+        $post = factory(Post::class)->create([
+            'school_id' => null,
+        ]);
+        $result = $post->toBlinkPayload();
+
+        $this->assertEquals($result['school_name'], null);
     }
 }

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -41,7 +41,7 @@ class PostModelTest extends TestCase
     {
         factory(Signup::class, 5)->create()
             ->each(function ($signup) {
-                $signup->posts()->saveMany(factory(Post::class, 'accepted', 3)->create());
+                $signup->posts()->saveMany(factory(Post::class, 'photo-accepted', 3)->create());
             });
 
         // Grab any old post.


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Model Factory to cleanup a few TODO's in the codebase:

* Creates a base Post factory class, and different factory states for post type + post status per https://github.com/DoSomething/rogue/pull/836#discussion_r365419349

* Modifies the Action factory to collect School ID by default, making it applicable to include a School ID by default in our Post factory


### How should this be reviewed?

👀 

### Any background context you want to provide?

There's still an outstanding cleanup issue to create `action_stat` records for all approved posts with school id's, but that will be addressed in a future PR if there's time.

### Relevant tickets

References [Pivotal #170693976](https://www.pivotaltracker.com/story/show/170693976).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
