### PR TITLE
Create ActionStats for seed data

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -9,6 +9,7 @@ use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
 use Rogue\Models\Reaction;
 use Rogue\Types\ActionType;
+use Rogue\Models\ActionStat;
 use Rogue\Types\TimeCommitment;
 
 /**
@@ -35,6 +36,17 @@ $factory->define(Action::class, function (Generator $faker) {
         'noun' => 'things',
         'verb' => 'done',
         'collect_school_id' => true,
+    ];
+});
+
+// ActionStat Factory
+$factory->define(ActionStat::class, function (Generator $faker) {
+    $faker->addProvider(new FakerSchoolId($faker));
+
+    return [
+        'school_id' => $this->faker->school_id,
+        'action_id' => factory(Action::class)->create()->id,
+        'accepted_quantity' => $faker->randomNumber(3),
     ];
 });
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -46,7 +46,7 @@ class DatabaseSeeder extends Seeder
                      * If this accepted photo post has a school, add its quantity to a running total
                      * of the school's approved quantity, that we'll use to create an ActionStat.
                      */
-                    if (isset($schoolId) && !isset($approvedQuantityBySchoolId[$schoolId])) {
+                    if (isset($schoolId) && ! isset($approvedQuantityBySchoolId[$schoolId])) {
                         $approvedQuantityBySchoolId[$schoolId] = $acceptedPhotoPost->quantity;
                     } elseif (isset($schoolId)) {
                         $approvedQuantityBySchoolId[$schoolId] += $acceptedPhotoPost->quantity;
@@ -81,7 +81,7 @@ class DatabaseSeeder extends Seeder
 
                     $schoolId = $acceptedPhotoPost->school_id;
 
-                    if (isset($schoolId) && !isset($approvedQuantityBySchoolId[$schoolId])) {
+                    if (isset($schoolId) && ! isset($approvedQuantityBySchoolId[$schoolId])) {
                         $approvedQuantityBySchoolId[$schoolId] = $acceptedPhotoPost->quantity;
                     } elseif (isset($schoolId)) {
                         $approvedQuantityBySchoolId[$schoolId] += $acceptedPhotoPost->quantity;


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Database Seeder to calculate running totals for all schools when creating approved photo posts, and then adds ActionStat records accordingly.

* **Example Action view**

<img width="600" alt="Screen Shot 2020-01-15 at 1 36 35 PM" src="https://user-images.githubusercontent.com/1236811/72474026-d4a17b80-379c-11ea-92ab-fe4aef5f1e3a.png">

* **Example School view**

<img width="600" alt="Screen Shot 2020-01-15 at 1 45 24 PM" src="https://user-images.githubusercontent.com/1236811/72474296-572a3b00-379d-11ea-8d6a-89b2e13a7b6f.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

This beats manually needing to review posts with schools in order to verify the ActionStat views on the School/Action views are working properly.

### Relevant tickets

References part 2 of line 10 in the [Q1 2020 Running Cleanup List](https://docs.google.com/document/d/1XYaTS_uptSva2hYunhHT2O2E1fq0wTE_UTlqLtTMcF8/edit).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
