### PR TITLE
Adds GroupType model and GET /api/v3/group-types endpoint

### DIFF
--- a/app/Http/Controllers/GroupTypesController.php
+++ b/app/Http/Controllers/GroupTypesController.php
@@ -2,8 +2,8 @@
 
 namespace Rogue\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Rogue\Models\GroupType;
+use Illuminate\Http\Request;
 use Rogue\Http\Transformers\GroupTypeTransformer;
 
 class GroupTypesController extends ApiController

--- a/app/Http/Controllers/GroupTypesController.php
+++ b/app/Http/Controllers/GroupTypesController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rogue\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Rogue\Models\GroupType;
+use Rogue\Http\Transformers\GroupTypeTransformer;
+
+class GroupTypesController extends ApiController
+{
+    /**
+     * @var Rogue\Http\Transformers\GroupTypeTransformer;
+     */
+    protected $transformer;
+
+    /**
+     * Create a controller instance.
+     */
+    public function __construct()
+    {
+        $this->transformer = new GroupTypeTransformer;
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $query = $this->newQuery(GroupType::class);
+
+        return $this->paginatedCollection($query, $request);
+    }
+}

--- a/app/Http/Transformers/GroupTypeTransformer.php
+++ b/app/Http/Transformers/GroupTypeTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rogue\Http\Transformers;
+
+use Rogue\Models\GroupType;
+use League\Fractal\TransformerAbstract;
+
+class GroupTypeTransformer extends TransformerAbstract
+{
+    /**
+     * Transform resource data.
+     *
+     * @param \Rogue\Models\GroupType $groupType
+     * @return array
+     */
+    public function transform(GroupType $groupType)
+    {
+        return [
+            'id' => $groupType->id,
+            'name' => $groupType->name,
+            'created_at' => $groupType->created_at->toIso8601String(),
+            'updated_at' => $groupType->updated_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -12,14 +12,4 @@ class GroupType extends Model
      * @var array
      */
     protected $fillable = ['name'];
-
-    /**
-     * Attributes that can be queried when filtering.
-     *
-     * This array is manually maintained. It does not necessarily mean that
-     * any of these are actual indexes on the database... but they should be!
-     *
-     * @var array
-     */
-    public static $indexes = ['id'];
 }

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rogue\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GroupType extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['name'];
+
+    /**
+     * Attributes that can be queried when filtering.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $indexes = ['id'];
+}

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -8,8 +8,8 @@ use Rogue\Models\Action;
 use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
 use Rogue\Models\Reaction;
-use Rogue\Types\ActionType;
 use Rogue\Models\GroupType;
+use Rogue\Types\ActionType;
 use Rogue\Models\ActionStat;
 use Rogue\Types\TimeCommitment;
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -198,6 +198,6 @@ $factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($
 // Group Type Factory
 $factory->define(GroupType::class, function (Generator $faker) {
     return [
-        'name' => title_case($faker->unique()->catchPhrase),
+        'name' => title_case($faker->unique()->company),
     ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -9,6 +9,7 @@ use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
 use Rogue\Models\Reaction;
 use Rogue\Types\ActionType;
+use Rogue\Models\GroupType;
 use Rogue\Models\ActionStat;
 use Rogue\Types\TimeCommitment;
 
@@ -192,4 +193,11 @@ $factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($
         'start_date' => $faker->dateTimeBetween('-12 months', '-6 months')->setTime(0, 0),
         'end_date' => $faker->dateTimeBetween('-3 months', 'yesterday')->setTime(0, 0),
     ]);
+});
+
+// Group Type Factory
+$factory->define(GroupType::class, function (Generator $faker) {
+    return [
+        'name' => title_case($faker->unique()->catchPhrase),
+    ];
 });

--- a/database/migrations/2020_05_27_000000_create_group_types_table.php
+++ b/database/migrations/2020_05_27_000000_create_group_types_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateGroupTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('group_types', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('group_types');
+    }
+}

--- a/docs/endpoints/README.md
+++ b/docs/endpoints/README.md
@@ -67,6 +67,12 @@ These endpoints use OAuth 2 to authenticate. [More information here](https://git
 | -------------------------- | ----------------------------------- |
 | `GET /api/v3/action-stats` | [Get action stats](action-stats.md) |
 
+#### Group Types
+
+| Endpoint                  | Functionality                     |
+| ------------------------- | --------------------------------- |
+| `GET /api/v3/group-types` | [Get group types](group-types.md) |
+
 #### Users
 
 | Endpoint                        | Functionality                        |

--- a/docs/endpoints/group-types.md
+++ b/docs/endpoints/group-types.md
@@ -1,0 +1,41 @@
+## Group Types
+
+Group types will be used as a lookup table for the upcoming Groups resource.
+
+## Retrieve All Group Types
+
+```
+GET /api/v3/group-types
+```
+
+Example Response:
+
+```
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "March For Our Lives",
+      "created_at": "2019-12-04T21:28:26+00:00",
+      "updated_at": "2019-12-04T22:33:03+00:00"
+    },
+    {
+      "id": 2,
+      "name": "College Board",
+      "created_at": "2019-12-04T22:05:29+00:00",
+      "updated_at": "2019-12-04T22:05:29+00:00"
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "total": 2,
+      "count": 2,
+      "per_page": 20,
+      "current_page": 1,
+      "total_pages": 1,
+      "links": [
+
+      ]
+    }
+  }
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,9 @@ $router->group(['prefix' => 'api/v3', 'middleware' => ['guard:api']], function (
     // action stats
     $this->get('action-stats', 'ActionStatsController@index');
 
+    // group types
+    $this->get('group-types', 'GroupTypesController@index');
+
     // users
     $this->delete('users/{id}', 'UsersController@destroy');
 });

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -16,12 +16,18 @@ class GroupTypeTest extends TestCase
     public function testGroupTypeIndex()
     {
         // Create five group types.
-        $first = factory(GroupType::class, 5)->create();
+        $groupTypes = factory(GroupType::class, 5)->create();
 
         $response = $this->getJson('api/v3/group-types');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+
+        foreach ($groupTypes as $groupType) {
+            $this->assertDatabaseHas('group_types', [
+                'name' => $groupType->name,
+            ]);
+        }
     }
 }

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -22,27 +22,5 @@ class GroupTypeTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-
-        foreach ($groupTypes as $groupType) {
-            $this->assertDatabaseHas('group_types', [
-                'name' => $groupType->name,
-            ]);
-        }
-    }
-
-    /**
-     * Test that the group_type name field is unique.
-     *
-     * @return void
-     */
-    public function testUniqueGroupTypeNameIndex()
-    {
-        $this->expectException(QueryException::class);
-
-        $groupType = factory(GroupType::class)->create();
-
-        factory(GroupType::class)->create([
-            'name' => $groupType->name,
-        ]);
     }
 }

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -4,7 +4,6 @@ namespace Tests\Http;
 
 use Tests\TestCase;
 use Rogue\Models\GroupType;
-use Illuminate\Database\QueryException;
 
 class GroupTypeTest extends TestCase
 {

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -4,18 +4,17 @@ namespace Tests\Http;
 
 use Tests\TestCase;
 use Rogue\Models\GroupType;
+use Illuminate\Database\QueryException;
 
 class GroupTypeTest extends TestCase
 {
     /**
      * Test that a GET request to /api/v3/group-types returns an index of all group types.
      *
-     * GET /api/v3/group-types
      * @return void
      */
     public function testGroupTypeIndex()
     {
-        // Create five group types.
         $groupTypes = factory(GroupType::class, 5)->create();
 
         $response = $this->getJson('api/v3/group-types');
@@ -29,5 +28,21 @@ class GroupTypeTest extends TestCase
                 'name' => $groupType->name,
             ]);
         }
+    }
+
+    /**
+     * Test that the group_type name field is unique.
+     *
+     * @return void
+     */
+    public function testUniqueGroupTypeNameIndex()
+    {
+        $this->expectException(QueryException::class);
+
+        $groupType = factory(GroupType::class)->create();
+
+        factory(GroupType::class)->create([
+            'name' => $groupType->name,
+        ]);
     }
 }

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Http;
+
+use Tests\TestCase;
+use Rogue\Models\GroupType;
+
+class GroupTypeTest extends TestCase
+{
+    /**
+     * Test that a GET request to /api/v3/group-types returns an index of all group types.
+     *
+     * GET /api/v3/group-types
+     * @return void
+     */
+    public function testGroupTypeIndex()
+    {
+        // Create five group types.
+        $first = factory(GroupType::class, 5)->create();
+
+        $response = $this->getJson('api/v3/group-types');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request starts on a `GroupType` resource, which will be used as a lookup table for the upcoming `Groups` resource needed for [Group OVRD campaigns](https://www.pivotaltracker.com/epic/show/4570244).

Going commit by commit, we can see this PR adds:

* `app/models/GroupType` -- our `fillable` property determines which fields are editable

* `database/migrations/[datetime]_create_group_types_table` - this migration will:
    * create the new `group_types` SQL table - Laravel will know this corresponds our `GroupType` model based on the [table/class names](https://laravel.com/docs/5.5/eloquent#eloquent-model-conventions)
    * add a unique index on `name` field (two group types should not have the same name)
    * add `created_at` and `updated_at` fields via calling the `timestamps()` method

At this point, we can run `php artisan migrate` to create the `group_types` table. I used [Sequel Pro](https://www.sequelpro.com/) to connect to my local Rogue DB, insert a record into `group_types` to verify it saved correctly.

Next we want to return data via API, so we'll need to add new files:

* `app/Http/Transformers/GroupTypeTransformer` - used to transform a `GroupType` instance into API response object

* `app/Http/Controllers/GroupTypeController` - to be used by the `group-types` API endpoint, sets our `GroupTypeTransformer` and adds an index method to return a paginated collection of `GroupType` data


And then modify `routes/web` to add a `GET /api/v3/group-types` index, using our newly added `GroupTypeController`.

We can test locally by visiting `http://rogue.test/api/v3/group-types` in browser (or by making a GET request Postman) to verify our database record we manually inserted earlier shows up in the API response.

Finally, we're now in good shape to start on some tests, adding a new [factory](https://laravel.com/docs/5.5/database-testing#writing-factories) for our new `GroupType` model, and adding a new test file -- `tests/Http/GroupTypeTest`

To run the tests, ssh into vagrant from your homestead directory. Once you'er in SSH, navigate to your Rogue directory and run:

```
phpunit tests/Http/GroupTypeTest.php 
```
cc @lindsayrmaher and @Dinnall as they'll be working on adding a new Groups resource next sprint

### How should this be reviewed?

* Pull this branch down
* Run `php artisan migrate`
* Add new record to `group_types`, e.g.
```
INSERT INTO `group_types` (`name`, `created_at`, `updated_at`)
VALUES
	('Test Group Type', '2020-03-24 18:33:56', '2020-03-24 18:33:56');
```
* Verify data appears in `GET /api/v3/group-types` request

### Any background context you want to provide?

We've still got a ways to go -- next up: 

* Add GraphQL `groupType(id)` and `groupTypes` queries to read data via GraphQL
* Adding a web controller to add and update records via Laravel blade templates.



### Relevant tickets

References [Pivotal #172541916](https://www.pivotaltracker.com/story/show/172541916).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
