### PR TITLE
Adds group_id field to Signups 

### DIFF
--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -43,6 +43,7 @@ class SignupTransformer extends TransformerAbstract
             $response['source_details'] = $signup->source_details;
             $response['details'] = $signup->details;
             $response['referrer_user_id'] = $signup->referrer_user_id;
+            $response['group_id'] = $signup->group_id;
         }
 
         return $response;

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -56,8 +56,8 @@ class Signup extends Model
      */
     public static $indexes = [
         'campaign_id',
-        'id',
         'group_id',
+        'id',
         'quantity',
         'northstar_id',
         'referrer_user_id',

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -32,7 +32,19 @@ class Signup extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'campaign_id', 'why_participated', 'source', 'source_details', 'details', 'created_at', 'updated_at', 'referrer_user_id'];
+    protected $fillable = [
+        'campaign_id',
+        'created_at',
+        'details',
+        'group_id',
+        'id',
+        'northstar_id',
+        'referrer_user_id',
+        'source',
+        'source_details',
+        'updated_at',
+        'why_participated',
+    ];
 
     /**
      * Attributes that can be queried when filtering.
@@ -43,7 +55,14 @@ class Signup extends Model
      * @var array
      */
     public static $indexes = [
-        'campaign_id', 'updated_at', 'northstar_id', 'id', 'quantity', 'source', 'referrer_user_id',
+        'campaign_id',
+        'id',
+        'group_id',
+        'quantity',
+        'northstar_id',
+        'referrer_user_id',
+        'source',
+        'updated_at',
     ];
 
     /**

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -26,6 +26,7 @@ class SignupRepository
         $signup->source_details = isset($data['source_details']) ? $data['source_details'] : null;
         $signup->details = isset($data['details']) ? $data['details'] : null;
         $signup->referrer_user_id = isset($data['referrer_user_id']) ? $data['referrer_user_id'] : null;
+        $signup->group_id = isset($data['group_id']) ? $data['group_id'] : null;
         $signup->save();
 
         return $signup;

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -4,6 +4,7 @@ use Faker\Generator;
 use Rogue\Models\Post;
 use Rogue\Models\User;
 use Rogue\Types\Cause;
+use Rogue\Models\Group;
 use Rogue\Models\Action;
 use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
@@ -202,6 +203,16 @@ $factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($
 // Group Type Factory
 $factory->define(GroupType::class, function (Generator $faker) {
     return [
+        'name' => title_case($faker->unique()->company),
+    ];
+});
+
+// Group Factory
+$factory->define(Group::class, function (Generator $faker) {
+    return [
+        'group_type_id' => function () {
+            return factory(GroupType::class)->create()->id;
+        },
         'name' => title_case($faker->unique()->company),
     ];
 });

--- a/database/migrations/2020_06_03_000000_add_group_id_to_signups_table.php
+++ b/database/migrations/2020_06_03_000000_add_group_id_to_signups_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGroupIdToSignupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->unsignedInteger('group_id')->nullable()->index()->after('referrer_user_id');
+            $table->foreign('group_id')->references('id')->on('groups');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('signups', function (Blueprint $table) {
+            $table->dropColumn('group_id');
+        });
+    }
+}

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -70,7 +70,15 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
   - You can also use include parameters to only return posts by type.
   - e.g. To only return text and photo posts: `api/v3/signups?include=posts:type(text|photo)`
 - **filter[column]** _(string)_
-  - Filter results by a column: `id`, `northstar_id`, `campaign_id`, `source`, `referrer_user_id`, `group_id`
+  - Filter results by a column. Available columns:
+    - `campaign_id`
+    - `group_id`
+    - `id`
+    - `quantity`
+    - `northstar_id`
+    - `referrer_user_id`
+    - `source`
+    - `updated_at`
   - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
 - **orderBy** _(string)_

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -9,7 +9,7 @@ POST /api/v3/signups
 ```
 
 - **campaign_id**: (int|string) required without action_id.
-  The drupal node id of the campaign the user is signing up for.
+  The ID of the campaign the user is signing up for.
 - **action_id**: (int) required without campaign_id.
   The action ID of the action that the user's post is associated with.
 - **northstar_id**: (int) optional.

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -20,8 +20,10 @@ POST /api/v3/signups
   The source of the signup.
 - **details**: (string) optional
   Details to be added to the "details" column on the signup, such as signed up to receive affiliate messaging.
-- **referrer_user_id** (string).
+- **referrer_user_id** :(string) optional.
   The referring User ID that this signup should be associated with.
+- **group_id**: (int) optional.
+  The Group ID that this signup should be associated with.
 - **dont_send_to_blink** (boolean) optional.
   If included and true, the data for this Signup will not be sent to Blink.
 - **created_at**: (string) optional.
@@ -68,7 +70,7 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
   - You can also use include parameters to only return posts by type.
   - e.g. To only return text and photo posts: `api/v3/signups?include=posts:type(text|photo)`
 - **filter[column]** _(string)_
-  - Filter results by the given column: `northstar_id`, `campaign_id`, `source`
+  - Filter results by the given column: `northstar_id`, `campaign_id`, `source`, `group_id`
   - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
 - **orderBy** _(string)_
@@ -99,6 +101,7 @@ Example Response:
       "source": "phoenix-web",
       "details": null,
       "referrer_user_id" : null,
+      "group_id": null,
     },
     {
       "id": 2,
@@ -112,6 +115,7 @@ Example Response:
       "source": "phoenix-web",
       "details": null,
       "referrer_user_id" : null,
+      "group_id": 11,
     },
   ],
   "meta": {

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -20,7 +20,7 @@ POST /api/v3/signups
   The source of the signup.
 - **details**: (string) optional
   Details to be added to the "details" column on the signup, such as signed up to receive affiliate messaging.
-- **referrer_user_id** :(string) optional.
+- **referrer_user_id**: (string) optional.
   The referring User ID that this signup should be associated with.
 - **group_id**: (int) optional.
   The Group ID that this signup should be associated with.
@@ -70,7 +70,7 @@ When using `?include=posts`, anonymous requests will only return accepted posts.
   - You can also use include parameters to only return posts by type.
   - e.g. To only return text and photo posts: `api/v3/signups?include=posts:type(text|photo)`
 - **filter[column]** _(string)_
-  - Filter results by the given column: `northstar_id`, `campaign_id`, `source`, `group_id`
+  - Filter results by a column: `id`, `northstar_id`, `campaign_id`, `source`, `referrer_user_id`, `group_id`
   - You can filter by more than one column, e.g. `/signups?filter[id]=4&filter[campaign_id]=5`
   - You can filter by more than one value for a column, e.g. `/signups?filter[campaign_id]=121,122`
 - **orderBy** _(string)_

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -67,7 +67,6 @@ class SignupTest extends TestCase
         $campaignId = $this->faker->randomNumber(4);
         $group = factory(Group::class)->create();
 
-        // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
 
         $response = $this->withAccessToken($northstarId)->postJson('api/v3/signups', [
@@ -75,7 +74,6 @@ class SignupTest extends TestCase
             'group_id' => $group->id,
         ]);
 
-        // Make sure we get the 201 Created response
         $response->assertStatus(201);
         $response->assertJson([
             'data' => [
@@ -83,13 +81,6 @@ class SignupTest extends TestCase
                 'campaign_id' => $campaignId,
                 'group_id' => $group->id,
             ],
-        ]);
-
-        // Make sure the signup is persisted.
-        $this->assertDatabaseHas('signups', [
-            'northstar_id' => $northstarId,
-            'campaign_id' => $campaignId,
-            'group_id' => $group->id,
         ]);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `group_id` field to the Signup resource, referencing the Groups resource added in #1031.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Related changes coming up for future PR's:

* Include `group_type_name` and `group_name` in a Customer.io `campaign_signup` event
* Add `group_id` to Posts

### Relevant tickets

References [Pivotal #172541936](https://www.pivotaltracker.com/story/show/172541936).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
