### PR TITLE
Hide contentful campaign id from non admins on CREATE form

### DIFF
--- a/resources/views/campaigns/create.blade.php
+++ b/resources/views/campaigns/create.blade.php
@@ -19,11 +19,13 @@
  e.g. Teens for Jeans 2015-08" value="{{old('internal_title') }}">
                     </div>
 
-                    <div class="form-item">
-                        <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
-                        <input type="text" name="contentful_campaign_id" class="text-field" value="{{ old('contentful_campaign_id') }}">
-                        <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
-                    </div>
+                    @if (is_admin_user())
+                        <div class="form-item">
+                            <label class="field-label">Contentful Campaign ID <em>(optional)</em></label>
+                            <input type="text" name="contentful_campaign_id" class="text-field" value="{{ old('contentful_campaign_id') }}">
+                            <p class="footnote"><em>If you are creating a campaign and want it to show up on <a href="https://www.dosomething.org/us/campaigns">Explore Campaigns</a> or under “Campaigns” on Cause Hub pages [<a href="https://www.dosomething.org/us/causes/education">example</a>] you must fill this in. <a href="https://user-images.githubusercontent.com/2658867/75452147-bb652080-593f-11ea-8338-188feecad0bd.png">Here’s how you can find the Contentful ID.</a></em></p>
+                        </div>
+                    @endif
 
                     <div class="form-item">
                         <label class="field-label">Cause Area <em>(choose between 1-5)</em></label>


### PR DESCRIPTION
### What's this PR do?

This pull request is an update to https://github.com/DoSomething/rogue/pull/1017 which turns out to be an unfinished job. I only removed the field on the campaign edit form but missed the campaign create form! This hides the `contentful_campaign_id` field unless the user is an admin.

As staff:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/4240292/82477838-e1084e80-9a84-11ea-9d2a-e87f8857b126.png">

As admin:
<img width="947" alt="image" src="https://user-images.githubusercontent.com/4240292/82482572-e74df900-9a8b-11ea-8e21-1769ac8f6e34.png">

### How should this be reviewed?

Did I miss anywhere else this time?

### Any background context you want to provide?

If we link to a Contentful page in Rogue that's not published, it'll take down /campaigns! So we want to make sure this field is only being added when it really should be.

### Relevant tickets

References [Pivotal #172383488](https://www.pivotaltracker.com/story/show/172383488).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
