### PR TITLE
Adds referrer_user_id field to Signups and Posts

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -66,6 +66,7 @@ class PostTransformer extends TransformerAbstract
             $response['source_details'] = $post->source_details;
             $response['remote_addr'] = '0.0.0.0';
             $response['details'] = $post->details;
+            $response['referrer_user_id'] = $post->referrer_user_id;
             $response['school_id'] = $post->school_id;
         }
 

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -42,6 +42,7 @@ class SignupTransformer extends TransformerAbstract
             $response['source'] = $signup->source;
             $response['source_details'] = $signup->source_details;
             $response['details'] = $signup->details;
+            $response['referrer_user_id'] = $signup->referrer_user_id;
         }
 
         return $response;

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -48,7 +48,7 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'location', 'postal_code', 'school_id'];
+    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'location', 'postal_code', 'school_id', 'referrer_user_id'];
 
     /**
      * Attributes that can be queried when filtering.
@@ -58,7 +58,7 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'action_id', 'northstar_id', 'status', 'created_at', 'source', 'location'];
+    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'action_id', 'northstar_id', 'status', 'created_at', 'source', 'location', 'referrer_user_id'];
 
     /**
      * Attributes that we can sort by with the '?orderBy' query parameter.
@@ -314,6 +314,7 @@ class Post extends Model
             'source' => $this->source,
             'source_details' => $this->source_details,
             'details' => $this->details,
+            'referrer_user_id' => $this->referrer_user_id,
             'school_id' => $this->school_id,
             'school_name' => isset($school) ? $school['name'] : null,
             'created_at' => $this->created_at->toIso8601String(),

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -32,7 +32,7 @@ class Signup extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'campaign_id', 'why_participated', 'source', 'source_details', 'details', 'created_at', 'updated_at'];
+    protected $fillable = ['id', 'northstar_id', 'campaign_id', 'why_participated', 'source', 'source_details', 'details', 'created_at', 'updated_at', 'referrer_user_id'];
 
     /**
      * Attributes that can be queried when filtering.
@@ -43,7 +43,7 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source',
+        'campaign_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source', 'referrer_user_id',
     ];
 
     /**
@@ -180,6 +180,7 @@ class Signup extends Model
             'why_participated' => $this->why_participated,
             'source' => $this->source,
             'source_details' => $this->source_details,
+            'referrer_user_id' => $this->referrer_user_id,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -101,6 +101,7 @@ class PostRepository
             'source' => token()->client(),
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
+            'referrer_user_id' => isset($data['referrer_user_id']) ? $data['referrer_user_id'] : null,
         ]);
 
         // If this is a share-social type post, auto-accept.

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -25,6 +25,7 @@ class SignupRepository
         $signup->source = isset($data['source']) ? $data['source'] : token()->client();
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;
         $signup->details = isset($data['details']) ? $data['details'] : null;
+        $signup->referrer_user_id = isset($data['referrer_user_id']) ? $data['referrer_user_id'] : null;
         $signup->save();
 
         return $signup;

--- a/database/migrations/2020_03_23_000000_add_referrer_user_id_to_signups_and_posts_tables.php
+++ b/database/migrations/2020_03_23_000000_add_referrer_user_id_to_signups_and_posts_tables.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddReferrerUserIdToSignupsAndPostsTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->string('referrer_user_id')->nullable()->index()->after('source_details');
+        });
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('referrer_user_id')->nullable()->index()->after('details');
+            $table->index(['referrer_user_id', 'type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropColumn('referrer_user_id');
+        });
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('referrer_user_id');
+            $table->dropIndex(['referrer_user_id', 'type']);
+        });
+    }
+}

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -95,6 +95,7 @@ Example Response:
             "location": "US-NY",
             "location_name": "New York",
             "school_id": null,
+            "referrer_user_id": null,
             "created_at": "2016-11-30T21:21:24+00:00",
             "updated_at": "2017-08-02T14:11:26+00:00"
         },
@@ -119,6 +120,7 @@ Example Response:
             "location": "US-NY",
             "location_name": "New York",
             "school_id": null,
+            "referrer_user_id": null,
             "created_at": "2016-02-10T16:19:25+00:00",
             "updated_at": "2017-08-02T14:11:35+00:00"
             "action_details": {
@@ -185,6 +187,7 @@ Example Response:
     "location": "US-NY",
     "location_name": "New York",
     "school_id": "3600052",
+    "referrer_user_id": null,
     "created_at": "2019-01-23T19:42:07+00:00",
     "updated_at": "2019-01-23T19:42:07+00:00"
     "action_details": {
@@ -242,6 +245,8 @@ Optional params:
   The school ID this post should be associated with.
 - **details** (json).
   A JSON field to store extra details about a post.
+- **referrer_user_id** (string).
+  The referring User ID that this post should be associated with.
 - **dont_send_to_blink** (boolean).
   If included and true, the data for this Post will not be sent to Blink.
 - **created_at** (timestamp).
@@ -279,6 +284,7 @@ Example Response:
     "location": "US-NY",
     "location_name": "New York",
     "school_id": "3600052",
+    "referrer_user_id": "559442cca59dbfca578b4bed",
     "created_at": "2018-12-06T21:44:15+00:00",
     "updated_at": "2018-12-06T21:44:15+00:00",
     "tags": [],
@@ -299,6 +305,7 @@ Example Response:
         "source": "dev-oauth",
         "source_details": null,
         "details": null,
+        "referrer_user_id: "559442cca59dbfca578b4bed",
         "user": {
           "data": {
               "first_name": "Santa",

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -20,6 +20,8 @@ POST /api/v3/signups
   The source of the signup.
 - **details**: (string) optional
   Details to be added to the "details" column on the signup, such as signed up to receive affiliate messaging.
+- **referrer_user_id** (string).
+  The referring User ID that this signup should be associated with.
 - **dont_send_to_blink** (boolean) optional.
   If included and true, the data for this Signup will not be sent to Blink.
 - **created_at**: (string) optional.
@@ -42,6 +44,7 @@ Example response:
         "why_participated": "to test",
         "source": null,
         "details": null,
+        "referrer_user_id": "559442cca59dbfca578b4bed"
     }
 }
 ```
@@ -95,6 +98,7 @@ Example Response:
       "why_participated": "Eos architecto et quibusdam quasi.",
       "source": "phoenix-web",
       "details": null,
+      "referrer_user_id" : null,
     },
     {
       "id": 2,
@@ -107,6 +111,7 @@ Example Response:
       "why_participated": "Non nobis ab asperiores fuga.",
       "source": "phoenix-web",
       "details": null,
+      "referrer_user_id" : null,
     },
   ],
   "meta": {

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -66,6 +66,7 @@ class PostTest extends TestCase
         $location = 'US-'.$this->faker->stateAbbr();
         $school_id = $this->faker->word;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
+        $referrerUserId = $this->faker->northstar_id;
 
         // Create an action to refer to.
         $action = factory(Action::class)->create(['campaign_id' => $campaignId]);
@@ -88,6 +89,7 @@ class PostTest extends TestCase
             'school_id'        => $school_id,
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
+            'referrer_user_id' => $referrerUserId,
         ]);
 
         $response->assertStatus(201);
@@ -98,6 +100,7 @@ class PostTest extends TestCase
             'campaign_id' => $campaignId,
             'northstar_id' => $northstarId,
             'why_participated' => $why_participated,
+            'referrer_user_id' => $referrerUserId,
         ]);
 
         $this->assertDatabaseHas('posts', [
@@ -111,6 +114,7 @@ class PostTest extends TestCase
             'school_id' => $school_id,
             'quantity' => $quantity,
             'details' => json_encode($details),
+            'referrer_user_id' => $referrerUserId,
         ]);
     }
 

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -20,6 +20,7 @@ class SignupTest extends TestCase
     {
         $northstarId = $this->faker->northstar_id;
         $campaignId = $this->faker->randomNumber(4);
+        $referrerUserId = $this->faker->northstar_id;
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
@@ -27,6 +28,7 @@ class SignupTest extends TestCase
         $response = $this->withAccessToken($northstarId)->postJson('api/v3/signups', [
             'campaign_id' => $campaignId,
             'details' => 'affiliate-messaging',
+            'referrer_user_id' => $referrerUserId,
         ]);
 
         // Make sure we get the 201 Created response
@@ -38,6 +40,7 @@ class SignupTest extends TestCase
                 'quantity' => null,
                 'source' => 'phpunit',
                 'why_participated' => null,
+                'referrer_user_id' => $referrerUserId,
             ],
         ]);
 

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -76,5 +76,14 @@ class PostModelTest extends TestCase
         $result = $post->toBlinkPayload();
 
         $this->assertEquals($result['school_name'], null);
+        $this->assertEquals($result['referrer_user_id'], null);
+
+        $referrerUserId = $this->faker->northstar_id;
+        $post = factory(Post::class)->create([
+            'referrer_user_id' => $referrerUserId,
+        ]);
+        $result = $post->toBlinkPayload();
+
+        $this->assertEquals($result['referrer_user_id'], $referrerUserId);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `referer_user_id` text column to the `signups` and `posts` tables. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

We'll eventually use this field for calculating the total number of voter registrations referred by a user on their OVRD, by adding support to filter the `/v3/posts` index endpoint by `referrer_user_id`. Saving that for a future PR to help keep this reviewable. 

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705), [Slack thread](https://dosomething.slack.com/archives/CP2D7UGAU/p1584987535004000).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
