### PR TITLE
Algolia requires UNIX timestamps to filter by dates.

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -298,6 +298,11 @@ class Campaign extends Model
             ]);
         });
 
+        // Transform dates into UNIX timestamps:
+        foreach ($this->dates as $date) {
+            $array[$date] = optional($this->{$date})->timestamp;
+        }
+
         // Only send data we want to search against.
         return Arr::only($array, [
             'accepted_count',


### PR DESCRIPTION
### What's this PR do?

This pull request transforms any dates in the Campaign's `toSearchableArray` payload into UNIX timestamps, which allows us to [filter on those fields using Algolia](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-by-date/).

### How should this be reviewed?

👀 

### Any background context you want to provide?

I considered creating `start_date_timestamp` and `end_date_timestamp` fields, like shown in Algolia's docs, but that seems like something that'd just unnecessarily increase our index size.

Can you think of any reasons we might want or need the ISO date in Algolia?

### Relevant tickets

References [Pivotal #172922602](https://www.pivotaltracker.com/story/show/172922602).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
