### PR TITLE
Campaign Cause Filter

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -60,7 +60,7 @@ class CampaignsController extends ApiController
 
         // Apply scope for campaigns including specified causes:
         if (isset($filters['causes'])) {
-            $query->whereCauses($filters['causes']);
+            $query->withCauses($filters['causes']);
         }
 
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -59,8 +59,8 @@ class CampaignsController extends ApiController
         }
 
         // Apply scope for campaigns including specified causes:
-        if (isset($filters['has_cause'])) {
-            $query->whereHasCauses($filters['has_cause']);
+        if (isset($filters['causes'])) {
+            $query->whereCauses($filters['causes']);
         }
 
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -59,8 +59,8 @@ class CampaignsController extends ApiController
         }
 
         // Apply scope for campaigns including specified causes:
-        if (isset($filters['causes'])) {
-            $query->withCauses($filters['causes']);
+        if (isset($filters['cause'])) {
+            $query->withCauses($filters['cause']);
         }
 
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -58,9 +58,9 @@ class CampaignsController extends ApiController
             }
         }
 
-        // Apply scope for campaigns including specified cause:
+        // Apply scope for campaigns including specified causes:
         if (isset($filters['has_cause'])) {
-            $query->whereHasCause($filters['has_cause']);
+            $query->whereHasCauses($filters['has_cause']);
         }
 
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -58,6 +58,11 @@ class CampaignsController extends ApiController
             }
         }
 
+        // Apply scope for campaigns including specified cause:
+        if (isset($filters['has_cause'])) {
+            $query->whereHasCause($filters['has_cause']);
+        }
+
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):
         if ($cursor = array_get($request->query('cursor'), 'after')) {
             $query->whereAfterCursor($cursor);

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -136,8 +136,8 @@ class Campaign extends Model
         // Sanitize the input to prevent melicious regex pattern injection:
         $sanitizedCause = preg_replace("/[^\w-]/", '', $cause);
 
-        // Regex matches on comma separated words to ensure precise match excepting first
-        // and last words (matching on only a following or preceding comma).
+        // Regex tests for complete match against one of the comma separated causes.
+        // (https://regex101.com/r/RaDXos/5).
         return $query->where('cause', 'regexp', '(^|,)'.$sanitizedCause.'(,|$)');
     }
 

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -112,7 +112,6 @@ class Campaign extends Model
     }
 
     /**
-<<<<<<< HEAD
      * Scope a query to only include campaigns with an associated Contentful 'Website' entry.
      */
     public function scopeWhereHasWebsite($query)

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -136,7 +136,8 @@ class Campaign extends Model
         // Sanitize the input to prevent melicious regex pattern injection:
         $sanitizedCause = preg_replace("/[^\w-]/", '', $cause);
 
-        // Regex tests for complete match against one of the comma separated causes.
+        // Regex matches on comma separated words to ensure precise match.
+        // Accounts for first and last words only having a comma on one side.
         // (https://regex101.com/r/RaDXos/5).
         return $query->where('cause', 'regexp', '(^|,)'.$sanitizedCause.'(,|$)');
     }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -4,6 +4,7 @@ namespace Rogue\Models;
 
 use Carbon\Carbon;
 use Rogue\Types\Cause;
+use Illuminate\Support\Str;
 use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -134,7 +135,7 @@ class Campaign extends Model
     public function scopeWhereHasCause($query, $cause)
     {
         // Sanitize the input to prevent melicious regex pattern injection:
-        $sanitizedCause = preg_replace("/[^\w-]/", '', $cause);
+        $sanitizedCause = Str::slug($cause);
 
         // Regex matches on comma separated words to ensure precise match.
         // Accounts for first and last words only having a comma on one side.

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -128,18 +128,21 @@ class Campaign extends Model
     }
 
     /**
-     * Scope a query to only include campaigns containing specified cause within
-     * "cause" field.
+     * Scope a query to only include campaigns containing specified causes.
      */
