### PR TITLE
Adds test for valid and invalid Update to a campaign

### DIFF
--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -217,7 +217,7 @@ class CampaignTest extends Testcase
 
         // Make sure the campaign update is persisted.
         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-        
+
         $response->assertStatus(200);
 
         $response->assertJson([

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -225,6 +225,11 @@ class CampaignTest extends Testcase
                 'contentful_campaign_id' => '123456',
             ],
         ]);
+
+        $this->assertDatabaseHas('campaigns', [
+            'id' => $campaign->id,
+            'contentful_campaign_id' => '123456',
+        ]);
     }
 
     /**

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -200,6 +200,54 @@ class CampaignTest extends Testcase
     }
 
     /**
+     * Test for updating a campaign successfully with contentful campaign id.
+     *
+     * PATCH /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testUpdatingACampaignWithContentfulId()
+    {
+        // Create a campaign to update.
+        $campaign = factory(Campaign::class)->create();
+
+        // Update the contentful campaign id.
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/campaigns/' . $campaign->id, [
+            'contentful_campaign_id' => '123456',
+        ]);
+
+        // Make sure the campaign update is persisted.
+        $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+        
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'contentful_campaign_id' => '123456',
+            ],
+        ]);
+    }
+
+    /**
+     * Test for updating a campaign with invalid status.
+     *
+     * PATCH /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testUpdatingACampaignWithInvalidStatus()
+    {
+        // Create a campaign to update.
+        $campaign = factory(Campaign::class)->create();
+
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/campaigns/' . $campaign->id, [
+            'contentful_campaign_id' => 123456, // This should be a string
+        ]);
+
+        $response->assertStatus(422);
+
+        $response->assertJsonValidationErrors(['contentful_campaign_id']);
+    }
+
+    /**
      * Test that a DELETE request to /campaigns/:campaign_id deletes a campaign.
      *
      * DELETE /campaigns/:campaign_id


### PR DESCRIPTION
### What's this PR do?

This pull request adds testing for the patch endpoint added to our `campaigns/:id` route. Includes a test for a valid request and invalid request

### How should this be reviewed?

Making sure this is thorough enough coverage for this endpoint! 

### Any background context you want to provide?

Follow similar patterns to the [post endpoint tests](https://github.com/DoSomething/rogue/blob/c1673a9b73c32d4bb16884a1d1619523c0d64054/tests/Http/PostTest.php#L1201).

### Relevant tickets

References [Pivotal #](https://www.pivotaltracker.com/story/show/170987264).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
