### PR TITLE
Posts Endpoint Status Filter Docs/Test

### DIFF
--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -34,8 +34,8 @@ If the post's action is marked as "anonymous", the `northstar_id` field will onl
   - The northstar_id to filter the response by.
   - e.g. `/posts?filter[northstar_id]=47asdf23abc`
 - **filter[status]** _(string)_
-  - The status to filter the response by.
-  - e.g. `/posts?filter[status]=accepted`
+  - The status(es) to filter the response by.
+  - e.g. `/posts?filter[status]=accepted,pending`
 - **filter[type]** _(string)_
   - The type to filter the response by.
   - e.g. `/posts?filter[type]=photo,voter-reg`

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -962,6 +962,31 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test for retrieving posts as admin filtered by status.
+     *
+     * GET /api/v3/posts
+     * @return void
+     */
+    public function testPostsIndexFilteredByStatusAsAdmin()
+    {
+        factory(Post::class, 1)->states('photo', 'accepted')->create();
+        factory(Post::class, 5)->states('photo', 'pending')->create();
+        factory(Post::class, 7)->states('photo', 'rejected')->create();
+
+        // Admins should see posts filtered by pending status.
+        $response = $this->withAdminAccessToken()->getJson('api/v3/posts?filter[status]=pending');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(5, 'data');
+
+        // Admins should be able to filter by multiple statuses and see pending and rejected posts.
+        $response = $this->withAdminAccessToken()->getJson('api/v3/posts?filter[status]=pending,rejected');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(12, 'data');
+    }
+
+    /**
      * Test for retrieving all posts as owner.
      * Owners should see tags, source, and remote_addr.
      *


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `/posts` documentation to indicate ability to filter posts by multiple statuses and adds a test for filtering by status.

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #171455035](https://www.pivotaltracker.com/n/projects/2401401/stories/171455035).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
