### PR TITLE
Attach client identifier to requests.

### DIFF
--- a/resources/assets/graphql.js
+++ b/resources/assets/graphql.js
@@ -44,5 +44,6 @@ export default uri => {
   return new ApolloClient({
     link: ApolloLink.from([errorLink, authLink, persistedLink, httpLink]),
     cache: new InMemoryCache(),
+    name: 'rogue',
   });
 };


### PR DESCRIPTION
### What's this PR do?

This pull request simply attaches this application's name to our GraphQL requests, so that we can segment these out in Apollo Engine when looking at metrics:

![Screen Shot 2020-04-01 at 3 59 29 PM](https://user-images.githubusercontent.com/583202/78181102-d2f96280-7431-11ea-983f-1ebe5f7b15b6.png)

### How should this be reviewed?

👀

### Any background context you want to provide?

Support for this was added in DoSomething/graphql#213.

I made a similar change to Phoenix in DoSomething/phoenix-next#2011.

### Relevant tickets

References [Pivotal #171001230](https://www.pivotaltracker.com/story/show/171001230).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
