### PR TITLE
Display groupType name on ShowGroup page

### DIFF
--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -12,7 +12,10 @@ const SHOW_GROUP_QUERY = gql`
   query ShowGroupQuery($id: Int!) {
     group(id: $id) {
       goal
-      groupTypeId
+      groupType {
+        id
+        name
+      }
       name
     }
   }
@@ -37,10 +40,10 @@ const ShowGroup = () => {
 
   if (!data.group) return <NotFound title={title} type="group" />;
 
-  const { goal, groupTypeId, name } = data.group;
+  const { goal, groupType, name } = data.group;
 
   return (
-    <Shell title={title} subtitle={name}>
+    <Shell title={title} subtitle={`${name} (${groupType.name})`}>
       <div className="container__row">
         <div className="container__block -half">
           <MetaInformation
@@ -63,8 +66,8 @@ const ShowGroup = () => {
       </div>
       <ul className="form-actions margin-vertical">
         <li>
-          <a className="button -tertiary" href={`/group-types/${groupTypeId}`}>
-            View all Groups for Group Type #{groupTypeId}
+          <a className="button -tertiary" href={`/group-types/${groupType.id}`}>
+            View all {groupType.name} Groups
           </a>
         </li>
       </ul>


### PR DESCRIPTION
### What's this PR do?

This pull request displays a Group's Group Type name instead of the Group Type ID per https://github.com/DoSomething/graphql/pull/239.

<img width="450" alt="Screen Shot 2020-06-04 at 2 15 19 PM" src="https://user-images.githubusercontent.com/1236811/83811011-e1e8d500-a66d-11ea-9f68-e47d453c6a9e.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

Last thing left to do on this ShowGroup page is displaying the list of signups whose `group_id` matches the current group, but that's for another PR. 

### Relevant tickets

References [Pivotal #172541916](https://www.pivotaltracker.com/story/show/172541916).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
