### PR TITLE
Adds user referrals view

### DIFF
--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -39,6 +39,9 @@ const Application = () => {
           <Route path="/users" exact>
             <UserIndex />
           </Route>
+          <Route path="/users/:id/referrals" exact>
+            <ShowUser selectedTab="referrals" />
+          </Route>
           <Route path="/users/:id">
             <ShowUser />
           </Route>

--- a/resources/assets/components/ReferralsTable.js
+++ b/resources/assets/components/ReferralsTable.js
@@ -1,0 +1,92 @@
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+import React, { useState } from 'react';
+import { parse, format } from 'date-fns';
+
+import Empty from './Empty';
+
+const USER_REFERRALS_QUERY = gql`
+  query UserReferralsQuery($userId: String) {
+    posts(referrerUserId: $userId) {
+      id
+      createdAt
+      userId
+      type
+      status
+    }
+  }
+`;
+
+/**
+ * This component handles fetches referrals for a given user, displaying only posts for now.
+ *
+ * @param String userId
+ */
+const ReferralsTable = ({ userId }) => {
+  const { error, loading, data } = useQuery(USER_REFERRALS_QUERY, {
+    variables: { userId },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (error) {
+    return (
+      <div className="text-center">
+        <p>There was an error. :(</p>
+        <code>{JSON.stringify(error)}</code>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="h-content flex-center-xy">
+        <div className="spinner" />
+      </div>
+    );
+  }
+
+  const { posts } = data;
+
+  if (posts.length == 0) {
+    return (
+      <div className="h-content flex-center-xy">
+        <Empty copy="No referrals found for this user." />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <table className="table">
+        <thead>
+          <tr>
+            <td>Created</td>
+            <td>User</td>
+            <td>Type</td>
+            <td>Status</td>
+          </tr>
+        </thead>
+        <tbody>
+          {data.posts.map(post => (
+            <tr key={post.id}>
+              <td>
+                <Link to={`/posts/${post.id}`}>
+                  {format(parse(post.createdAt), 'M/D/YYYY h:m:s')}
+                </Link>
+              </td>
+              <td>
+                <Link to={`/users/${post.userId}`}>{post.userId}</Link>
+              </td>
+              <td>{post.type}</td>
+              <td>{post.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+};
+
+export default ReferralsTable;

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -7,6 +7,7 @@ import { useQuery } from '@apollo/react-hooks';
 import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import SignupGallery from '../components/SignupGallery';
+import ReferralsTable from '../components/ReferralsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 import UserInformation, {
   UserInformationFragment,
@@ -24,7 +25,10 @@ const SHOW_USER_QUERY = gql`
   ${UserInformationFragment}
 `;
 
-const ShowUser = () => {
+/**
+ * @param string selectedTab
+ */
+const ShowUser = ({ selectedTab }) => {
   const { id } = useParams();
 
   const title = 'Members';
@@ -66,12 +70,24 @@ const ShowUser = () => {
           />
         </UserInformation>
       </div>
-
       <div className="container__block">
-        <h2 className="heading -emphasized -padded">
-          <span>Campaigns</span>
-        </h2>
-        <SignupGallery userId={user.id} />
+        {selectedTab === 'referrals' ? (
+          <React.Fragment>
+            <h2 className="heading -emphasized -padded">
+              <span>Referrals</span>
+            </h2>
+            <div className="container__block">
+              <ReferralsTable userId={user.id} />
+            </div>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <h2 className="heading -emphasized -padded">
+              <span>Campaigns</span>
+            </h2>
+            <SignupGallery userId={user.id} />
+          </React.Fragment>
+        )}
       </div>
     </Shell>
   );

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -73,12 +73,10 @@ const ShowUser = ({ selectedTab }) => {
       <div className="container__block">
         {selectedTab === 'referrals' ? (
           <React.Fragment>
-            <h2 className="heading -emphasized -padded">
+            <h2 className="heading -emphasized -padded mb-4">
               <span>Referrals</span>
             </h2>
-            <div className="container__block">
-              <ReferralsTable userId={user.id} />
-            </div>
+            <ReferralsTable userId={user.id} />
           </React.Fragment>
         ) : (
           <React.Fragment>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Users
     Route::view('users', 'app')->name('users.index');
     Route::view('users/{id}', 'app')->name('users.show');
+    Route::view('users/{id}/referrals', 'app')->name('users.show');
 });
 
 // Admin image routes:


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `user/:id/referrals` route to view all referral posts for a user (refs https://github.com/DoSomething/graphql/pull/212)

<img width="600" alt="Screen Shot 2020-03-30 at 11 04 15 AM" src="https://user-images.githubusercontent.com/1236811/77945869-38a0ef80-7276-11ea-8f51-a764583380c0.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

Eventually we can add pagination, and lists of signups and users that the user has referred -- but for now it will be extremely helpful to have this to spot check voter registration referrals.

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
