### PR TITLE
Keep Actions from indexing themselves.

### DIFF
--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -2,7 +2,6 @@
 
 namespace Rogue\Models;
 
-use Laravel\Scout\Searchable;
 use Illuminate\Database\Eloquent\Model;
 
 class Action extends Model

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -7,8 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Action extends Model
 {
-    use Searchable;
-
     /**
      * The attributes that should be cast to native types.
      *


### PR DESCRIPTION
### What's this PR do?

This pull request removes the use of the `Searchable` trait. I realized that by adding this Scout would also create an index for `*_actions` which is not what we want. We solely want actions within campaign record in the `*_campaigns` index!

The Action model still specifies the `$touches` property which lets the Campaign model know when an action is updated, etc.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172660182](https://www.pivotaltracker.com/story/show/172660182).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
