### PR TITLE
Add <5 minute time commitment

### DIFF
--- a/app/Types/TimeCommitment.php
+++ b/app/Types/TimeCommitment.php
@@ -4,6 +4,7 @@ namespace Rogue\Types;
 
 class TimeCommitment extends Type
 {
+    private const LESS_THAN_FIVE_MINUTES = '<0.083';
     private const LESS_THAN_THIRTY_MINUTES = '<0.5';
     private const THIRTY_MINUTES_TO_HOUR = '0.5-1.0';
     private const ONE_TO_THREE_HOURS = '1.0-3.0';
@@ -17,6 +18,7 @@ class TimeCommitment extends Type
     public static function labels()
     {
         return [
+            self::LESS_THAN_FIVE_MINUTES => '< 5 minutes',
             self::LESS_THAN_THIRTY_MINUTES => '< 30 minutes',
             self::THIRTY_MINUTES_TO_HOUR => '30 minutes - 1 hour',
             self::ONE_TO_THREE_HOURS => '1 - 3 hours',


### PR DESCRIPTION
### What's this PR do?

This pull request adds another option for `time_commitment` on actions, <5 minutes. For the numerical value that is stored in the database, we store those in terms of hours. So we have like `3.0+` for "more than 3 hours" and we have `<0.5` for "less than 30 minutes. `5/60` is `0.083333333` so we store `<0.083`. Is that too specific? Should we do `<0.08` instead? None of them look particularly "nice" to me so I chose going with `0.083` since it's closer to `5/60` 🤷‍♀ 

### How should this be reviewed?

Does this add <5 minutes as an option for time commitment for actions? Any tests needed?

### Any background context you want to provide?

We want to add this for some quicker actions. We have <30 but that makes people think it might take 30 minutes, saying <5 shows them that it really will be quick!

### Relevant tickets

References [Pivotal #171753530](https://www.pivotaltracker.com/story/show/171753530).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
