### PR TITLE
Action Volunteer Credit Field on the Front End

### DIFF
--- a/app/Http/Controllers/Web/ActionsController.php
+++ b/app/Http/Controllers/Web/ActionsController.php
@@ -41,6 +41,7 @@ class ActionsController extends Controller
             'actionTypes' => ActionType::labels(),
             'timeCommitments' => TimeCommitment::labels(),
             'campaignId' => (int) $campaignId,
+            'isAdminUser' => is_admin_user(),
         ]);
     }
 
@@ -89,6 +90,7 @@ class ActionsController extends Controller
             'postTypes' => PostType::labels(),
             'actionTypes' => ActionType::labels(),
             'timeCommitments' => TimeCommitment::labels(),
+            'isAdminUser' => is_admin_user(),
         ]);
     }
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -106,7 +106,7 @@ class PostRepository
         // If this is a share-social type post, auto-accept.
         $post->status = $post->type === 'share-social' ? 'accepted' : 'pending';
 
-        $isAdminOrStaff = auth()->user() && in_array(auth()->user()->role, ['admin', 'staff']);
+        $isAdminOrStaff = is_staff_user();
 
         $hasAdminScope = in_array('admin', token()->scopes());
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -92,22 +92,6 @@ function getNorthstarId($request)
 }
 
 /**
- * Determines if the user is an admin or staff.
- *
- * @return bool
- */
-function is_staff_user(): bool
-{
-    // If this is a machine client, then it's de-facto an admin:
-    if (token()->exists() && ! token()->id()) {
-        return true;
-    }
-
-    // Otherwise, do we have a (web or OAuth) user? If so, are they a staff/admin?
-    return auth()->user() && in_array(auth()->user()->role, ['admin', 'staff']);
-}
-
-/**
  * Determines if the user is an admin.
  *
  * @return bool
@@ -119,8 +103,17 @@ function is_admin_user(): bool
         return true;
     }
 
-    // Otherwise, do we have a (web or OAuth) user? If so, are they an admin?
-    return auth()->user() && in_array(auth()->user()->role, ['admin']);
+    return optional(auth()->user())->role === 'admin';
+}
+
+/**
+ * Determines if the user is an admin or staff.
+ *
+ * @return bool
+ */
+function is_staff_user(): bool
+{
+    return is_admin_user() || optional(auth()->user())->role === 'staff';
 }
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -108,6 +108,22 @@ function is_staff_user(): bool
 }
 
 /**
+ * Determines if the user is an admin.
+ *
+ * @return bool
+ */
+function is_admin_user(): bool
+{
+    // If this is a machine client, then it's de-facto an admin:
+    if (token()->exists() && ! token()->id()) {
+        return true;
+    }
+
+    // Otherwise, do we have a (web or OAuth) user? If so, are they an admin?
+    return auth()->user() && in_array(auth()->user()->role, ['admin']);
+}
+
+/**
  * Determine if the user owns the given resource.
  *
  * @return bool

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -148,6 +148,15 @@ export const Action = ({ action, deleteAction, isPermalink }) => {
               <p className="no">No</p>
             )}
           </li>
+          {/*@TODO: Add volunteerCredit field to gql fragmant above once it's added to the graphql schema */}
+          <li>
+            <h4>VOLUNTEER CREDIT</h4>
+            {action.volunteerCredit === true ? (
+              <p className="yes">Yes</p>
+            ) : (
+              <p className="no">No</p>
+            )}
+          </li>
         </ul>
       </div>
       {action.campaign && action.campaign.isOpen && !isAdmin ? null : (

--- a/resources/assets/components/Action/index.js
+++ b/resources/assets/components/Action/index.js
@@ -23,6 +23,7 @@ export const ActionFragment = gql`
     postType
     reportback
     scholarshipEntry
+    volunteerCredit
     timeCommitmentLabel
     verb
   }
@@ -148,7 +149,6 @@ export const Action = ({ action, deleteAction, isPermalink }) => {
               <p className="no">No</p>
             )}
           </li>
-          {/*@TODO: Add volunteerCredit field to gql fragmant above once it's added to the graphql schema */}
           <li>
             <h4>VOLUNTEER CREDIT</h4>
             {action.volunteerCredit === true ? (

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -51,6 +51,9 @@
                         @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback'])
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action'])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry'])
+                        @if ($isAdminUser)
+                            @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit'])
+                        @endif
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous'])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action'])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action'])

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -55,6 +55,9 @@
                         @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback', 'value' => $action->reportback])
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action', 'value' => $action->civic_action])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry', 'value' => $action->scholarship_entry])
+                        @if ($isAdminUser)
+                            @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit'])
+                        @endif
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous', 'value' => $action->anonymous])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action', 'value' => $action->online])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action', 'value' => $action->quiz])


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `volunteer_credit` field to the Action forms for admins & exposes the field on Action views.

### How should this be reviewed?
commit-by-commit!
- https://github.com/DoSomething/rogue/commit/20b80057149c408233e770c856e78e6121dec766 adds a new `is_admin_user` helper method to determine admin role status.
- https://github.com/DoSomething/rogue/commit/a9592f151a90d45c3f8881a0612625ab054338ea does a touch of refactoring to those helpers since we're now repeating logic
- https://github.com/DoSomething/rogue/commit/c273cf80fdd10509a6567efcab0b893064ea7932 adds the form field to Action create/edit forms for admins
- https://github.com/DoSomething/rogue/commit/5d3edad70812f6eaf27779c77911ef5fc729dc3b adds the field to the Action view component
- https://github.com/DoSomething/rogue/commit/72aea92cbb11f7aa1b9c8296b778a0c42213aae2 uses the user role helper someplace I chanced upon that we didn't

### Any background context you want to provide?
- We're limiting the form field to admins until this feature is more formalized and rolled out. I didn't do anything fancy with validation for roles or whatnot since this is just a low-level barrier for our staff.
- ~The field on the Action show component won't actually work until we add the field to the GraphQL schema & query it in the fragment~ added to the fragment in https://github.com/DoSomething/rogue/pull/996/commits/2020c6eaf3f8496d0823619ea06e0acd294a7b18, and merged https://github.com/DoSomething/graphql/pull/199
### Relevant tickets

References [Pivotal #171455025](https://www.pivotaltracker.com/story/show/171455025).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
