### PR TITLE
Adds index to posts table on group_id, action_id, status

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -78,7 +78,21 @@ class Post extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'signup_id', 'campaign_id', 'type', 'action', 'action_id', 'northstar_id', 'status', 'created_at', 'source', 'location', 'referrer_user_id'];
+    public static $indexes = [
+        'action',
+        'action_id',
+        'campaign_id',
+        'created_at',
+        'group_id',
+        'id',
+        'location',
+        'northstar_id',
+        'referrer_user_id',
+        'signup_id',
+        'source',
+        'status',
+        'type',
+    ];
 
     /**
      * Attributes that we can sort by with the '?orderBy' query parameter.
@@ -497,13 +511,12 @@ class Post extends Model
             return;
         }
 
-        return $query->where('status', 'accepted')
+        return $query->whereIn('status', ['accepted', 'register-form', 'register-OVR'])
             ->orWhere('northstar_id', auth()->id())
             ->orWhere(function ($query) {
                 $query->whereNotNull('referrer_user_id')
                     ->where('referrer_user_id', auth()->id())
-                    ->where('type', 'voter-reg')
-                    ->whereIn('status', ['register-form', 'register-OVR']);
+                    ->where('type', 'voter-reg');
             });
     }
 

--- a/database/migrations/2020_06_08_000000_add_compound_index_to_posts_with_group_id.php
+++ b/database/migrations/2020_06_08_000000_add_compound_index_to_posts_with_group_id.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCompoundIndexToPostsWithGroupId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->index(['action_id', 'group_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropIndex(['action_id', 'group_id', 'status']);
+        });
+    }
+}

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -2,6 +2,16 @@
 
 All `v3 /posts` endpoints require the `activity` scope. `Create`/`update`/`delete` endpoints also require the `write` scope.
 
+Only admins and post owners will have `tags`, `source`, `remote_addr` (which will be `0.0.0.0` for all posts in compliance with GDPR), and hidden posts (posts that are tagged 'Hide In Gallery') returned in the response.
+
+Anonymous requests will only return posts with status `accepted`, `register-form`, or `register-OVR`.
+
+Logged-in users can additionally see any of their own posts with any status, and any voter-reg post (with any status) that they have referred.
+
+Staff can see all posts.
+
+If the post's action is marked as "anonymous", the `northstar_id` field will only be returned for the owner.
+
 ## Retrieve All Posts
 
 ```
@@ -9,16 +19,6 @@ GET /api/v3/posts
 ```
 
 Posts are returned in reverse chronological order.
-
-Only admins and post owners will have `tags`, `source`, `remote_addr` (which will be `0.0.0.0` for all posts in compliance with GDPR), and hidden posts (posts that are tagged 'Hide In Gallery') returned in the response.
-
-Anonymous requests will only return posts with status `accepted`, `register-form`, or `register-OVR`.
-
-Logged-in users can additionally see any of their own pending or rejected posts and any voter-reg post (of any status) that they have referred.
-
-Staff can see all posts.
-
-If the post's action is marked as "anonymous", the `northstar_id` field will only be returned for the owner.
 
 ### Optional Query Parameters
 
@@ -169,10 +169,6 @@ Example Response:
 ```
 GET /api/v3/posts/:post_id
 ```
-
-Only admins and post owners will have `tags`, `source`, and `remote_addr` (which will be `0.0.0.0` for all posts in compliance with GDPR)returned in the response.
-
-Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
 
 Example Response:
 

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -12,7 +12,11 @@ Posts are returned in reverse chronological order.
 
 Only admins and post owners will have `tags`, `source`, `remote_addr` (which will be `0.0.0.0` for all posts in compliance with GDPR), and hidden posts (posts that are tagged 'Hide In Gallery') returned in the response.
 
-Anonymous requests will only return accepted posts. Logged-in users can see accepted posts & any of their own pending or rejected posts. Staff can see anything!
+Anonymous requests will only return posts with status `accepted`, `register-form`, or `register-OVR`.
+
+Logged-in users can additionally see any of their own pending or rejected posts and any voter-reg post (of any status) that they have referred.
+
+Staff can see all posts.
 
 If the post's action is marked as "anonymous", the `northstar_id` field will only be returned for the owner.
 
@@ -30,6 +34,9 @@ If the post's action is marked as "anonymous", the `northstar_id` field will onl
 - **filter[campaign_id]** _(integer)_
   - The campaign ID to filter the response by.
   - e.g. `/posts?filter[campaign_id]=47`
+- **filter[group_id]** _(integer)_
+  - The group ID to filter the response by.
+  - e.g. `/posts?filter[group_id]=11`
 - **filter[northstar_id]** _(string)_
   - The northstar_id to filter the response by.
   - e.g. `/posts?filter[northstar_id]=5554eac1a59dbf117e8b4567`
@@ -99,6 +106,7 @@ Example Response:
             "location_name": "New York",
             "school_id": null,
             "referrer_user_id": null,
+            "group_id": null,
             "created_at": "2016-11-30T21:21:24+00:00",
             "updated_at": "2017-08-02T14:11:26+00:00"
         },
@@ -124,6 +132,7 @@ Example Response:
             "location_name": "New York",
             "school_id": null,
             "referrer_user_id": null,
+            "group_id": null,
             "created_at": "2016-02-10T16:19:25+00:00",
             "updated_at": "2017-08-02T14:11:35+00:00"
             "action_details": {
@@ -191,6 +200,7 @@ Example Response:
     "location_name": "New York",
     "school_id": "3600052",
     "referrer_user_id": null,
+    "group_id": null,
     "created_at": "2019-01-23T19:42:07+00:00",
     "updated_at": "2019-01-23T19:42:07+00:00"
     "action_details": {
@@ -250,6 +260,8 @@ Optional params:
   A JSON field to store extra details about a post.
 - **referrer_user_id** (string).
   The referring User ID that this post should be associated with.
+- **group_id** (int).
+  The Group ID that this post should be associated with.
 - **dont_send_to_blink** (boolean).
   If included and true, the data for this Post will not be sent to Blink.
 - **created_at** (timestamp).

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1165,18 +1165,16 @@ class PostTest extends TestCase
     {
         $referrerUserId = $this->faker->unique()->northstar_id;
 
-        // Add two completed voter reg referrals for our referrer, which should be visible to them.
-        $firstCompletedVoterRegReferral = factory(Post::class)->states('voter-reg', 'register-form')->create(['referrer_user_id' => $referrerUserId]);
-        $secondCompletedVoterRegReferral = factory(Post::class)->states('voter-reg', 'register-OVR')->create(['referrer_user_id' => $referrerUserId]);
+        // A referrer can see all of their voter registration referrals.
+        $firstVoterRegReferral = factory(Post::class)->states('voter-reg', 'register-form')->create(['referrer_user_id' => $referrerUserId]);
+        $secondVoterRegReferral = factory(Post::class)->states('voter-reg', 'rejected')->create(['referrer_user_id' => $referrerUserId]);
+        $thirdVoterRegReferral = factory(Post::class)->states('voter-reg', 'step-1')->create(['referrer_user_id' => $referrerUserId]);
 
-        // Add a non-completed voter reg referral for our referrer, which should be visible.
-        factory(Post::class)->states('voter-reg', 'step-1')->create(['referrer_user_id' => $referrerUserId]);
+        // Add a completed voter reg without a referrer, which is public because it's completed.
+        $publicVoterRegPost = factory(Post::class)->states('voter-reg', 'register-OVR')->create();
 
-        // Add a completed voter reg without a referrer, which should be visible.
-        factory(Post::class)->states('voter-reg', 'register-OVR')->create();
-
-        // Add pending referrals for a different referrer, which shouldn't be visible.
-        factory(Post::class)->states('photo', 'pending')->create(['referrer_user_id' => $this->faker->unique()->northstar_id]);
+        // Add non-completed voter referrals for a different referrer, which shouldn't be visible.
+        factory(Post::class)->states('voter-reg', 'step-1')->create(['referrer_user_id' => $this->faker->unique()->northstar_id]);
 
         // Add a pending photo post, which shouldn't be visible.
         factory(Post::class)->states('photo', 'pending')->create();
@@ -1185,11 +1183,19 @@ class PostTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonCount(4, 'data');
         $response->assertJsonFragment([
-            'id' => $firstCompletedVoterRegReferral->id,
+            'id' => $firstVoterRegReferral->id,
             'status' => 'register-form',
         ]);
         $response->assertJsonFragment([
-            'id' => $secondCompletedVoterRegReferral->id,
+            'id' => $secondVoterRegReferral->id,
+            'status' => 'rejected',
+        ]);
+        $response->assertJsonFragment([
+            'id' => $thirdVoterRegReferral->id,
+            'status' => 'step-1',
+        ]);
+        $response->assertJsonFragment([
+            'id' => $publicVoterRegPost->id,
             'status' => 'register-OVR',
         ]);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a compound index referred to in #1038, and allows filtering a `GET /posts` index query by `group_id`. This should improve performance when we eventually regularly query the database to get a count of the total completed voter registration posts for a specific `group_id`.

It also modifies the visible scope of the `Post` model to return all completed voter-reg posts, to simplify the logic needed for the calculation (it'd be complicated and more costly to try to join on `signups` to determine whether the authenticated user has signed up with the `group_id` we're running the calculation for)

### How should this be reviewed?

👀 

### Any background context you want to provide?

A reason to show any voter-reg referral regardless of status is that we eventually want to show a referrer ALL referrals broken down by different status (including non-completed status) in https://www.pivotaltracker.com/story/show/173230283

### Relevant tickets

References [Pivotal #173019860](https://www.pivotaltracker.com/story/show/173019860).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
