### PR TITLE
Posts API Index Endpoint - Volunteer Credit Filter

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -91,6 +91,14 @@ class PostsController extends ApiController
             $query = $query->withTag($filters['tag']);
         }
 
+        if (array_has($filters, 'volunteer_credit')) {
+            if (filter_var($filters['volunteer_credit'], FILTER_VALIDATE_BOOLEAN)) {
+                $query = $query->withVolunteerCredit($filters['volunteer_credit']);
+            } else {
+                $query = $query->withoutVolunteerCredit($filters['volunteer_credit']);
+            }
+        }
+
         // If the northstar_id param is passed, only allow admins, staff, or owner to see anonymous posts.
         if (array_has($filters, 'northstar_id')) {
             $query = $query->withoutAnonymousPosts();

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -400,6 +400,28 @@ class Post extends Model
     }
 
     /**
+     * Returns posts which qualify for volunteer credit.
+     * (The associated Action's volunteer credit field is set to true).
+     */
+    public function scopeWithVolunteerCredit($query, $volunteerCreditValue)
+    {
+        return $query->whereHas('actionModel', function ($query) use ($volunteerCreditValue) {
+            $query->where('volunteer_credit', true);
+        });
+    }
+
+    /**
+     * Returns posts which do not qualify for volunteer credit.
+     * (The associated Action's volunteer credit field is set to false).
+     */
+    public function scopeWithoutVolunteerCredit($query, $volunteerCreditValue)
+    {
+        return $query->whereHas('actionModel', function ($query) use ($volunteerCreditValue) {
+            $query->where('volunteer_credit', false);
+        });
+    }
+
+    /**
      * Returns posts that are reviewable.
      */
     public function scopeWhereReviewable($query)

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -36,6 +36,7 @@ $factory->define(Action::class, function (Generator $faker) {
         'noun' => 'things',
         'verb' => 'done',
         'collect_school_id' => true,
+        'volunteer_credit' => false,
     ];
 });
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -61,6 +61,9 @@ If the post's action is marked as "anonymous", the `northstar_id` field will onl
 - **filter[location]** _(string)_
   - The location to filter the response by.
   - e.g. `/posts?filter[location]=US-NY`
+- **filter[volunteer_credit]** _(boolean)_
+  - Filter for posts (un)qualified for volunteer credit (where the associated action's volunteer_credit field is true/false.)
+  - e.g. `/posts?filter[volunteer_credit]=true`
 - **include** _(string)_
   - Include additional related records in the response: `signup`, `siblings`
   - e.g. `/posts?include=signup,siblings`

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -987,6 +987,33 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test for retrieving posts filtered by the volunteer_credit value of the associated action.
+     *
+     * GET /api/v3/posts
+     * @return void
+     */
+    public function testPostsIndexFilteredByVolunteerCredit()
+    {
+        $action = factory(Action::class)->create([
+            'volunteer_credit' => true,
+        ]);
+        // Posts qualifying for volunteer credit:
+        factory(Post::class, 4)->states('photo', 'accepted')->create([
+            'action_id' => $action->id,
+        ]);
+        // Posts not qualifying for volunteer credit:
+        factory(Post::class, 7)->states('photo', 'accepted')->create();
+
+        $response = $this->getJson('api/v3/posts?filter[volunteer_credit]=true');
+        $response->assertSuccessful();
+        $response->assertJsonCount(4, 'data');
+
+        $response = $this->getJson('api/v3/posts?filter[volunteer_credit]=false');
+        $response->assertSuccessful();
+        $response->assertJsonCount(7, 'data');
+    }
+
+    /**
      * Test for retrieving all posts as owner.
      * Owners should see tags, source, and remote_addr.
      *


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `filter[volunteer_credit]=true/false` filter to the `/posts` API endpoint to filter for posts un/qualified for volunteer credit.

### How should this be reviewed?
Feel free to weigh in [on this conversation](https://www.pivotaltracker.com/story/show/171455085/comments/212433853):
We deliberated over implementing this as more of a direct filter on the Action itself, allowing us to filter by multiple Action fields as positive includes. e.g. `/posts?filter[action_model]=volunteer_credit,quiz...`

The downside is that this does not allow for the negative include (where posts are _not_ anonymous for example. Though admittedly, there isn't a use case for the `volunteer_credit` negative scoping as of yet...), and is more direct to the feature we're filtering by. (This also _doesn't_ negate the possibility of adding such a filter if the need arises!) 

### Any background context you want to provide?
This will serve the Volunteer Credit rewards table on Phoenix, where we can now filter the Posts qualifying for volunteer credit from Rogue.

### Relevant tickets

References [Pivotal #171455085](https://www.pivotaltracker.com/story/show/171455085).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
