### PR TITLE
Add referrer_user_id filter to Posts endpoint documentation

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -83,6 +83,7 @@ $factory->define(Post::class, function (Generator $faker) {
          */
         'school_id' => $this->faker->optional()->school_id,
         'source' => 'phpunit',
+        'referrer_user_id' => $this->faker->optional()->northstar_id,
     ];
 });
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -30,9 +30,9 @@ If the post's action is marked as "anonymous", the `northstar_id` field will onl
 - **filter[campaign_id]** _(integer)_
   - The campaign ID to filter the response by.
   - e.g. `/posts?filter[campaign_id]=47`
-- **filter[northstar_id]** _(integer)_
+- **filter[northstar_id]** _(string)_
   - The northstar_id to filter the response by.
-  - e.g. `/posts?filter[northstar_id]=47asdf23abc`
+  - e.g. `/posts?filter[northstar_id]=5554eac1a59dbf117e8b4567`
 - **filter[status]** _(string)_
   - The status(es) to filter the response by.
   - e.g. `/posts?filter[status]=accepted,pending`
@@ -58,6 +58,9 @@ If the post's action is marked as "anonymous", the `northstar_id` field will onl
 - **filter[source]** _(string)_
   - The source(s) to filter the response by.
   - e.g. `/posts?filter[source]=sms`
+- **filter[referrer_user_id]** _(string)_
+  - The referrer_user_id to filter the response by.
+  - e.g. `/posts?filter[referrer_user_id]=581ba6dd7f43c26c6d2349d3`
 - **filter[location]** _(string)_
   - The location to filter the response by.
   - e.g. `/posts?filter[location]=US-NY`


### PR DESCRIPTION
### What's this PR do?

This pull request documents that the `/v3/posts` index supports filtering by `referrer_user_id`, per the addition to the `$indexes` property in #1003. Also populates the field in our database seeder to make it easier to test.

### How should this be reviewed?

👀 

### Any background context you want to provide?

To find the total number of voter registration referrals for a user, our query will look like this:

```
GET /api/v3/posts?filter[referrer_user_id]=:userId&filter[type]=voter-reg
```

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
