### PR TITLE
Create + edit Groups via web

### DIFF
--- a/app/Http/Controllers/Web/GroupTypesController.php
+++ b/app/Http/Controllers/Web/GroupTypesController.php
@@ -66,6 +66,8 @@ class GroupTypesController extends Controller
      */
     public function update(GroupType $groupType, Request $request)
     {
+        // @TODO: Override unique rule.
+        // @see https://github.com/DoSomething/rogue/pull/1030#discussion_r434628475
         $this->validate($request, $this->rules);
 
         $groupType->update($request->all());

--- a/app/Http/Controllers/Web/GroupsController.php
+++ b/app/Http/Controllers/Web/GroupsController.php
@@ -16,8 +16,10 @@ class GroupsController extends Controller
         $this->middleware('auth');
         $this->middleware('role:admin,staff');
 
+        // @TODO: We should validate that name field is unique within the group type.
         $this->rules = [
-            'name' => 'required|unique:groups,group_type_id',
+            'name' => 'required',
+            'goal' => 'nullable|integer'
         ];
     }
 

--- a/app/Http/Controllers/Web/GroupsController.php
+++ b/app/Http/Controllers/Web/GroupsController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Rogue\Http\Controllers\Web;
+
+use Rogue\Models\Group;
+use Illuminate\Http\Request;
+use Rogue\Http\Controllers\Controller;
+
+class GroupsController extends Controller
+{
+    /**
+     * Create a controller instance.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('role:admin,staff');
+
+        $this->rules = [
+            'name' => 'required|unique:groups,group_type_id',
+        ];
+    }
+
+    /**
+     * Create a new group.
+     */
+    public function create($groupTypeId)
+    {
+        return view('groups.create')->with(['groupTypeId' => (int) $groupTypeId]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function store(Request $request)
+    {
+        $request->validate($this->rules);
+
+        $group = Group::create($request->all());
+
+        // Log that a group was created.
+        info('group', ['id' => $group->id]);
+
+        return redirect('groups/' . $group->id);
+    }
+
+    /**
+     * Edit an existing group.
+     *
+     * @param  \Rogue\Models\Group  $group
+     */
+    public function edit(Group $group)
+    {
+        return view('groups.edit')->with([
+            'group' => $group,
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Rogue\Models\Group  $group
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function update(Group $group, Request $request)
+    {
+        $this->validate($request, $this->rules);
+
+        $group->update($request->all());
+
+        // Log that a group was updated.
+        info('group_updated', ['id' => $group->id]);
+
+        return redirect('groups/' . $group->id);
+    }
+}

--- a/app/Http/Controllers/Web/GroupsController.php
+++ b/app/Http/Controllers/Web/GroupsController.php
@@ -19,7 +19,7 @@ class GroupsController extends Controller
         // @TODO: We should validate that name field is unique within the group type.
         $this->rules = [
             'name' => 'required',
-            'goal' => 'nullable|integer'
+            'goal' => 'nullable|integer',
         ];
     }
 

--- a/app/Http/Controllers/Web/GroupsController.php
+++ b/app/Http/Controllers/Web/GroupsController.php
@@ -18,6 +18,7 @@ class GroupsController extends Controller
 
         $this->rules = [
             'name' => 'required|unique:groups,group_type_id',
+            'goal' => 'integer',
         ];
     }
 

--- a/app/Http/Controllers/Web/GroupsController.php
+++ b/app/Http/Controllers/Web/GroupsController.php
@@ -18,7 +18,6 @@ class GroupsController extends Controller
 
         $this->rules = [
             'name' => 'required|unique:groups,group_type_id',
-            'goal' => 'integer',
         ];
     }
 

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -7,6 +7,7 @@ import graphql from './graphql';
 import ShowPost from './pages/ShowPost';
 import ShowUser from './pages/ShowUser';
 import UserIndex from './pages/UserIndex';
+import ShowGroup from './pages/ShowGroup';
 import ShowAction from './pages/ShowAction';
 import ShowSignup from './pages/ShowSignup';
 import ShowSchool from './pages/ShowSchool';
@@ -43,6 +44,9 @@ const Application = () => {
           </Route>
           <Route path="/group-types/:id">
             <ShowGroupType />
+          </Route>
+          <Route path="/groups/:id">
+            <ShowGroup />
           </Route>
           <Route path="/users" exact>
             <UserIndex />

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -11,7 +11,7 @@ import MetaInformation from '../components/utilities/MetaInformation';
 const SHOW_GROUP_QUERY = gql`
   query ShowGroupQuery($id: Int!) {
     group(id: $id) {
-      createdAt
+      goal
       groupTypeId
       name
     }
@@ -37,7 +37,7 @@ const ShowGroup = () => {
 
   if (!data.group) return <NotFound title={title} type="group" />;
 
-  const { createdAt, groupTypeId, name } = data.group;
+  const { goal, groupTypeId, name } = data.group;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -45,16 +45,14 @@ const ShowGroup = () => {
         <div className="container__block -half">
           <MetaInformation
             details={{
-              Created: createdAt,
+              Goal: goal || '--',
             }}
           />
         </div>
         <div className="container__block -half form-actions -inline text-right">
-          <div className="container__block -narrow">
-            <a className="button -tertiary" href={`/groups/${id}/edit`}>
-              Edit Group
-            </a>
-          </div>
+          <a className="button -tertiary" href={`/groups/${id}/edit`}>
+            Edit Group
+          </a>
         </div>
       </div>
       <div className="container__row">

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -8,21 +8,22 @@ import Empty from '../components/Empty';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
 
-const SHOW_GROUP_TYPE_QUERY = gql`
-  query ShowGroupTypeQuery($id: Int!) {
-    groupType(id: $id) {
+const SHOW_GROUP_QUERY = gql`
+  query ShowGroupQuery($id: Int!) {
+    group(id: $id) {
       createdAt
+      groupTypeId
       name
     }
   }
 `;
 
-const ShowGroupType = () => {
+const ShowGroup = () => {
   const { id } = useParams();
-  const title = `Group Type #${id}`;
+  const title = `Group #${id}`;
   document.title = title;
 
-  const { loading, error, data } = useQuery(SHOW_GROUP_TYPE_QUERY, {
+  const { loading, error, data } = useQuery(SHOW_GROUP_QUERY, {
     variables: { id: Number(id) },
   });
 
@@ -34,9 +35,9 @@ const ShowGroupType = () => {
     return <Shell title={title} loading />;
   }
 
-  if (!data.groupType) return <NotFound title={title} type="group type" />;
+  if (!data.group) return <NotFound title={title} type="group" />;
 
-  const { createdAt, name } = data.groupType;
+  const { createdAt, groupTypeId, name } = data.group;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -44,36 +45,28 @@ const ShowGroupType = () => {
         <div className="container__block -half">
           <MetaInformation
             details={{
-              Campaigns: '--',
+              Created: createdAt,
             }}
           />
         </div>
         <div className="container__block -half form-actions -inline text-right">
           <div className="container__block -narrow">
-            <a
-              className="button -secondary"
-              href={`/group-types/${id}/groups/create`}
-            >
-              Add Group
+            <a className="button -tertiary" href={`/groups/${id}/edit`}>
+              Edit Group
             </a>
           </div>
         </div>
       </div>
       <div className="container__row">
         <div className="container__block">
-          <h3>Groups</h3>
+          <h3>Signups</h3>
           <Empty />
         </div>
       </div>
       <ul className="form-actions margin-vertical">
         <li>
-          <a className="button -tertiary" href={`/group-types/${id}/edit`}>
-            Edit Group Type #{id}
-          </a>
-        </li>
-        <li>
-          <a className="button -tertiary" href={`/group-types`}>
-            View all Group Types
+          <a className="button -tertiary" href={`/group-types/${groupTypeId}`}>
+            View all Groups for Group Type #{groupTypeId}
           </a>
         </li>
       </ul>
@@ -81,4 +74,4 @@ const ShowGroupType = () => {
   );
 };
 
-export default ShowGroupType;
+export default ShowGroup;

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -14,6 +14,10 @@ const SHOW_GROUP_TYPE_QUERY = gql`
       createdAt
       name
     }
+    groups(groupTypeId: $id) {
+      id
+      name
+    }
   }
 `;
 
@@ -61,8 +65,28 @@ const ShowGroupType = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <h3>Groups</h3>
-          <Empty />
+          {data.groups ? (
+            <table className="table">
+              <thead>
+                <tr>
+                  <td>Group ID</td>
+                </tr>
+              </thead>
+              <tbody>
+                {data.groups.map(group => (
+                  <tr>
+                    <td>
+                      <a href={`/groups/${group.id}`}>
+                        {group.name} ({group.id})
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <Empty />
+          )}
         </div>
       </div>
       <ul className="form-actions margin-vertical">

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -16,6 +16,7 @@ const SHOW_GROUP_TYPE_QUERY = gql`
     }
     groups(groupTypeId: $id) {
       id
+      goal
       name
     }
   }
@@ -65,6 +66,7 @@ const ShowGroupType = () => {
               <thead>
                 <tr>
                   <td>Group ID</td>
+                  <td>Goal</td>
                 </tr>
               </thead>
               <tbody>
@@ -75,6 +77,7 @@ const ShowGroupType = () => {
                         {group.name} ({group.id})
                       </a>
                     </td>
+                    <td>{group.goal || '--'}</td>
                   </tr>
                 ))}
               </tbody>

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -53,14 +53,9 @@ const ShowGroupType = () => {
           />
         </div>
         <div className="container__block -half form-actions -inline text-right">
-          <div className="container__block -narrow">
-            <a
-              className="button -secondary"
-              href={`/group-types/${id}/groups/create`}
-            >
-              Add Group
-            </a>
-          </div>
+          <a className="button -tertiary" href={`/group-types/${id}/edit`}>
+            Edit Group Type #{id}
+          </a>
         </div>
       </div>
       <div className="container__row">
@@ -87,14 +82,17 @@ const ShowGroupType = () => {
           ) : (
             <Empty />
           )}
+          <div className="container__block -narrow">
+            <a
+              className="button -secondary"
+              href={`/group-types/${id}/groups/create`}
+            >
+              Add Group
+            </a>
+          </div>
         </div>
       </div>
       <ul className="form-actions margin-vertical">
-        <li>
-          <a className="button -tertiary" href={`/group-types/${id}/edit`}>
-            Edit Group Type #{id}
-          </a>
-        </li>
         <li>
           <a className="button -tertiary" href={`/group-types`}>
             View all Group Types

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -87,7 +87,7 @@ const ShowGroupType = () => {
           )}
           <div className="container__block -narrow">
             <a
-              className="button -secondary"
+              className="button -primary"
               href={`/group-types/${id}/groups/create`}
             >
               Add Group

--- a/resources/views/group-types/create.blade.php
+++ b/resources/views/group-types/create.blade.php
@@ -9,10 +9,12 @@
             <div class="container__block -narrow">
                 <form method="POST" action="{{ route('group-types.store') }}">
                     {{ csrf_field()}}
+
                     <div class="form-item">
                         <label class="field-label">Name</label>
                         @include('forms.text', ['name' => 'name', 'placeholder' => 'e.g. March For Our Lives, DoSomething Clubs'])
                     </div>
+
                     <ul class="form-actions -inline -padded">
                         <li><input type="submit" class="button" value="Create"></li>
                     </ul>

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -2,17 +2,25 @@
 
 @section('main_content')
 
-    @include('layouts.header', ['header' => 'New Group', 'subtitle' => 'Group Type #' . $groupTypeId])
+    @include('layouts.header', ['header' => 'New Group'])
 
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -narrow">
+                <h1>
+                    <a href="/group-types/{{ $groupTypeId }}">Group Type #{{ $groupTypeId }}</a>
+                </h1>
                 <form method="POST" action="{{ route('groups.store', ['group_type_id' => $groupTypeId]) }}">
                     {{ csrf_field()}}
 
                     <div class="form-item">
                         <label class="field-label">Name</label>
                         @include('forms.text', ['name' => 'name', 'placeholder' => 'Enter group name'])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Goal</label>
+                        @include('forms.text', ['name' => 'goal', 'placeholder' => 'e.g. 200 (optional)'])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -15,12 +15,12 @@
 
                     <div class="form-item">
                         <label class="field-label">Name</label>
-                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Enter group name'])
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Group name, e.g. NYC Chapter'])
                     </div>
 
                     <div class="form-item">
                         <label class="field-label">Goal</label>
-                        @include('forms.text', ['name' => 'goal', 'placeholder' => 'e.g. 200 (optional)'])
+                        @include('forms.text', ['name' => 'goal', 'placeholder' => 'Optional group goal, e.g. 200'])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header', ['header' => 'New Group', 'subtitle' => 'Group Type #' . $groupTypeId])
+
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <form method="POST" action="{{ route('groups.store', ['group_type_id' => $groupTypeId]) }}">
+                    {{ csrf_field()}}
+
+                    <div class="form-item">
+                        <label class="field-label">Name</label>
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'NYC Chapter'])
+                    </div>
+
+                    <ul class="form-actions -inline -padded">
+                        <li><input type="submit" class="button" value="Create Group"></li>
+                    </ul>
+                </form>
+            </div>
+        </div>
+    </div>
+
+@stop

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -12,7 +12,7 @@
 
                     <div class="form-item">
                         <label class="field-label">Name</label>
-                        @include('forms.text', ['name' => 'name', 'placeholder' => 'NYC Chapter'])
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Enter group name'])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -2,21 +2,26 @@
 
 @section('main_content')
 
-    @include('layouts.header', ['header' => 'Edit Group Type'])
+    @include('layouts.header', ['header' => 'Edit Group'])
 
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -narrow">
                 <h1>
-                    <a href="/group-types/{{ $groupType->id }}">{{ $groupType->name }}</a>
+                    <a href="/groups/{{ $group->id }}">{{ $group->name }}</a>
                 </h1>
-                <form method="POST" action="{{ route('group-types.update', $groupType->id) }}">
+                <form method="POST" action="{{ route('groups.update', $group->id) }}">
                     {{ csrf_field()}}
                     {{ method_field('PATCH') }}
 
                     <div class="form-item">
                         <label class="field-label">Name</label>
-                        @include('forms.text', ['name' => 'name', 'placeholder' => 'e.g. March For Our Lives, DoSomething Clubs', 'value' => $groupType->name])
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'e.g. NYC Chapter', 'value' => $group->name])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Goal</label>
+                        @include('forms.text', ['name' => 'goal', 'placeholder' => 'e.g. 200 (optional)', 'value' => $group->goal])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -16,12 +16,12 @@
 
                     <div class="form-item">
                         <label class="field-label">Name</label>
-                        @include('forms.text', ['name' => 'name', 'placeholder' => 'e.g. NYC Chapter', 'value' => $group->name])
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Group name, e.g. NYC Chapter', 'value' => $group->name])
                     </div>
 
                     <div class="form-item">
                         <label class="field-label">Goal</label>
-                        @include('forms.text', ['name' => 'goal', 'placeholder' => 'e.g. 200 (optional)', 'value' => $group->goal])
+                        @include('forms.text', ['name' => 'goal', 'placeholder' => 'Optional group goal, e.g. 200', 'value' => $group->goal])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,9 @@ Route::resource('actions', 'ActionsController', ['except' => 'show']);
 Route::get('campaigns/{id}/actions/create', 'ActionsController@create');
 Route::resource('campaigns', 'CampaignsController', ['except' => ['index', 'show']]);
 Route::resource('group-types', 'GroupTypesController', ['except' => ['index', 'show']]);
+Route::resource('groups', 'GroupsController', ['except' => 'show']);
+Route::get('group-types/{id}/groups/create', 'GroupsController@create');
+
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
@@ -32,6 +35,9 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     Route::view('campaigns', 'app');
     Route::view('campaigns/{id}', 'app');
     Route::view('campaigns/{id}/{status}', 'app');
+
+    // Groups
+    Route::view('groups/{id}', 'app');
 
     // Group Types
     Route::view('group-types', 'app');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,8 +22,8 @@ Route::resource('actions', 'ActionsController', ['except' => 'show']);
 Route::get('campaigns/{id}/actions/create', 'ActionsController@create');
 Route::resource('campaigns', 'CampaignsController', ['except' => ['index', 'show']]);
 Route::resource('group-types', 'GroupTypesController', ['except' => ['index', 'show']]);
-Route::resource('groups', 'GroupsController', ['except' => 'show']);
 Route::get('group-types/{id}/groups/create', 'GroupsController@create');
+Route::resource('groups', 'GroupsController', ['except' => 'show']);
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::get('campaigns/{id}/actions/create', 'ActionsController@create');
 Route::resource('campaigns', 'CampaignsController', ['except' => ['index', 'show']]);
 Route::resource('group-types', 'GroupTypesController', ['except' => ['index', 'show']]);
 Route::get('group-types/{id}/groups/create', 'GroupsController@create');
-Route::resource('groups', 'GroupsController', ['except' => 'show']);
+Route::resource('groups', 'GroupsController', ['except' => ['create', 'show']]);
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,6 @@ Route::resource('group-types', 'GroupTypesController', ['except' => ['index', 's
 Route::resource('groups', 'GroupsController', ['except' => 'show']);
 Route::get('group-types/{id}/groups/create', 'GroupsController@create');
 
-
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Actions


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for staff and admins to create, view, and edit a Group (added in #1031) via the admin UI, by first navigating to the Group Type page to create/edit a Group for.

<img width="500" alt="Screen Shot 2020-06-03 at 11 07 23 AM" src="https://user-images.githubusercontent.com/1236811/83672230-c9ec5500-a58a-11ea-97d7-8615f80d5026.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

* This is missing tests for now, to help keep this 👹 of a PR this reviewable.

* I mentioned this in https://github.com/DoSomething/rogue/pull/1030#discussion_r434707291, but couldn't figure out how to add form validation to prevent the server error if you try to create/edit a group with a duplicate name within the group type. Because this is an internal tool, I think we'll be fine to fix this up in a future PR, again to cut down on complexity / review time.

### Relevant tickets

References [Pivotal #172541916](https://www.pivotaltracker.com/story/show/172541916).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
