### PR TITLE
Only allow admins to edit Contentful Campaign ID field

### DIFF
--- a/resources/views/campaigns/edit.blade.php
+++ b/resources/views/campaigns/edit.blade.php
@@ -24,6 +24,7 @@
                         >
                     </div>
 
+                @if (Auth::user()->role === 'admin')
                     <div class="form-item">
                         <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
                         <input type="text" name="contentful_campaign_id" class="text-field"
@@ -35,6 +36,7 @@
                         >
                         <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
                     </div>
+                @endif
 
                     <div class="form-item">
                         <label class="field-label">Cause Area <em>(choose between 1-5)</em></label>

--- a/resources/views/campaigns/edit.blade.php
+++ b/resources/views/campaigns/edit.blade.php
@@ -24,7 +24,7 @@
                         >
                     </div>
 
-                @if (Auth::user()->role === 'admin')
+                @if (is_admin_user())
                     <div class="form-item">
                         <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
                         <input type="text" name="contentful_campaign_id" class="text-field"


### PR DESCRIPTION
### What's this PR do?

This pull request hides the Contentful Campaign ID field on the edit campaign view to everyone except admins! It does NOT hide this field on the view campaign page.

As admin:
<img width="1149" alt="Screen Shot 2020-05-11 at 3 19 58 PM" src="https://user-images.githubusercontent.com/4240292/81618091-86436880-939b-11ea-8ca8-555b51dfbfc9.png">

As staff:
<img width="1152" alt="Screen Shot 2020-05-11 at 3 21 18 PM" src="https://user-images.githubusercontent.com/4240292/81618105-8c394980-939b-11ea-8d37-244c560cfc25.png">


### How should this be reviewed?

Will this prevent anyone who is not an admin from editing this field? Can admins still edit this field?

### Any background context you want to provide?

If we link to a Contentful page in Rogue that's not published, it'll take down `/campaigns`! So we want to make sure this field is only being added when it really should be.

### Relevant tickets

References [Pivotal #172383488](https://www.pivotaltracker.com/story/show/172383488).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
