### PR TITLE
Adds referral_post_created and referral_post_updated Customer.io events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,8 @@ GRAPHQL_URL=https://graphql-dev.dosomething.org
 # a new Incoming Webhook that posts messages to your DMs here:
 # <https://dosomething.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks>
 SLACK_WEBHOOK_INTEGRATION_URL=
+
+# Customer.io:
+CUSTOMER_IO_URL=https://track.customer.io/api/v1/
+CUSTOMER_IO_USERNAME=siteName
+CUSTOMER_IO_PASSWORD=apiKey

--- a/app/Jobs/CreateCustomerIoEvent.php
+++ b/app/Jobs/CreateCustomerIoEvent.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Jobs;
 
-use Rogue\Models\Post;
 use Illuminate\Bus\Queueable;
 use Rogue\Services\CustomerIo;
 use Illuminate\Queue\SerializesModels;
@@ -57,12 +56,12 @@ class CreateCustomerIoEvent implements ShouldQueue
     {
         // Rate limit Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
+
         $throttler->then(function () use ($customerIo) {
             $response = $customerIo->trackEvent($this->userId, $this->eventName, $this->eventData);
-   
+
             info("Sent {$this->userId} event to Customer.io for user {$this->userId}");
         }, function () {
-            // Could not obtain lock... release to the queue.
             return $this->release(10);
         });
     }

