### PR TITLE
Script to clean up causes

### DIFF
--- a/app/Console/Commands/StandardizeCauses.php
+++ b/app/Console/Commands/StandardizeCauses.php
@@ -43,7 +43,7 @@ class StandardizeCauses extends Command
         // Grab every campaign that has a cause set
         $campaignsWithCause = Campaign::whereNotNull('cause')->get();
 
-        foreach($campaignsWithCause as $campaign) {
+        foreach ($campaignsWithCause as $campaign) {
             $this->info('Updating campaign '.$campaign->id);
 
             $oldCause = $campaign->getOriginal('cause');

--- a/app/Console/Commands/StandardizeCauses.php
+++ b/app/Console/Commands/StandardizeCauses.php
@@ -48,7 +48,7 @@ class StandardizeCauses extends Command
 
             // Grab the old causes
             $oldCauses = $campaign->cause;
-            $this->info('--From:'.implode(',',$oldCauses));
+            $this->info('--From:'.implode(',', $oldCauses));
 
             // Trim whitespace, make the causes lowercase, and replaces spaces with hyphens
             // Add cleaned up causes to a new array
@@ -56,7 +56,7 @@ class StandardizeCauses extends Command
             foreach ($oldCauses as $oldCause) {
                 array_push($newCauses, str_replace(' ', '-', strtolower(trim($oldCause))));
             }
-            $this->info('--To:'.implode(',',$newCauses));
+            $this->info('--To:'.implode(',', $newCauses));
 
             // Set and save the clean causes
             $campaign->cause = $newCauses;

--- a/app/Console/Commands/StandardizeCauses.php
+++ b/app/Console/Commands/StandardizeCauses.php
@@ -46,17 +46,20 @@ class StandardizeCauses extends Command
         foreach ($campaignsWithCause as $campaign) {
             $this->info('Updating campaign '.$campaign->id);
 
-            $oldCause = $campaign->getOriginal('cause');
-            $this->info('--From:'.$oldCause);
+            // Grab the old causes
+            $oldCauses = $campaign->cause;
+            $this->info('--From:'.implode(',',$oldCauses));
 
-            // Make the causes lowercase and replaces spaces with hyphens
-            $newCause = str_replace(' ', '-', strtolower($oldCause));
-            $this->info('--To:'.$newCause);
+            // Trim whitespace, make the causes lowercase, and replaces spaces with hyphens
+            // Add cleaned up causes to a new array
+            $newCauses = [];
+            foreach ($oldCauses as $oldCause) {
+                array_push($newCauses, str_replace(' ', '-', strtolower(trim($oldCause))));
+            }
+            $this->info('--To:'.implode(',',$newCauses));
 
-            // Re-format the new cause string as the array that our mutator expects
-            $newCause = explode(',', $newCause);
-            $campaign->cause = $newCause;
-
+            // Set and save the clean causes
+            $campaign->cause = $newCauses;
             $campaign->save();
 
             $this->info('--✔ Successfully updated!');

--- a/app/Console/Commands/StandardizeCauses.php
+++ b/app/Console/Commands/StandardizeCauses.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Rogue\Models\Campaign;
+use Illuminate\Console\Command;
+
+class StandardizeCauses extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:standardizecauses';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates causes on campaigns to be lowercased and hyphenated';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info('rogue:standardizecauses: Starting to clean up the causes!');
+
+        // Grab every campaign that has a cause set
+        $campaignsWithCause = Campaign::whereNotNull('cause')->get();
+
+        foreach($campaignsWithCause as $campaign) {
+            $this->info('Updating campaign '.$campaign->id);
+
+            $oldCause = $campaign->getOriginal('cause');
+            $this->info('--From:'.$oldCause);
+
+            // Make the causes lowercase and replaces spaces with hyphens
+            $newCause = str_replace(' ', '-', strtolower($oldCause));
+            $this->info('--To:'.$newCause);
+
+            // Re-format the new cause string as the array that our mutator expects
+            $newCause = explode(',', $newCause);
+            $campaign->cause = $newCause;
+
+            $campaign->save();
+
+            $this->info('--✔ Successfully updated!');
+        }
+
+        $this->info('rogue:standardizecauses: All causes cleaned up!');
+    }
+}

--- a/tests/Console/StandardizeCausesCommandTest.php
+++ b/tests/Console/StandardizeCausesCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Console;
+
+use Tests\TestCase;
+use Rogue\Models\Campaign;
+
+class StandardizeCausesCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_standardize_causes()
+    {
+        // Create the campaigns with causes that we'll stadardize
+        $campaign1 = factory(Campaign::class)->create(['cause' => ['Olympic Gold Medal', 'Soccer Games', 'Team USA']])->first();
+        $campaign2 = factory(Campaign::class)->create(['cause' => ['Atlanta-Games', 'Centennial-Park']])->first();
+        $campaign3 = factory(Campaign::class)->create(['cause' => ['snowboard-cross', 'short-track']])->first();
+
+        // Run the 'rogue:standardizecauses' command
+        $this->artisan('rogue:standardizecauses');
+
+        // And see that the standardized causes are stored in the database
+        $this->assertDatabaseHas('campaigns', [
+            'cause' => 'olympic-gold-medal,soccer-games,team-usa',
+        ]);
+
+        $this->assertDatabaseHas('campaigns', [
+            'cause' => 'atlanta-games,centennial-park',
+        ]);
+
+        $this->assertDatabaseHas('campaigns', [
+            'cause' => 'snowboard-cross,short-track',
+        ]);
+    }
+}

