### PR TITLE
Make voter-reg referrals visible to the referrer

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -467,7 +467,7 @@ class Post extends Model
      * - authenticated user is a staffer
      * - the post status is accepted
      * - authenticated user is owner of post
-     * - the post is type voter-reg and authenticated user is the referrer
+     * - the post is type voter-reg, status is register-*, and authenticated user is the referrer
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
@@ -480,9 +480,10 @@ class Post extends Model
         return $query->where('status', 'accepted')
             ->orWhere('northstar_id', auth()->id())
             ->orWhere(function ($query) {
-                $query->where('type', 'voter-reg')
-                    ->whereNotNull('referrer_user_id')
-                    ->where('referrer_user_id', auth()->id());
+                $query->whereNotNull('referrer_user_id')
+                    ->where('referrer_user_id', auth()->id())
+                    ->where('type', 'voter-reg')
+                    ->whereIn('status', ['register-form', 'register-OVR']);
             });
     }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -463,16 +463,26 @@ class Post extends Model
     }
 
     /**
-     * Scope a query to only return posts if a user is an admin, staff, or is owner of post and the post's action is not anonymous.
+     * Scope a query to only return posts if one of these conditions is true:
+     * - authenticated user is a staffer
+     * - the post status is accepted
+     * - authenticated user is owner of post and the post's action is not anonymous
+     * - the post is type voter-reg and authenticated user is the referrer
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereVisible($query)
     {
-        if (! is_staff_user()) {
-            return $query->where('status', 'accepted')
-                         ->orWhere('northstar_id', auth()->id());
+        if (is_staff_user()) {
+            return;
         }
+
+        return $query->where('status', 'accepted')
+            ->orWhere('northstar_id', auth()->id())
+            ->orWhere(function ($query) {
+                $query->where('type', 'voter-reg')
+                    ->where('referrer_user_id', auth()->id());
+            });
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -466,7 +466,7 @@ class Post extends Model
      * Scope a query to only return posts if one of these conditions is true:
      * - authenticated user is a staffer
      * - the post status is accepted
-     * - authenticated user is owner of post and the post's action is not anonymous
+     * - authenticated user is owner of post
      * - the post is type voter-reg and authenticated user is the referrer
      *
      * @return \Illuminate\Database\Eloquent\Builder

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -481,6 +481,7 @@ class Post extends Model
             ->orWhere('northstar_id', auth()->id())
             ->orWhere(function ($query) {
                 $query->where('type', 'voter-reg')
+                    ->whereNotNull('referrer_user_id')
                     ->where('referrer_user_id', auth()->id());
             });
     }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -102,6 +102,10 @@ $factory->state(Post::class, 'text', [
     'type' => 'text',
 ]);
 
+$factory->state(Post::class, 'voter-reg', [
+    'type' => 'voter-reg',
+]);
+
 /**
  * Post status factory states.
  */
@@ -115,6 +119,18 @@ $factory->state(Post::class, 'pending', [
 
 $factory->state(Post::class, 'rejected', [
     'status' => 'rejected',
+]);
+
+$factory->state(Post::class, 'step-1', [
+    'status' => 'step-1',
+]);
+
+$factory->state(Post::class, 'register-form', [
+    'status' => 'register-form',
+]);
+
+$factory->state(Post::class, 'register-OVR', [
+    'status' => 'register-OVR',
 ]);
 
 // Signup Factory

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1140,6 +1140,38 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test for retrieving voter registration posts as a referrer.
+     * A referrer should see all completed voter registrations that they have referred.
+     *
+     * GET /api/v3/posts
+     * @return void
+     */
+    public function testPostsIndexAsVoterRegistrationReferrer()
+    {
+        $referrerUserId = $this->faker->unique()->northstar_id;
+
+        // Add two completed voter reg referrals for our referrer, which should be visible to them.
+        factory(Post::class)->states('voter-reg', 'register-form')->create(['referrer_user_id' => $referrerUserId]);
+        factory(Post::class)->states('voter-reg', 'register-OVR')->create(['referrer_user_id' => $referrerUserId]);
+
+        // Add a non-completed voter reg referral for our referrer, which shouldn't be visible.
+        factory(Post::class)->states('voter-reg', 'step-1')->create(['referrer_user_id' => $referrerUserId]);
+
+        // Add a completed voter reg without a referrer, which shouldn't be visible.
+        factory(Post::class)->states('voter-reg', 'register-OVR')->create();
+
+        // Add a completed voter reg referral for a different referrer, which shouldn't be visible.
+        factory(Post::class)->states('voter-reg', 'register-form')->create(['referrer_user_id' => $this->faker->unique()->northstar_id]);
+
+        // Add a pending photo post, which shouldn't be visible.
+        factory(Post::class)->states('photo', 'pending')->create();
+
+        $response = $this->withAccessToken($referrerUserId)->getJson('api/v3/posts');
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data');
+    }
+
+    /**
      * Test for retrieving a specific post as non-admin and non-owner.
      * Non-admin and non-owners can't see other's unapproved or any rejected posts.
      *

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1151,8 +1151,8 @@ class PostTest extends TestCase
         $referrerUserId = $this->faker->unique()->northstar_id;
 
         // Add two completed voter reg referrals for our referrer, which should be visible to them.
-        factory(Post::class)->states('voter-reg', 'register-form')->create(['referrer_user_id' => $referrerUserId]);
-        factory(Post::class)->states('voter-reg', 'register-OVR')->create(['referrer_user_id' => $referrerUserId]);
+        $firstCompletedVoterRegReferral = factory(Post::class)->states('voter-reg', 'register-form')->create(['referrer_user_id' => $referrerUserId]);
+        $secondCompletedVoterRegReferral = factory(Post::class)->states('voter-reg', 'register-OVR')->create(['referrer_user_id' => $referrerUserId]);
 
         // Add a non-completed voter reg referral for our referrer, which shouldn't be visible.
         factory(Post::class)->states('voter-reg', 'step-1')->create(['referrer_user_id' => $referrerUserId]);
@@ -1169,6 +1169,14 @@ class PostTest extends TestCase
         $response = $this->withAccessToken($referrerUserId)->getJson('api/v3/posts');
         $response->assertStatus(200);
         $response->assertJsonCount(2, 'data');
+        $response->assertJsonFragment([
+            'id' => $firstCompletedVoterRegReferral->id,
+            'status' => 'register-form',
+        ]);
+        $response->assertJsonFragment([
+            'id' => $secondCompletedVoterRegReferral->id,
+            'status' => 'register-OVR',
+        ]);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `scopeWhereVisible` function in our `Post` model to allow a referrer to see completed voter registrations they have referred. This fixes a [bug found while testing the new Alpha OVRD "Get 3 friends to register" section](https://www.pivotaltracker.com/story/show/172417306/comments/213979491) -- staff users can see their referrals but non-staff users cannot, without these changes in place. I've tested my local Phoenix against this branch locally and confirmed a non-staff can now see their referrals.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We may eventually want to display more statuses than our completed statuses if we get around to building out displaying a [list of non-completed voter registration referrals to the alpha](https://www.pivotaltracker.com/story/show/171043026) - -but we can change this code up then should we move forward with that feature.

### Relevant tickets

References [Pivotal #172417306](https://www.pivotaltracker.com/story/show/172417306).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
