### PR TITLE
Set the default SCOUT_DRIVER to 'null'.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,10 @@ NORTHSTAR_CLIENT_SECRET=
 
 GRAPHQL_URL=https://graphql-dev.dosomething.org
 
-# Search Engine
+# Algolia (only use if testing indexing):
+SCOUT_DRIVER=null
 ALGOLIA_APP_ID=
 ALGOLIA_SECRET=
-SCOUT_DRIVER=
 
 # Slack '#notify-badass-members' integration. If testing, create
 # a new Incoming Webhook that posts messages to your DMs here:


### PR DESCRIPTION
### What's this PR do?

This pull request sets the default `SCOUT_DRIVER` to `'null'`. This fixes an issue where we'd pass the _actual_ `null` value (from the empty value in `.env`) when trying to create a driver and it'd explode whenever the application tried to boot:

```
Type error: Too few arguments to function Illuminate\Support\Manager::createDriver(), 0 passed
```

### How should this be reviewed?

When running this application with a fresh `.env`, things should no longer error out.

### Any background context you want to provide?

This was a bug introduced in #1022.

### Relevant tickets

References [Pivotal #173252821](https://www.pivotaltracker.com/story/show/173252821).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
