### PR TITLE
Change post minimum dimensions to 50x50

### DIFF
--- a/config/posts.php
+++ b/config/posts.php
@@ -12,8 +12,8 @@ return [
     */
     'image' => [
         'min' => [
-            'height' => 400,
-            'width' => 400,
+            'height' => 50,
+            'width' => 50,
         ],
         'max' => [
             'height' => 4000,


### PR DESCRIPTION
### What's this PR do?

This pull request lowers the minimum image size required for posts from 400 by 400 to 50 by 50.

Image I can submit now but couldn't before:
<img width="41" alt="Screen Shot 2020-05-20 at 11 52 26 AM" src="https://user-images.githubusercontent.com/4240292/82486093-3b0f1100-9a91-11ea-8ee4-9a1c4de50bcb.png">

Image I still can't submit:
<img width="14" alt="Screen Shot 2020-05-20 at 11 52 56 AM" src="https://user-images.githubusercontent.com/4240292/82486022-203c9c80-9a91-11ea-8ced-e6dd72292137.png">


### How should this be reviewed?

Any flags?

### Any background context you want to provide?

There's a whole incident channel linked from the card but something happened and Gambit images were coming in real small so we want to lower this limit so we can push them through so we don't lose them!

### Relevant tickets

References [Pivotal #172939835](https://www.pivotaltracker.com/story/show/172939835).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
