### PR TITLE
Updating to use app env as prefix.

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'prefix' => env('SCOUT_PREFIX', ''),
+    'prefix' => env('SCOUT_PREFIX', config('app.env').'_'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
### What's this PR do?

This pull request simply adds a Scout Prefix for the indexes related to Rogue.

I'm still figuring out what the ideal setup for all this is, but for the time being I've decided on setting up platform specific API Keys and for each platform having 3 keys per environment. So for Rogue we have:

- Rogue[Development]: handles indexes prefixed by either `local_*` or `development_*`
- Rogue[QA]: handles indexes prefixed by`qa_*`
- Rogue[Production]: handles indexes prefixed by`production_*`

GraphQL will have its own keys but will handle the same prefixed indexes. What this means is that, for example, there will be a "GraphQL[Production]" API Key, that will allow requests to create/update records in any indexes that are prefixed by `production_*`. So Rogue and GraphQL can both work with production data, but API keys are specific to the apps in case we accidentally expose one or need to change it, we don't have to remember to change in multiple places, just the specific app affected.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I felt grabbing the `config('app.env')` variable made sense for the `SCOUT_PREFIX` setting since all our apps (even our `local`) should have these set and we won't have to worry about typos resulting in unique indexes potentially created on algolia's end.

_Long explanations for simple one-liner changes are my specialty!_ 🕺 

### Relevant tickets

References [Pivotal #172660182](https://www.pivotaltracker.com/story/show/172660182).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