-    public function scopeWhereHasCause($query, $cause)
+    public function scopeWhereHasCauses($query, $causes)
     {
-        // Sanitize the input to prevent melicious regex pattern injection:
-        $sanitizedCause = Str::slug($cause);
+        // Sanitize the inputted causes against our internal cause list.
+        $inputCauses = explode(',', $causes);
+        $sanitizedInputCauses = array_intersect(Cause::all(), $inputCauses);
 
-        // Regex matches on comma separated words to ensure precise match.
+        // Merge cause list separated by the regex "or" operator to filter by multiple causes.
+        $causesRegex = implode('|', $sanitizedInputCauses);
+
+        // Regex matches on comma separated words to ensure precise match for each cause.
         // Accounts for first and last words only having a comma on one side.
-        // (https://regex101.com/r/RaDXos/5).
-        return $query->where('cause', 'regexp', '(^|,)'.$sanitizedCause.'(,|$)');
+        // (https://regex101.com/r/RaDXos/6).
+        return $query->where('cause', 'regexp', '(^|,)'.$causesRegex.'(,|$)');
     }
 
     /**

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -130,7 +130,7 @@ class Campaign extends Model
     /**
      * Scope a query to only include campaigns containing specified causes.
      */
-    public function scopeWhereHasCauses($query, $causes)
+    public function scopeWhereCauses($query, $causes)
     {
         // Sanitize the inputted causes against our internal cause list.
         $inputCauses = explode(',', $causes);

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -129,7 +129,7 @@ class Campaign extends Model
     /**
      * Scope a query to only include campaigns containing specified causes.
      */
-    public function scopeWhereCauses($query, $causes)
+    public function scopeWithCauses($query, $causes)
     {
         // Sanitize the inputted causes against our internal cause list.
         $inputCauses = explode(',', $causes);

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -4,7 +4,6 @@ namespace Rogue\Models;
 
 use Carbon\Carbon;
 use Rogue\Types\Cause;
-use Illuminate\Support\Str;
 use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -133,9 +133,12 @@ class Campaign extends Model
      */
     public function scopeWhereHasCause($query, $cause)
     {
+        // Sanitize the input to prevent melicious regex pattern injection:
+        $sanitizedCause = preg_replace("/[^\w-]/", '', $cause);
+
         // Regex matches on comma separated words to ensure precise match excepting first
         // and last words (matching on only a following or preceding comma).
-        return $query->where('cause', 'regexp', '(^|,)'.$cause.'(,|$)');
+        return $query->where('cause', 'regexp', '(^|,)'.$sanitizedCause.'(,|$)');
     }
 
     /**

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -111,6 +111,7 @@ class Campaign extends Model
     }
 
     /**
+<<<<<<< HEAD
      * Scope a query to only include campaigns with an associated Contentful 'Website' entry.
      */
     public function scopeWhereHasWebsite($query)
@@ -124,6 +125,17 @@ class Campaign extends Model
     public function scopeWhereDoesNotHaveWebsite($query)
     {
         return $query->whereNull('contentful_campaign_id');
+    }
+
+    /**
+     * Scope a query to only include campaigns containing specified cause within
+     * "cause" field.
+     */
+    public function scopeWhereHasCause($query, $cause)
+    {
+        // Regex matches on comma separated words to ensure precise match excepting first
+        // and last words (matching on only a following or preceding comma).
+        return $query->where('cause', 'regexp', '(^|,)'.$cause.'(,|$)');
     }
 
     /**

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -12,7 +12,7 @@ GET /api/v3/campaigns
   - Filter results by the given column: `id`, `is_open`, `has_website`, `has_cause`
   - You can filter by more than one value for the ID column, e.g. `/campaigns?filter[id]=121,122`
   - Set the `has_website` filter to `true` (`filter[has_website]=true`) to yield campaign with their `contentful_campaign_id` field populated. Filter for campaigns _without_ the field set with `filter[has_website]=false`.
-  - The `has_cause` filter (`/campaigns?filter[has_cause]=education`) will return campaigns _including_ the specified cause. (Can filter by one value only).
+  - The `has_cause` filter (`/campaigns?filter[has_cause]=education`) will return campaigns _including_ the specified causes (you can filter by more then one value e.g. `filter[has_cause]=education,healthcare`).
 
 Example Response:
 

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -11,9 +11,10 @@ GET /api/v3/campaigns
 ### Optional Query Parameters
 
 - **filter[column]** _(string)_
-  - Filter results by the given column: `id`, `is_open`, `has_website`
+  - Filter results by the given column: `id`, `is_open`, `has_website`, `has_cause`
   - You can filter by more than one value for the ID column, e.g. `/campaigns?filter[id]=121,122`
   - Set the `has_website` filter to `true` (`filter[has_website]=true`) to yield campaign with their `contentful_campaign_id` field populated. Filter for campaigns _without_ the field set with `filter[has_website]=false`.
+  - The `has_cause` filter (`/campaigns?filter[has_cause]=education`) will return campaigns _including_ the specified cause. (Can filter by one value only).
 
 Example Response:
 

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -1,7 +1,5 @@
 ## Campaigns
 
-These endpoints require the role `admin` or `staff` to use.
-
 ## Retrieve All Campaigns (created in Rogue)
 
 ```

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -9,10 +9,10 @@ GET /api/v3/campaigns
 ### Optional Query Parameters
 
 - **filter[column]** _(string)_
-  - Filter results by the given column: `id`, `is_open`, `has_website`, `has_cause`
+  - Filter results by the given column: `id`, `is_open`, `has_website`, `causes`
   - You can filter by more than one value for the ID column, e.g. `/campaigns?filter[id]=121,122`
   - Set the `has_website` filter to `true` (`filter[has_website]=true`) to yield campaign with their `contentful_campaign_id` field populated. Filter for campaigns _without_ the field set with `filter[has_website]=false`.
-  - The `has_cause` filter (`/campaigns?filter[has_cause]=education`) will return campaigns _including_ the specified causes (you can filter by more then one value e.g. `filter[has_cause]=education,healthcare`).
+  - The `has_cause` filter (`/campaigns?filter[causes]=education`) will return campaigns _including_ the specified causes (you can filter by more then one value e.g. `filter[causes]=education,healthcare`).
 
 Example Response:
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -126,6 +126,12 @@ class CampaignTest extends Testcase
             $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
             $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
         }
+
+        // Test that regex patterns and special characters are discounted in filter:
+        $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.'+?!'.$causes[0].':)*.');
+        $decodedResponse = $response->decodeResponseJson();
+        $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+        $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
     }
 
     /**

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -127,11 +127,18 @@ class CampaignTest extends Testcase
             $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
         }
 
-        // Test that regex patterns and special characters are discounted in filter:
-        $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.'+?!'.$causes[0].':)*.');
+        // Test that we can filter by multiple causes.
+        $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.implode(',', array_slice($causes, 0, 3)));
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
         $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
+
+
+        // Test that invalid causes are rejected by the filter:
+        $response = $this->getJson('api/v3/campaigns?filter[has_cause]=this-is-not-a-cause,nor-this!');
+        $decodedResponse = $response->decodeResponseJson();
+        $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
+
     }
 
     /**

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -133,12 +133,10 @@ class CampaignTest extends Testcase
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
         $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
 
-
         // Test that invalid causes are rejected by the filter:
         $response = $this->getJson('api/v3/campaigns?filter[causes]=this-is-not-a-cause,nor-this!');
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
-
     }
 
     /**

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -120,7 +120,7 @@ class CampaignTest extends Testcase
         ]);
 
         foreach (array_slice($causes, 0, 3) as $index => $cause) {
-            $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.$cause);
+            $response = $this->getJson('api/v3/campaigns?filter[causes]='.$cause);
             $decodedResponse = $response->decodeResponseJson();
 
             $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
@@ -128,14 +128,14 @@ class CampaignTest extends Testcase
         }
 
         // Test that we can filter by multiple causes.
-        $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.implode(',', array_slice($causes, 0, 3)));
+        $response = $this->getJson('api/v3/campaigns?filter[causes]='.implode(',', array_slice($causes, 0, 3)));
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
         $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
 
 
         // Test that invalid causes are rejected by the filter:
-        $response = $this->getJson('api/v3/campaigns?filter[has_cause]=this-is-not-a-cause,nor-this!');
+        $response = $this->getJson('api/v3/campaigns?filter[causes]=this-is-not-a-cause,nor-this!');
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -120,7 +120,7 @@ class CampaignTest extends Testcase
         ]);
 
         foreach (array_slice($causes, 0, 3) as $index => $cause) {
-            $response = $this->getJson('api/v3/campaigns?filter[causes]='.$cause);
+            $response = $this->getJson('api/v3/campaigns?filter[cause]='.$cause);
             $decodedResponse = $response->decodeResponseJson();
 
             $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
@@ -128,13 +128,13 @@ class CampaignTest extends Testcase
         }
 
         // Test that we can filter by multiple causes.
-        $response = $this->getJson('api/v3/campaigns?filter[causes]='.implode(',', array_slice($causes, 0, 3)));
+        $response = $this->getJson('api/v3/campaigns?filter[cause]='.implode(',', array_slice($causes, 0, 3)));
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
         $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
 
         // Test that invalid causes are rejected by the filter:
-        $response = $this->getJson('api/v3/campaigns?filter[causes]=this-is-not-a-cause,nor-this!');
+        $response = $this->getJson('api/v3/campaigns?filter[cause]=this-is-not-a-cause,nor-this!');
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
     }

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Http;
 
 use Tests\TestCase;
-use Rogue\Types\Cause;
 use Rogue\Models\Post;
+use Rogue\Types\Cause;
 use Rogue\Models\Campaign;
 
 class CampaignTest extends Testcase
@@ -113,13 +113,13 @@ class CampaignTest extends Testcase
         // Let's test against pairs of three causes each so that we have a first, last, and middle cause
         // (ensuring we're testing our filtering logic against surrounding commas).
         $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
-            'cause' => array_slice($causes, 0 , 3),
+            'cause' => array_slice($causes, 0, 3),
         ]);
         $campaignWithLastThreeCauses = factory(Campaign::class, 1)->create([
             'cause' => array_slice($causes, -3),
         ]);
 
-        foreach(array_slice($causes, 0, 3) as $index => $cause) {
+        foreach (array_slice($causes, 0, 3) as $index => $cause) {
             $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.$cause);
             $decodedResponse = $response->decodeResponseJson();
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Http;
 
 use Tests\TestCase;
+use Rogue\Types\Cause;
 use Rogue\Models\Post;
 use Rogue\Models\Campaign;
 
@@ -103,6 +104,28 @@ class CampaignTest extends Testcase
         $response = $this->getJson('api/v3/campaigns?filter[has_website]=false');
         $decodedResponse = $response->decodeResponseJson();
         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+    }
+
+    public function testCauseFilteredCampaignIndex()
+    {
+        $causes = Cause::all();
+
+        // Let's test against pairs of three causes each so that we have a first, last, and middle cause
+        // (ensuring we're testing our filtering logic against surrounding commas).
+        $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
+            'cause' => array_slice($causes, 0 , 3),
+        ]);
+        $campaignWithLastThreeCauses = factory(Campaign::class, 1)->create([
+            'cause' => array_slice($causes, -3),
+        ]);
+
+        foreach(array_slice($causes, 0, 3) as $index => $cause) {
+            $response = $this->getJson('api/v3/campaigns?filter[has_cause]='.$cause);
+            $decodedResponse = $response->decodeResponseJson();
+
+            $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+            $this->assertEquals($campaignWithFirstThreeCauses->first()['id'], $decodedResponse['data'][0]['id']);
+        }
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds a filter to the `/campaigns` index API endpoint & Campaign model to allow filtering by included cause.

**Updated** as per our conversation [in Slack](https://dosomething.slack.com/archives/C0YGXUE01/p1580861249011600) to allow filtering by multiple causes with some more reliable sanitization.

### How should this be reviewed?
How's the filtering Regex? 
How's the filter name? (I thought `cause` implied a singular cause, as opposed to _included_ cause. I wasn't quite sure between `has_cause` and `includes_cause` though)
Does the test logic make sense?

### Any background context you want to provide?
I went with a `regexp` operator instead of a `LIKE` so that we obtain more precise matches. I couldn't think of an elegant way to allow fuzzy matching without being -in my view- way too generous about the filter. (Some of our cause words overlap, like `lgbtq-rights` & `gender-rights` and we want our cause pages to yield precise matches.)

You can mess around with the regex [here](https://regex101.com/r/D1dRxd/6).

I opted to test for a case where we have three comma-separated causes to ensure we're testing first, last, and regular ole middle words as far as commas are concerned. I hope this made sense!

### Relevant tickets

References [Pivotal #170734672](https://www.pivotaltracker.com/story/show/170734672).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
