### PR TITLE
Adds group_id field to Posts

### DIFF
--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -67,6 +67,7 @@ class PostTransformer extends TransformerAbstract
             $response['remote_addr'] = '0.0.0.0';
             $response['details'] = $post->details;
             $response['referrer_user_id'] = $post->referrer_user_id;
+            $response['group_id'] = $post->group_id;
             $response['school_id'] = $post->school_id;
         }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -48,7 +48,27 @@ class Post extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'signup_id', 'campaign_id', 'northstar_id', 'type', 'action', 'action_id', 'details', 'quantity', 'url', 'text', 'status', 'source', 'source_details', 'location', 'postal_code', 'school_id', 'referrer_user_id'];
+    protected $fillable = [
+        'action',
+        'action_id',
+        'campaign_id',
+        'details',
+        'group_id',
+        'id',
+        'location',
+        'postal_code',
+        'quantity',
+        'northstar_id',
+        'referrer_user_id',
+        'school_id',
+        'signup_id',
+        'source',
+        'source_details',
+        'status',
+        'text',
+        'type',
+        'url',
+    ];
 
     /**
      * Attributes that can be queried when filtering.

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -102,6 +102,7 @@ class PostRepository
             'source_details' => isset($data['source_details']) ? $data['source_details'] : null,
             'details' => isset($data['details']) ? $data['details'] : null,
             'referrer_user_id' => isset($data['referrer_user_id']) ? $data['referrer_user_id'] : null,
+            'group_id' => isset($data['group_id']) ? $data['group_id'] : null,
         ]);
 
         // If this is a share-social type post, auto-accept.

--- a/database/migrations/2020_06_05_000000_add_group_id_to_posts.php
+++ b/database/migrations/2020_06_05_000000_add_group_id_to_posts.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGroupIdToPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->unsignedInteger('group_id')->nullable()->after('referrer_user_id');
+            $table->foreign('group_id')->references('id')->on('groups');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('group_id');
+        });
+    }
+}

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -5,6 +5,7 @@ namespace Tests\Http;
 use Tests\TestCase;
 use Rogue\Models\Post;
 use Rogue\Models\User;
+use Rogue\Models\Group;
 use Rogue\Models\Action;
 use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
@@ -69,6 +70,7 @@ class PostTest extends TestCase
         $school_id = $this->faker->word;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
         $referrerUserId = $this->faker->northstar_id;
+        $groupId = factory(Group::class)->create()->id;
 
         // Create an action to refer to.
         $action = factory(Action::class)->create(['campaign_id' => $campaignId]);
@@ -100,6 +102,7 @@ class PostTest extends TestCase
             'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
             'details'          => json_encode($details),
             'referrer_user_id' => $referrerUserId,
+            'group_id'         => $groupId,
         ]);
 
         $response->assertStatus(201);
@@ -111,6 +114,7 @@ class PostTest extends TestCase
             'northstar_id' => $northstarId,
             'why_participated' => $why_participated,
             'referrer_user_id' => $referrerUserId,
+            'group_id' => $groupId,
         ]);
 
         $this->assertDatabaseHas('posts', [
@@ -125,6 +129,7 @@ class PostTest extends TestCase
             'quantity' => $quantity,
             'details' => json_encode($details),
             'referrer_user_id' => $referrerUserId,
+            'group_id' => $groupId,
         ]);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a group_id field to the Posts resource, referencing the Groups resource added in #1031.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We'll eventually need a compound index to the `posts` table on `group_id`, `status`, and potentially `action_id` -- but holding off on adding this, as we'll likely want to deploy that migration while the website is in maintenance mode to avoid timeouts (which happened when we deployed #1034)

### Relevant tickets

References [Pivotal #172541936](https://www.pivotaltracker.com/story/show/172541936), #1034


### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
