### PR TITLE
ReviewablePosts query - status field update

### DIFF
--- a/resources/assets/components/ReviewablePostGallery.js
+++ b/resources/assets/components/ReviewablePostGallery.js
@@ -6,14 +6,14 @@ import { useQuery } from '@apollo/react-hooks';
 
 import Empty from './Empty';
 import Shell from './utilities/Shell';
-import { updateQuery } from '../helpers';
+import { updateQuery, withoutNulls } from '../helpers';
 import ReviewablePost, { ReviewablePostFragment } from './ReviewablePost';
 
 const REVIEWABLE_POSTS_QUERY = gql`
   query ReviewablePostsQuery(
     $campaignId: String
     $signupId: String
-    $status: String
+    $status: [ReviewStatus]
     $tags: [String]
     $cursor: String
   ) {
@@ -44,7 +44,12 @@ const REVIEWABLE_POSTS_QUERY = gql`
 
 const ReviewablePostGallery = ({ campaignId, signupId, status, tags }) => {
   const { loading, error, data, fetchMore } = useQuery(REVIEWABLE_POSTS_QUERY, {
-    variables: { campaignId, signupId, status, tags },
+    variables: withoutNulls({
+      campaignId,
+      signupId,
+      status: status ? [status.toUpperCase()] : null,
+      tags,
+    }),
     notifyOnNetworkStatusChange: true,
   });
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -1,6 +1,6 @@
 /* global document */
 
-import { isArray, mergeWith } from 'lodash';
+import { isArray, isNull, mergeWith, omitBy } from 'lodash';
 
 /**
  * Valid statuses for posts, and their human-friendly labels.
@@ -83,3 +83,13 @@ export const updateQuery = (previous, { fetchMoreResult }) => {
     }
   });
 };
+
+/**
+ * Remove items with null properties.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutNulls(data) {
+  return omitBy(data, isNull);
+}


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `status` field in our `ReviewablePostsQuery` query to be a `ReviewStatus` enum list per this change in our GraphQL schema https://github.com/DoSomething/graphql/pull/207

### How should this be reviewed?
How's the implementation? I feel like there were a few ways to approach this. Am I missing any edge cases here that would complicate things?

### Any background context you want to provide?
I went with leaving the [`STATUS` values](https://github.com/DoSomething/rogue/blob/f98c79808a51930d8dd507be3f6200c18a007573/resources/assets/helpers.js#L5-L12) as they are since they're used in the [route params](https://github.com/DoSomething/rogue/blob/f98c79808a51930d8dd507be3f6200c18a007573/resources/assets/pages/ShowCampaign.js#L24) and so the logic to just upcase the values within our component felt more contained. But lmk if you disagree!

The `withoutNulls` helper was grifted [off of Phoenix](https://github.com/DoSomething/phoenix-next/blob/0623ddc2a5c1f4982d30d7ecec1010b23e38877f/resources/assets/helpers/index.js#L89-L99)

### Relevant tickets

References [Pivotal #171729071](https://www.pivotaltracker.com/story/show/171729071).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
