### PR TITLE
Check if group_type exists before creating

### DIFF
--- a/database/migrations/2020_05_27_000000_create_group_types_table.php
+++ b/database/migrations/2020_05_27_000000_create_group_types_table.php
@@ -13,6 +13,12 @@ class CreateGroupTypesTable extends Migration
      */
     public function up()
     {
+        if (Schema::hasTable('group_types')) {
+            info('group_types table already exists.');
+
+            return;
+        }
+
         Schema::create('group_types', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name')->unique();


### PR DESCRIPTION
### What's this PR do?

This pull request is a bit of a band-aid for builds failing on QA right now. The initial problem began when trying to build after merging #1028 today, Monday. Our weekend refresh overwrote the Rogue production QA `migrations` table  with production values, so when the build ran today and executed the `migrate` Artisan command, it failed with:

```
Base table or view already exists: 1050 Table 'group_types  
  ' already exists  
```
Because this table never made it to prod last summer Friday.

This addition to the migration should prevent it from failing, if we start from the `prod` migrations. I tried rolling back a migration to fix, and ended up borking the `referrer_user_id` on signups and posts -- causing the `migrate` fail to instead fail with ` Duplicate column name 'referre  
  r_user_id' `

SO -- order of operations would be:
* Refresh QA db from prod
* Merge this PR
* It should work

The other alternative would be manually dropping the table in the QA db... 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🍌 

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