--- a/tests/Console/StandardizeCausesCommandTest.php
+++ b/tests/Console/StandardizeCausesCommandTest.php
@@ -11,9 +11,10 @@ class StandardizeCausesCommandTest extends TestCase
     public function it_should_standardize_causes()
     {
         // Create the campaigns with causes that we'll stadardize
-        $campaign1 = factory(Campaign::class)->create(['cause' => ['Olympic Gold Medal', 'Soccer Games', 'Team USA']])->first();
-        $campaign2 = factory(Campaign::class)->create(['cause' => ['Atlanta-Games', 'Centennial-Park']])->first();
-        $campaign3 = factory(Campaign::class)->create(['cause' => ['snowboard-cross', 'short-track']])->first();
+        $campaign1 = factory(Campaign::class)->create(['cause' => ['Olympic Gold Medal', 'Soccer Games', 'Team USA']]);
+        $campaign2 = factory(Campaign::class)->create(['cause' => ['Atlanta-Games', 'Centennial-Park']]);
+        $campaign3 = factory(Campaign::class)->create(['cause' => ['snowboard-cross', 'short-track']]);
+        $campaign4 = factory(Campaign::class)->create(['cause' => [' Equal Pay  ', 'Corner Kick ']]);
 
         // Run the 'rogue:standardizecauses' command
         $this->artisan('rogue:standardizecauses');
@@ -29,6 +30,10 @@ class StandardizeCausesCommandTest extends TestCase
 
         $this->assertDatabaseHas('campaigns', [
             'cause' => 'snowboard-cross,short-track',
+        ]);
+
+        $this->assertDatabaseHas('campaigns', [
+            'cause' => 'equal-pay,corner-kick',
         ]);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request creates an artisan command to clean up causes! It grabs all campaigns with `cause` set, then it takes that cause and makes it lowercase and also replaces spaces with hyphens. This operation is performed even if the cause is already in that format, so messed up causes will be fixed and ones that are already formatted correctly will remain as they are.

### How should this be reviewed?

Will this clean up all the funky causes?

### Any background context you want to provide?

We don't want to have to worry about transforming these causes in other places, let's store them all the same!

### Relevant tickets

References [Pivotal #171159859](https://www.pivotaltracker.com/story/show/171159859).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
