### PR TITLE
Campaign Has-Website Filter

### DIFF
--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -54,7 +54,7 @@ class CampaignsController extends ApiController
             if (filter_var($filters['has_website'], FILTER_VALIDATE_BOOLEAN)) {
                 $query->whereHasWebsite();
             } else {
-                $query->whereDoesntHaveWebsite();
+                $query->whereDoesNotHaveWebsite();
             }
         }
 

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -49,6 +49,15 @@ class CampaignsController extends ApiController
             }
         }
 
+        // Apply scope for the has_website filter:
+        if (isset($filters['has_website'])) {
+            if (filter_var($filters['has_website'], FILTER_VALIDATE_BOOLEAN)) {
+                $query->whereHasWebsite();
+            } else {
+                $query->whereDoesntHaveWebsite();
+            }
+        }
+
         // Experimental: Allow paginating by cursor (e.g. `?cursor[after]=OTAxNg==`):
         if ($cursor = array_get($request->query('cursor'), 'after')) {
             $query->whereAfterCursor($cursor);

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -121,7 +121,7 @@ class Campaign extends Model
     /**
      * Scope a query to only include campaigns without an associated Contentful 'Website' entry.
      */
-    public function scopeWhereDoesntHaveWebsite($query)
+    public function scopeWhereDoesNotHaveWebsite($query)
     {
         return $query->whereNull('contentful_campaign_id');
     }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -111,6 +111,22 @@ class Campaign extends Model
     }
 
     /**
+     * Scope a query to only include campaigns with an associated Contentful 'Website' entry.
+     */
+    public function scopeWhereHasWebsite($query)
+    {
+        return $query->whereNotNull('contentful_campaign_id');
+    }
+
+    /**
+     * Scope a query to only include campaigns without an associated Contentful 'Website' entry.
+     */
+    public function scopeWhereDoesntHaveWebsite($query)
+    {
+        return $query->whereNull('contentful_campaign_id');
+    }
+
+    /**
      * Should we accept new signups & posts for this campaign?
      *
      * @return bool

--- a/docs/endpoints/campaigns.md
+++ b/docs/endpoints/campaigns.md
@@ -11,8 +11,9 @@ GET /api/v3/campaigns
 ### Optional Query Parameters
 
 - **filter[column]** _(string)_
-  - Filter results by the given column: `id`, `is_open`
+  - Filter results by the given column: `id`, `is_open`, `has_website`
   - You can filter by more than one value for the ID column, e.g. `/campaigns?filter[id]=121,122`
+  - Set the `has_website` filter to `true` (`filter[has_website]=true`) to yield campaign with their `contentful_campaign_id` field populated. Filter for campaigns _without_ the field set with `filter[has_website]=false`.
 
 Example Response:
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -84,6 +84,28 @@ class CampaignTest extends Testcase
     }
 
     /**
+     * Test that we can filter campaigns with an associated Contentful 'Website' entry.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testWebsiteFilteredCampaignIndex()
+    {
+        factory(Campaign::class, 5)->create([
+            'contentful_campaign_id' => '123',
+        ]);
+        factory(Campaign::class, 3)->create();
+
+        $response = $this->getJson('api/v3/campaigns?filter[has_website]=true');
+        $decodedResponse = $response->decodeResponseJson();
+        $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson('api/v3/campaigns?filter[has_website]=false');
+        $decodedResponse = $response->decodeResponseJson();
+        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+    }
+
+    /**
      * Test that we can use cursor pagination.
      *
      * GET /api/v3/campaigns


### PR DESCRIPTION
### What's this PR do?

This pull request adds a filter to the Campaigns index API endpoint to scope out campaigns with/without an assigned `contentful_campaign_id`

### How should this be reviewed?
How's the naming?
Does it make sense to have both scopes for with/without? (It seemed like a logical way to apply this filter).

### Any background context you want to provide?
Now that we have this new column 'linking' to associated 'Campaign Websites' in Contentful (#450), this filter will allow us to properly scope out these campaigns via the API

### Relevant tickets

References [Pivotal #171027117](https://www.pivotaltracker.com/n/projects/2401401/stories/171027117).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
