### PR TITLE
Revert "Public Images & CORS"

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,10 +43,6 @@ class Kernel extends HttpKernel
             // 'throttle:60,1',
             \Barryvdh\Cors\HandleCors::class,
         ],
-
-        'asset' => [
-            \Barryvdh\Cors\HandleCors::class,
-        ],
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,7 +10,7 @@
  */
 
 // Assets
-$router->get('images/{hash}', 'Web\ImagesController@show')->middleware('asset');
+$router->get('images/{hash}', 'Web\ImagesController@show');
 
 // v3 routes
 $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function () {


### PR DESCRIPTION
Reverts DoSomething/rogue#1013

In my conflagrated state of mind, I failed to properly investigate and realize that the `/images/{hash}` route _is_ in the `api` middleware group by its very existence within the `routes/api.php` file, and thus already had the CORS Handler.

> The routes in routes/api.php are stateless and are assigned the api middleware group.
(https://laravel.com/docs/5.5/routing#basic-routing)

I also failed to properly test this locally https://github.com/DoSomething/rogue/pull/1013#issuecomment-622482285

In any case, happy Friday, we figured out that there's something afoot in general with this CORS issue and have some time set aside to investigate on Monday! https://github.com/DoSomething/rogue/pull/1013#issuecomment-622496295