### PR TITLE
Adding group_type_id to the campaigns table

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -27,7 +27,7 @@ class Campaign extends Model
      *
      * @var array
      */
-    protected $fillable = ['internal_title', 'cause', 'impact_doc', 'start_date', 'end_date', 'contentful_campaign_id'];
+    protected $fillable = ['internal_title', 'cause', 'impact_doc', 'start_date', 'end_date', 'contentful_campaign_id', 'group_type_id'];
 
     /**
      * Attributes that can be queried when filtering.

--- a/database/migrations/2020_06_02_204137_add_group_type_id_to_campaigns_table.php
+++ b/database/migrations/2020_06_02_204137_add_group_type_id_to_campaigns_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGroupTypeIdToCampaignsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->unsignedInteger('group_type_id')->nullable()->index()->comment('The group type id the group is for.');
+            $table->foreign('group_type_id')->references('id')->on('group_types');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->dropColumn('group_type_id');
+        });
+    }
+}


### PR DESCRIPTION

### What's this PR do?

This pull request creates a migration to add the `group_type_id` as a foreign key on the campaigns table! It also adds the property as fillable so we are able to edit it later on.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We are going to allow admins the ability to add a group type id on a campaign so that it can be associated with a particular group. (right now this is specific to our OVRD campaigns for Voter Registration)

### Relevant tickets

References [Pivotal # 173101101](https://www.pivotaltracker.com/story/show/173101101).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
