### PR TITLE
Adding an index to the start date in campaigns

### DIFF
--- a/database/migrations/2020_02_12_154805_add_index_to_campaign_start_date.php
+++ b/database/migrations/2020_02_12_154805_add_index_to_campaign_start_date.php
@@ -13,7 +13,7 @@ class AddIndexToCampaignStartDate extends Migration
      */
     public function up()
     {
-        Schema::table('campaigns', function(Blueprint $table) {
+        Schema::table('campaigns', function (Blueprint $table) {
             $table->index('start_date');
         });
     }
@@ -25,7 +25,7 @@ class AddIndexToCampaignStartDate extends Migration
      */
     public function down()
     {
-        Schema::table('campaigns', function(Blueprint $table) {
+        Schema::table('campaigns', function (Blueprint $table) {
             $table->dropIndex('start_date');
         });
     }

--- a/database/migrations/2020_02_12_154805_add_index_to_campaign_start_date.php
+++ b/database/migrations/2020_02_12_154805_add_index_to_campaign_start_date.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToCampaignStartDate extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('campaigns', function(Blueprint $table) {
+            $table->index('start_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('campaigns', function(Blueprint $table) {
+            $table->dropIndex('start_date');
+        });
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration for an index to be added to the start date in the campaigns table. We are doing this as a precaution since we'll be using this property to sort in phoenix via graphql.

### How should this be reviewed?

👀 

### Any background context you want to provide?

See note about why we are adding above ^^

### Relevant tickets

References [Pivotal # 170823697](https://www.pivotaltracker.com/story/show/170823697).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
