### PR TITLE
Index + show views for Group Types

### DIFF
--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -3,6 +3,7 @@
 namespace Rogue\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class GroupType extends Model
 {
@@ -12,4 +13,13 @@ class GroupType extends Model
      * @var array
      */
     protected $fillable = ['name'];
+
+    protected static function boot()
+    {
+        parent::boot();
+     
+        static::addGlobalScope('order', function (Builder $builder) {
+            $builder->orderBy('name', 'asc');
+        });
+    }
 }

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -17,7 +17,7 @@ class GroupType extends Model
     protected static function boot()
     {
         parent::boot();
-     
+
         static::addGlobalScope('order', function (Builder $builder) {
             $builder->orderBy('name', 'asc');
         });

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -11,6 +11,7 @@ import ShowAction from './pages/ShowAction';
 import ShowSignup from './pages/ShowSignup';
 import ShowSchool from './pages/ShowSchool';
 import ShowCampaign from './pages/ShowCampaign';
+import ShowGroupType from './pages/ShowGroupType';
 import CampaignIndex from './pages/CampaignIndex';
 import GroupTypeIndex from './pages/GroupTypeIndex';
 
@@ -39,6 +40,9 @@ const Application = () => {
           </Route>
           <Route path="/group-types" exact>
             <GroupTypeIndex />
+          </Route>
+          <Route path="/group-types/:id">
+            <ShowGroupType />
           </Route>
           <Route path="/users" exact>
             <UserIndex />

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -12,6 +12,7 @@ import ShowSignup from './pages/ShowSignup';
 import ShowSchool from './pages/ShowSchool';
 import ShowCampaign from './pages/ShowCampaign';
 import CampaignIndex from './pages/CampaignIndex';
+import GroupTypeIndex from './pages/GroupTypeIndex';
 
 const Application = () => {
   const endpoint = env('GRAPHQL_URL');
@@ -35,6 +36,9 @@ const Application = () => {
           <Redirect from="/campaigns/:id/inbox" to="/campaigns/:id/pending" />
           <Route path="/campaigns/:id/:status">
             <ShowCampaign />
+          </Route>
+          <Route path="/group-types" exact>
+            <GroupTypeIndex />
           </Route>
           <Route path="/users" exact>
             <UserIndex />

--- a/resources/assets/pages/GroupTypeIndex.js
+++ b/resources/assets/pages/GroupTypeIndex.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+
+import Empty from '../components/Empty';
+import Shell from '../components/utilities/Shell';
+
+const GROUP_TYPE_INDEX_QUERY = gql`
+  query GroupTypeIndexQuery {
+    groupTypes {
+      id
+      name
+    }
+  }
+`;
+
+const GroupTypeIndex = () => {
+  const title = 'Group types';
+  const { loading, error, data } = useQuery(GROUP_TYPE_INDEX_QUERY);
+
+  document.title = title;
+
+  if (error) {
+    return <Shell error={error} />;
+  }
+
+  if (loading) {
+    return <Shell title={title} loading />;
+  }
+
+  if (!data.groupTypes) {
+    return (
+      <Shell title={title}>
+        <Empty />
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell title={title}>
+      <div className="container__block">
+        <table className="table">
+          <thead>
+            <tr>
+              <td>Name</td>
+            </tr>
+          </thead>
+          <tbody>
+            {data.groupTypes.map(groupType => (
+              <tr key={groupType.id}>
+                <td>
+                  <Link to={`/group-types/${groupType.id}`}>
+                    {groupType.name} ({groupType.id})
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Shell>
+  );
+};
+
+export default GroupTypeIndex;

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -1,0 +1,62 @@
+import gql from 'graphql-tag';
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+
+import NotFound from './NotFound';
+import Empty from '../components/Empty';
+import Shell from '../components/utilities/Shell';
+import MetaInformation from '../components/utilities/MetaInformation';
+
+const SHOW_GROUP_TYPE_QUERY = gql`
+  query ShowGroupTypeQuery($id: Int!) {
+    groupType(id: $id) {
+      createdAt
+      name
+    }
+  }
+`;
+
+const ShowGroupType = () => {
+  const { id } = useParams();
+  const title = `Group type #${id}`;
+  document.title = title;
+
+  const { loading, error, data } = useQuery(SHOW_GROUP_TYPE_QUERY, {
+    variables: { id: Number(id) },
+  });
+
+  if (error) {
+    return <Shell error={error} />;
+  }
+
+  if (loading) {
+    return <Shell title={title} loading />;
+  }
+
+  if (!data.groupType) return <NotFound title={title} type="group type" />;
+
+  const { createdAt, name } = data.groupType;
+
+  return (
+    <Shell title={title} subtitle={name}>
+      <div className="container__row">
+        <div className="container__block">
+          <MetaInformation
+            details={{
+              Created: createdAt,
+            }}
+          />
+        </div>
+      </div>
+      <div className="container__row">
+        <div className="container__block">
+          <h3>Groups</h3>
+          <Empty />
+        </div>
+      </div>
+    </Shell>
+  );
+};
+
+export default ShowGroupType;

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
 
     // Group Types
     Route::view('group-types', 'app');
+    Route::view('group-types/{id}', 'app');
 
     // Posts
     Route::view('posts/{id}', 'app')->name('posts.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,9 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     Route::view('campaigns/{id}', 'app');
     Route::view('campaigns/{id}/{status}', 'app');
 
+    // Group Types
+    Route::view('group-types', 'app');
+
     // Posts
     Route::view('posts/{id}', 'app')->name('posts.show');
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds front-end UI for the `groupTypes` and `groupType(id)` GraphQL queries added in https://github.com/DoSomething/graphql/pull/234, displaying a list of all `group_types` records, or a single `group_type` entity.


### How should this be reviewed?

:eyes:

### Any background context you want to provide?

Web forms for adding/editing to be added in a future PR to help keep this reviewable.

### Relevant tickets

References [Pivotal #172541916](https://www.pivotaltracker.com/story/show/172541916).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
