### PR TITLE
Adds migration for the Contentful campaign id column in campaigns table

### DIFF
--- a/database/migrations/2020_01_30_155905_add_contentful_campaign_i_d_to__campaign_table.php
+++ b/database/migrations/2020_01_30_155905_add_contentful_campaign_i_d_to__campaign_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddContentfulCampaignIDToCampaignTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('campaigns', function(Blueprint $table) {
+            $table->string('contentful_campaign_id')->nullable->comment('Add the related contentful campaign id when applicable.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('campaigns', function(Blueprint $table) {
+            $table->dropColumn('contentful_campaign_id');
+        });
+    }
+}

--- a/database/migrations/2020_01_30_155905_add_contentful_campaign_i_d_to__campaign_table.php
+++ b/database/migrations/2020_01_30_155905_add_contentful_campaign_i_d_to__campaign_table.php
@@ -14,7 +14,7 @@ class AddContentfulCampaignIDToCampaignTable extends Migration
     public function up()
     {
         Schema::table('campaigns', function (Blueprint $table) {
-            $table->string('contentful_campaign_id')->nullable->comment('Add the related contentful campaign id when applicable.');
+            $table->string('contentful_campaign_id')->after('id')->nullable()->comment('Add the related contentful campaign id when applicable.');
         });
     }
 

--- a/database/migrations/2020_01_30_155905_add_contentful_campaign_i_d_to__campaign_table.php
+++ b/database/migrations/2020_01_30_155905_add_contentful_campaign_i_d_to__campaign_table.php
@@ -13,7 +13,7 @@ class AddContentfulCampaignIDToCampaignTable extends Migration
      */
     public function up()
     {
-        Schema::table('campaigns', function(Blueprint $table) {
+        Schema::table('campaigns', function (Blueprint $table) {
             $table->string('contentful_campaign_id')->nullable->comment('Add the related contentful campaign id when applicable.');
         });
     }
@@ -25,7 +25,7 @@ class AddContentfulCampaignIDToCampaignTable extends Migration
      */
     public function down()
     {
-        Schema::table('campaigns', function(Blueprint $table) {
+        Schema::table('campaigns', function (Blueprint $table) {
             $table->dropColumn('contentful_campaign_id');
         });
     }


### PR DESCRIPTION
### What's this PR do?

This pull request creates the migration for adding the contentfulCampaignId to the Campaigns table!

### How should this be reviewed?

Does making this column nullable make sense? Or should it be required? 

Is the campaignID stored as a string or a number? How could one check this in the future? 

### Any background context you want to provide?

Doing some prep work for getting filters set up in Phoenix on the explore campaigns page.

### Relevant tickets

References [Pivotal #170987264](https://www.pivotaltracker.com/story/show/170987264).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
