### PR TITLE
Display Group's signups, Signup's Group ID

### DIFF
--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -3,15 +3,14 @@ import { map } from 'lodash';
 import gql from 'graphql-tag';
 import usePortal from 'react-useportal';
 import { Link } from 'react-router-dom';
-import { parse, format } from 'date-fns';
 
 import Quantity from './utilities/Quantity';
 import PostTile from './PostTile';
-import { TAGS } from '../helpers';
 import HelpLink from './utilities/HelpLink';
 import TextBlock from './utilities/TextBlock';
 import Modal from './utilities/Modal';
 import PostCard from './utilities/PostCard';
+import { formatDateTime, TAGS } from '../helpers';
 import DeletePostButton from './DeletePostButton';
 import TagButton, { TagButtonFragment } from './TagButton';
 import QuantityForm, { QuantityFormFragment } from './QuantityForm';
@@ -199,7 +198,7 @@ const ReviewablePost = ({ post }) => {
               Type: post.type,
               Source: post.source,
               Location: post.location,
-              Submitted: format(parse(post.createdAt), 'M/D/YYYY h:m:s'),
+              Submitted: formatDateTime(post.createdAt),
               Referrer: post.referrerUserId ? (
                 <Link to={`/users/${post.referrerUserId}`}>
                   {post.referrerUserId}

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -74,7 +74,7 @@ export function env(key) {
  * @return {String}
  */
 export function formatDateTime(dateTimeString) {
-  return format(parse(dateTimeString), 'M/D/YYYY h:m A');
+  return format(parse(dateTimeString), 'M/D/YYYY h:mm A');
 }
 
 /**

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -1,5 +1,6 @@
 /* global document */
 
+import { parse, format } from 'date-fns';
 import { isArray, isNull, mergeWith, omitBy } from 'lodash';
 
 /**
@@ -66,6 +67,14 @@ export function modifiers(...names) {
  */
 export function env(key) {
   return (window.ENV || {})[key];
+}
+
+/**
+ * @param {String} dateTimeString
+ * @return {String}
+ */
+export function formatDateTime(dateTimeString) {
+  return format(parse(dateTimeString), 'M/D/YYYY h:m A');
 }
 
 /**

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -8,6 +8,7 @@ import Empty from '../components/Empty';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
 
+// @TODO: Paginate through signups.
 const SHOW_GROUP_QUERY = gql`
   query ShowGroupQuery($id: Int!) {
     group(id: $id) {
@@ -17,6 +18,15 @@ const SHOW_GROUP_QUERY = gql`
         name
       }
       name
+    }
+    signups(groupId: $id) {
+      id
+      userId
+      campaign {
+        id
+        internalTitle
+      }
+      createdAt
     }
   }
 `;
@@ -61,7 +71,36 @@ const ShowGroup = () => {
       <div className="container__row">
         <div className="container__block">
           <h3>Signups</h3>
-          <Empty />
+          {data.signups.length ? (
+            <table className="table">
+              <thead>
+                <tr>
+                  <td>ID</td>
+                  <td>User</td>
+                  <td>Campaign</td>
+                  <td>Created</td>
+                </tr>
+              </thead>
+              {data.signups.map(signup => (
+                <tr>
+                  <td>
+                    <a href={`/signups/${signup.id}`}>{signup.id}</a>
+                  </td>
+                  <td>
+                    <a href={`/users/${signup.userId}`}>{signup.userId}</a>
+                  </td>
+                  <td>
+                    <a href={`/campaigns/${signup.campaign.id}`}>
+                      {signup.campaign.internalTitle}
+                    </a>
+                  </td>
+                  <td>{signup.createdAt}</td>
+                </tr>
+              ))}
+            </table>
+          ) : (
+            <Empty />
+          )}
         </div>
       </div>
       <ul className="form-actions margin-vertical">

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -5,6 +5,7 @@ import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
 import Empty from '../components/Empty';
+import { formatDateTime } from '../helpers';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
 
@@ -94,7 +95,7 @@ const ShowGroup = () => {
                       {signup.campaign.internalTitle}
                     </a>
                   </td>
-                  <td>{signup.createdAt}</td>
+                  <td>{formatDateTime(signup.createdAt)}</td>
                 </tr>
               ))}
             </table>

--- a/resources/assets/pages/ShowSignup.js
+++ b/resources/assets/pages/ShowSignup.js
@@ -18,6 +18,7 @@ const SHOW_SIGNUP_QUERY = gql`
   query ShowCampaignQuery($id: Int!) {
     signup(id: $id) {
       id
+      groupId
       whyParticipated
       source
       sourceDetails
@@ -93,6 +94,13 @@ const ShowCampaign = () => {
                     Referrer: signup.referrerUserId ? (
                       <Link to={`/users/${signup.referrerUserId}`}>
                         {signup.referrerUserId}
+                      </Link>
+                    ) : (
+                      '-'
+                    ),
+                    Group: signup.groupId ? (
+                      <Link to={`/groups/${signup.groupId}`}>
+                        {signup.groupId}
                       </Link>
                     ) : (
                       '-'

--- a/resources/assets/pages/ShowSignup.js
+++ b/resources/assets/pages/ShowSignup.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import { Link } from 'react-router-dom';
-import { parse, format } from 'date-fns';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
-import TextBlock from '../components/utilities/TextBlock';
+import { formatDateTime } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import TextBlock from '../components/utilities/TextBlock';
 import MetaInformation from '../components/utilities/MetaInformation';
 import ReviewablePostGallery from '../components/ReviewablePostGallery';
 import DeleteSignupButton from '../components/DeleteSignupButton';
@@ -83,14 +83,13 @@ const ShowCampaign = () => {
                       <span>
                         {signup.source}{' '}
                         {signup.sourceDetails ? (
-                          <span class="footnote">({signup.sourceDetails})</span>
+                          <span className="footnote">
+                            ({signup.sourceDetails})
+                          </span>
                         ) : null}
                       </span>
                     ),
-                    'Created At': format(
-                      parse(signup.createdAt),
-                      'M/D/YYYY h:m A',
-                    ),
+                    'Created At': formatDateTime(signup.createdAt),
                     Referrer: signup.referrerUserId ? (
                       <Link to={`/users/${signup.referrerUserId}`}>
                         {signup.referrerUserId}


### PR DESCRIPTION
### What's this PR do?

This pull request adds front end changes per https://github.com/DoSomething/graphql/pull/238 that will come in handy for testing https://github.com/DoSomething/phoenix-next/pull/2200:

* Display a signup's Group ID on a Signup page (`/signups/:id`)
* Display a list of a Group's most recent signups on a Group page (`/groups/:id`)

Also adds a `formatDateTime` helper and fixes a Collective Freezer bug.

<img width="500" alt="Screen Shot 2020-06-08 at 2 18 36 PM" src="https://user-images.githubusercontent.com/1236811/84081524-f6411080-a992-11ea-8d6e-724e7ff8e458.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

We'll eventually want to paginate through the list of a group's signups, or potentially add a filter by the `campaignId` but for now this will help us test OVRD groups while we're actively in development/QA.

### Relevant tickets
* [#172541936](https://www.pivotaltracker.com/story/show/172541936)
* [#172084266](https://www.pivotaltracker.com/story/show/172084266)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