--- a/app/Jobs/CreateCustomerIoEvent.php
+++ b/app/Jobs/CreateCustomerIoEvent.php
@@ -4,11 +4,11 @@ namespace Rogue\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Rogue\Services\CustomerIo;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-
 
 class CreateCustomerIoEvent implements ShouldQueue
 {
@@ -60,7 +60,7 @@ class CreateCustomerIoEvent implements ShouldQueue
         $throttler->then(function () use ($customerIo) {
             $response = $customerIo->trackEvent($this->userId, $this->eventName, $this->eventData);
 
-            info("Sent {$this->userId} event to Customer.io for user {$this->userId}");
+            info("Sent {$this->userId} event to Customer.io for user {$this->userId}", ['response' => $response]);
         }, function () {
             return $this->release(10);
         });

--- a/app/Jobs/CreateCustomerIoEvent.php
+++ b/app/Jobs/CreateCustomerIoEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rogue\Jobs;
+
+use Rogue\Models\Post;
+use Illuminate\Bus\Queueable;
+use Rogue\Services\CustomerIo;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+
+class CreateCustomerIoEvent implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The ID of the user to create the event for.
+     *
+     * @var string
+     */
+    protected $userId;
+
+    /**
+     * The name of the event to create.
+     *
+     * @var string
+     */
+    protected $eventName;
+
+    /**
+     * The payload of the event to create.
+     *
+     * @var array
+     */
+    protected $eventData;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($userId, $eventName, $eventData)
+    {
+        $this->userId = $userId;
+        $this->eventName = $eventName;
+        $this->eventData = $eventData;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(CustomerIo $customerIo)
+    {
+        // Rate limit Customer.io API requests to 10/s.
+        $throttler = Redis::throttle('customerio')->allow(10)->every(1);
+        $throttler->then(function () use ($customerIo) {
+            $response = $customerIo->trackEvent($this->userId, $this->eventName, $this->eventData);
+   
+            info("Sent {$this->userId} event to Customer.io for user {$this->userId}");
+        }, function () {
+            // Could not obtain lock... release to the queue.
+            return $this->release(10);
+        });
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -564,18 +564,17 @@ class Post extends Model
     /**
      * Gets event payload for a referral post, on behalf of the referrer user ID.
      */
-    public static function getReferralPostEventPayload()
+    public function getReferralPostEventPayload()
     {
         $userId = $this->northstar_id;
-        $user = app(GraphQL::class)->getUserById($this->northstar_id);
+        $user = app(GraphQL::class)->getUserById($userId);
 
         return [
             'user_id' => $userId,
-            'user_display_name' => $user['displayName'],
+            'user_display_name' => isset($user) ? $user['displayName'] : null,
             'type' => $this->type,
             'status' => $this->status,
             'action_id' => $this->action_id,
-            // @TODO: Send referral count for this action?
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -564,7 +564,8 @@ class Post extends Model
     /**
      * Gets event payload for a referral post, on behalf of the referrer user ID.
      */
-    public static function getReferralPostEventPayload() {
+    public static function getReferralPostEventPayload()
+    {
         $userId = $this->northstar_id;
         $user = app(GraphQL::class)->getUserById($this->northstar_id);
 
@@ -574,8 +575,9 @@ class Post extends Model
             'type' => $this->type,
             'status' => $this->status,
             'action_id' => $this->action_id,
+            // @TODO: Send referral count for this action?
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];
-    }        
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -560,4 +560,22 @@ class Post extends Model
             ->where('status', 'accepted')
             ->sum('quantity');
     }
+
+    /**
+     * Gets event payload for a referral post, on behalf of the referrer user ID.
+     */
+    public static function getReferralPostEventPayload() {
+        $userId = $this->northstar_id;
+        $user = app(GraphQL::class)->getUserById($this->northstar_id);
+
+        return [
+            'user_id' => $userId,
+            'user_display_name' => $user['displayName'],
+            'type' => $this->type,
+            'status' => $this->status,
+            'action_id' => $this->action_id,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }        
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -570,6 +570,7 @@ class Post extends Model
         $user = app(GraphQL::class)->getUserById($userId);
 
         return [
+            'id' => $this->id,
             'user_id' => $userId,
             'user_display_name' => isset($user) ? $user['displayName'] : null,
             'type' => $this->type,

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Services;
+namespace Rogue\Services;
 
 class CustomerIo
 {

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Northstar\Services;
+
+class CustomerIo
+{
+    /**
+     * The Customer.io client.
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Create a new Customer.io API client.
+     */
+    public function __construct()
+    {
+        $config = config('services.customerio');
+
+        $this->client = new \GuzzleHttp\Client([
+            'base_uri' => $config['url'],
+            'auth' => [$config['username'], $config['password']],
+        ]);
+    }
+
+    /**
+     * Track Customer.io event for given user with given name and data.
+     * @see https://customer.io/docs/api/#apitrackeventsevent_add
+     *
+     * @param string $userId
+     * @param string $eventName
+     * @param array $eventData
+     */
+    public function trackEvent($userId, $eventName, $eventData = [])
+    {
+        $payload = ['name' => $eventName];
+
+        foreach ($eventData as $key => $value) {
+            $payload["data[$key]"] = $value;
+        }
+
+        return $this->client->post('customers/'.$userId.'/events', [
+            'form_params' => $payload,
+        ]);
+    }
+}

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -76,4 +76,26 @@ class GraphQL
 
         return $this->query($query, $variables)['school'];
     }
+
+    /**
+     * Query for a User by ID.
+     *
+     * @param  $userId String
+     * @return array
+     */
+    public function getUserById($schoolId)
+    {
+        $query = '
+        query GetUserById($userId: String!) {
+          user(id: $userId) {
+            displayName
+          }
+        }';
+
+        $variables = [
+            'userId' => $userId,
+        ];
+
+        return $this->query($query, $variables)['user'];
+    }
 }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -83,7 +83,7 @@ class GraphQL
      * @param  $userId String
      * @return array
      */
-    public function getUserById($schoolId)
+    public function getUserById($userId)
     {
         $query = '
         query GetUserById($userId: String!) {

--- a/config/services.php
+++ b/config/services.php
@@ -65,11 +65,18 @@ return [
         'url' => env('SLACK_WEBHOOK_INTEGRATION_URL'),
     ],
 
+    'customerio' => [
+        'url' => env('CUSTOMER_IO_URL'),
+        'username' => env('CUSTOMER_IO_USERNAME'),
+        'password' => env('CUSTOMER_IO_PASSWORD'),
+    ],
+
     'fastly' => [
         'url' => 'https://api.fastly.com/',
         'key' => env('FASTLY_API_TOKEN'),
         'service_id' => env('FASTLY_SERVICE_ID'),
     ],
+
     'graphql' => [
         'url' => env('GRAPHQL_URL'),
     ],

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -83,7 +83,6 @@ $factory->define(Post::class, function (Generator $faker) {
          */
         'school_id' => $this->faker->optional()->school_id,
         'source' => 'phpunit',
-        'referrer_user_id' => $this->faker->optional()->northstar_id,
     ];
 });
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1360,6 +1360,29 @@ class PostTest extends TestCase
     }
 
     /**
+     * Test that updating a referral post sends an event to Customer.io.
+     *
+     * PATCH /api/v3/posts/:id
+     * @return void
+     */
+    public function testUpdatingAReferralPost()
+    {
+        $post = factory(Post::class)->create([
+            'referrer_user_id' => $this->faker->northstar_id,
+            'type' => 'voter-reg',
+            'status' => 'step-1',
+        ]);
+
+        $this->mock(CustomerIo::class)
+          ->shouldReceive('trackEvent')
+          ->with($post->referrer_user_id, 'referral_post_updated', $post->getReferralPostEventPayload());
+
+        $response = $this->withAdminAccessToken()->patchJson('api/v3/posts/' . $post->id, [
+            'status' => 'register-form',
+        ]);
+    }
+
+    /**
      * Test for updating a post with invalid status.
      *
      * PATCH /api/v3/posts/:id

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -86,8 +86,6 @@ class PostTest extends TestCase
         $this->mock(CustomerIo::class)
             ->shouldReceive('trackEvent');
 
-
-
         // Create the post!
         $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [
             'campaign_id'      => $campaignId,

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -10,7 +10,9 @@ use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
 use Rogue\Models\Reaction;
 use Rogue\Services\Fastly;
+use Rogue\Services\GraphQL;
 use DoSomething\Gateway\Blink;
+use Rogue\Services\CustomerIo;
 use Illuminate\Http\UploadedFile;
 
 class PostTest extends TestCase
@@ -75,6 +77,16 @@ class PostTest extends TestCase
         $this->mock(Blink::class)
             ->shouldReceive('userSignup')
             ->shouldReceive('userSignupPost');
+
+        // Mock the GraphQL API calls.
+        $this->mock(GraphQL::class)
+            ->shouldReceive('getUserById');
+
+        // Mock the Customer.io API calls.
+        $this->mock(CustomerIo::class)
+            ->shouldReceive('trackEvent');
+
+
 
         // Create the post!
         $response = $this->withAccessToken($northstarId)->json('POST', 'api/v3/posts', [

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -590,7 +590,7 @@ class SignupTest extends TestCase
      */
     public function testSignupsIndexAsAdminWithFilters()
     {
-        $northstarId = $this->faker->northstar_id;
+        $northstarId = $this->faker->unique()->northstar_id;
         $campaignId = str_random(22);
 
         // Create two signups

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -87,4 +87,30 @@ class PostModelTest extends TestCase
 
         $this->assertEquals($result['referrer_user_id'], $referrerUserId);
     }
+
+    /**
+     * Test expected payload for a referral post event.
+     *
+     * @return void
+     */
+    public function testGetReferralPostEventPayload()
+    {
+        $post = factory(Post::class)->create([
+            'northstar_id' =>  $this->faker->unique()->northstar_id,
+            'referrer_user_id' => $this->faker->unique()->northstar_id,
+        ]);
+
+        $result = $post->getReferralPostEventPayload();
+
+        $this->assertEquals($result['action_id'], $post->action_id);
+        $this->assertEquals($result['created_at'], $post->created_at->toIso8601String());
+        $this->assertEquals($result['id'], $post->id);
+        $this->assertEquals($result['status'], $post->status);
+        $this->assertEquals($result['type'], $post->type);
+        $this->assertEquals($result['updated_at'], $post->updated_at->toIso8601String());
+        $this->assertEquals($result['user_id'], $post->northstar_id);
+
+        // Test expected data was retrieved from GraphQL.
+        $this->assertEquals($result['user_display_name'], 'Daisy D.');
+    }
 }

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -59,6 +59,9 @@ trait WithMocks
         $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([
             'name' => 'San Dimas High School',
         ]);
+        $this->graphqlMock->shouldReceive('getUserById')->andReturn([
+            'displayName' => 'Daisy D.',
+        ]);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request sends two new events, `referral_post_created` and `referral_post_updated` to Customer.io when a post with a `referral_user_id` is created or updated. Each event is created on behalf of the referrer -- so we can send email or SMS notifications to an alpha if a beta completes a voter registration from their OVRD page.

It's passing along a minimal set of attributes for now to keep this easier to maintain and review. The majority of the changes in this PR are for new classes for a Customer.io API client and the new `CreateCustomerIoEvent` job that will be used to create these events.


### How should this be reviewed?

👀 
Once this is merged,it should be straight forward enough to manually test this out with QA Test Import form in Chompy - verifying the events are created when a referral voter reg post is created or updated, and that the events are not created when the post does not have a referrer.

### Any background context you want to provide?

I wanted the `CreateCustomerIoEvent` job to be very general, so it can eventually be used to deprecate the various jobs that post to Blink in order to create Customer.io events. The only tricky piece there would be sending along a `POST /v2/messages?origin=signup` request to the Gambit API on signup creation (Blink handles that currently), but this work would all be for an epic cleanup sprint anyway. 

### Relevant tickets

*  [Pivotal #172318228](https://www.pivotaltracker.com/story/show/172318228).
* Discussion in [#dev-applications](https://dosomething.slack.com/archives/CUQMU4Q6B/p1588960979193300?thread_ts=1588365799.150600&cid=CUQMU4Q6B)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
