### PR TITLE
Surface Contentful campaign ID in Rogue admin

### DIFF
--- a/app/Http/Controllers/Web/CampaignsController.php
+++ b/app/Http/Controllers/Web/CampaignsController.php
@@ -20,6 +20,7 @@ class CampaignsController extends Controller
 
         $this->rules = [
             'internal_title' => ['required', 'string'],
+            'contentful_campaign_id' => ['nullable', 'string', 'max:255'],
             'cause' => ['required', 'array', 'between:1,5'],
             'cause.*' => ['string', Rule::in(Cause::all())],
             'impact_doc' => ['required', 'url'],

--- a/resources/assets/components/Campaign/index.js
+++ b/resources/assets/components/Campaign/index.js
@@ -24,6 +24,7 @@ const SHOW_CAMPAIGN_ACTIONS_QUERY = gql`
       createdAt
       endDate
       id
+      contentfulCampaignId
       impactDoc
       internalTitle
       startDate
@@ -100,6 +101,13 @@ const Campaign = ({ id }) => {
 
         <h4>Campaign ID</h4>
         <p>{campaign.id}</p>
+
+        <h4>Contentful Campaign ID</h4>
+        {campaign.contentfulCampaignId ? (
+          <p>{campaign.contentfulCampaignId}</p>
+        ) : (
+          <p>–</p>
+        )}
 
         <h4>URL</h4>
         <p>

--- a/resources/views/campaigns/create.blade.php
+++ b/resources/views/campaigns/create.blade.php
@@ -8,7 +8,7 @@
         <div class="wrapper">
             <div class="container__block -narrow">
                 <h1>Create Campaign ID</h1>
-                <p>Please reach out in the #dev-rogue channel for help creating a campaign ID for your campaign.</p>
+                <p>Please reach out in the #help-product channel for help creating a campaign ID for your campaign.</p>
                 <br>
                 <form method="post" enctype="application/x-www-form-urlencoded" action="{{ route('campaigns.store') }}">
                 {{ csrf_field()}}

--- a/resources/views/campaigns/create.blade.php
+++ b/resources/views/campaigns/create.blade.php
@@ -16,6 +16,7 @@
                     <div class="form-item">
                         <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
                         <input type="text" name="contentful_campaign_id" class="text-field" value="{{ old('contentful_campaign_id') }}">
+                        <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
                     </div>
 
                     <div class="form-item">

--- a/resources/views/campaigns/create.blade.php
+++ b/resources/views/campaigns/create.blade.php
@@ -14,15 +14,15 @@
                 {{ csrf_field()}}
 
                     <div class="form-item">
-                        <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
-                        <input type="text" name="contentful_campaign_id" class="text-field" value="{{ old('contentful_campaign_id') }}">
-                        <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
-                    </div>
-
-                    <div class="form-item">
                         <label class="field-label">Internal Campaign Name</label>
                         <input type="text" name="internal_title" class="text-field" placeholder="Campaign Name YYYY-MM Start Date
  e.g. Teens for Jeans 2015-08" value="{{old('internal_title') }}">
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
+                        <input type="text" name="contentful_campaign_id" class="text-field" value="{{ old('contentful_campaign_id') }}">
+                        <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
                     </div>
 
                     <div class="form-item">

--- a/resources/views/campaigns/create.blade.php
+++ b/resources/views/campaigns/create.blade.php
@@ -14,6 +14,11 @@
                 {{ csrf_field()}}
 
                     <div class="form-item">
+                        <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
+                        <input type="text" name="contentful_campaign_id" class="text-field" value="{{ old('contentful_campaign_id') }}">
+                    </div>
+
+                    <div class="form-item">
                         <label class="field-label">Internal Campaign Name</label>
                         <input type="text" name="internal_title" class="text-field" placeholder="Campaign Name YYYY-MM Start Date
  e.g. Teens for Jeans 2015-08" value="{{old('internal_title') }}">

--- a/resources/views/campaigns/edit.blade.php
+++ b/resources/views/campaigns/edit.blade.php
@@ -25,7 +25,7 @@
                     </div>
 
                     <div class="form-item">
-                        <label class="field-label">Contentful Campaign ID</label>
+                        <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
                         <input type="text" name="contentful_campaign_id" class="text-field"
                             @if (old('contentful_campaign_id'))
                                 value="{{ old('contentful_campaign_id') }}"

--- a/resources/views/campaigns/edit.blade.php
+++ b/resources/views/campaigns/edit.blade.php
@@ -33,6 +33,7 @@
                                 value="{{ $campaign->contentful_campaign_id }}"
                             @endif
                         >
+                        <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
                     </div>
 
                     <div class="form-item">

--- a/resources/views/campaigns/edit.blade.php
+++ b/resources/views/campaigns/edit.blade.php
@@ -25,6 +25,17 @@
                     </div>
 
                     <div class="form-item">
+                        <label class="field-label">Contentful Campaign ID</label>
+                        <input type="text" name="contentful_campaign_id" class="text-field"
+                            @if (old('contentful_campaign_id'))
+                                value="{{ old('contentful_campaign_id') }}"
+                            @else
+                                value="{{ $campaign->contentful_campaign_id }}"
+                            @endif
+                        >
+                    </div>
+
+                    <div class="form-item">
                         <label class="field-label">Cause Area <em>(choose between 1-5)</em></label>
                         <div class="columns-2">
                             @foreach($causes as $cause => $name)


### PR DESCRIPTION
### What's this PR do?

This pull request surfaces the `contentful_campaign_id` in Rogue admin when a campaign is created, edited, or viewed.

Creating:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/4240292/75492782-51637000-596d-11ea-816e-4ec34df7237f.png">

Editing:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/4240292/75492741-401a6380-596d-11ea-96d0-95934d9248ca.png">

Viewing:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/4240292/75384103-6ae3b980-5892-11ea-8c4d-6850e06edf3d.png">

### How should this be reviewed?

Is there anywhere else this field needs to be surfaced? Does this correctly show and edit the field? Is the validation good to go?

### Relevant tickets

References [Pivotal #171026928](https://www.pivotaltracker.com/story/show/171026928).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
