### PR TITLE
Fixes intermittent failure in Post test

### DIFF
--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -72,6 +72,7 @@ class PostModelTest extends TestCase
 
         $post = factory(Post::class)->create([
             'school_id' => null,
+            'referrer_user_id' => null,
         ]);
         $result = $post->toBlinkPayload();
 


### PR DESCRIPTION
### What's this PR do?

This pull request ensures the Post unit test will pass, by setting the expected values for `referrer_user_id`. This is a bug introduced by #1004, where we made the `referrer_user_id` property optional on the Post factory. The commits in #1004 passed because the factory generated `referrer_user_id` values as expected, but the merge commit into master did not.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐦 

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/n/projects/2417735/stories/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
