### PR TITLE
Public Images & CORS

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -45,7 +45,7 @@ class Kernel extends HttpKernel
         ],
 
         'asset' => [
-          \Barryvdh\Cors\HandleCors::class,
+            \Barryvdh\Cors\HandleCors::class,
         ],
     ];
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,6 +43,10 @@ class Kernel extends HttpKernel
             // 'throttle:60,1',
             \Barryvdh\Cors\HandleCors::class,
         ],
+
+        'asset' => [
+          \Barryvdh\Cors\HandleCors::class,
+        ],
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,7 +10,7 @@
  */
 
 // Assets
-$router->get('images/{hash}', 'Web\ImagesController@show');
+$router->get('images/{hash}', 'Web\ImagesController@show')->middleware('asset');
 
 // v3 routes
 $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function () {


### PR DESCRIPTION
### What's this PR do?

This pull request (experimentally) adds a new `asset` middleware group for public `/images/{hash}` routes to enable assigning the https://github.com/fruitcake/laravel-cors handler to this route specifically since it doesn't fall into our `api` or `web` groups.

### How should this be reviewed?
To be completely honest, I've been floundering, trying to figure this one out. I haven't been able to validate that this will work locally beyond assuming this should work logically! (For some reason, I'm unable to replicate the CORS issues I'm seeing on the dev environment related to the issue below locally).

Does this make sense? Is the middleware name ok?

### Any background context you want to provide?
See https://dosomething.slack.com/archives/CUQMU4Q6B/p1588343622106600

### Relevant tickets

References [Pivotal #172624016](https://www.pivotaltracker.com/story/show/172624016).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
