### PR TITLE
Display a Group Type's campaigns

### DIFF
--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+
+const GROUP_TYPE_CAMPAIGN_LIST_QUERY = gql`
+  query GroupTypeCampaignListQuery($groupTypeId: Int!) {
+    paginatedCampaigns(groupTypeId: $groupTypeId) {
+      edges {
+        node {
+          id
+          internalTitle
+        }
+      }
+    }
+  }
+`;
+
+const GroupTypeCampaignList = ({ groupTypeId }) => {
+  const { loading, error, data } = useQuery(GROUP_TYPE_CAMPAIGN_LIST_QUERY, {
+    variables: { groupTypeId },
+  });
+
+  if (loading) {
+    return <>...</>;
+  }
+
+  if (error) {
+    return <>{JSON.stringify(error)}</>;
+  }
+  console.log(data);
+
+  if (!data.paginatedCampaigns || !data.paginatedCampaigns.edges) {
+    return <>--</>;
+  }
+
+  return (
+    <>
+      {data.paginatedCampaigns.edges.map(item => (
+        <a key={item.node.id} href={`/campaigns/${item.node.id}`}>
+          {item.node.internalTitle}
+        </a>
+      ))}
+    </>
+  );
+};
+
+export default GroupTypeCampaignList;

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -19,6 +19,14 @@ const SHOW_GROUP_TYPE_QUERY = gql`
       goal
       name
     }
+    paginatedCampaigns(groupTypeId: $id) {
+      edges {
+        node {
+          id
+          internalTitle
+        }
+      }
+    }
   }
 `;
 
@@ -42,6 +50,7 @@ const ShowGroupType = () => {
   if (!data.groupType) return <NotFound title={title} type="group type" />;
 
   const { createdAt, name } = data.groupType;
+  const campaigns = data.paginatedCampaigns.edges;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -49,7 +58,13 @@ const ShowGroupType = () => {
         <div className="container__block -half">
           <MetaInformation
             details={{
-              Campaigns: '--',
+              Campaigns: campaigns.length
+                ? campaigns.map(item => (
+                    <a key={item.node.id} href={`/campaigns/${item.node.id}`}>
+                      {item.node.internalTitle}
+                    </a>
+                  ))
+                : '--',
             }}
           />
         </div>
@@ -71,7 +86,7 @@ const ShowGroupType = () => {
               </thead>
               <tbody>
                 {data.groups.map(group => (
-                  <tr>
+                  <tr key={group.id}>
                     <td>
                       <a href={`/groups/${group.id}`}>
                         {group.name} ({group.id})

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -7,6 +7,7 @@ import NotFound from './NotFound';
 import Empty from '../components/Empty';
 import Shell from '../components/utilities/Shell';
 import MetaInformation from '../components/utilities/MetaInformation';
+import GroupTypeCampaignList from '../components/GroupTypeCampaignList';
 
 const SHOW_GROUP_TYPE_QUERY = gql`
   query ShowGroupTypeQuery($id: Int!) {
@@ -18,14 +19,6 @@ const SHOW_GROUP_TYPE_QUERY = gql`
       id
       goal
       name
-    }
-    paginatedCampaigns(groupTypeId: $id) {
-      edges {
-        node {
-          id
-          internalTitle
-        }
-      }
     }
   }
 `;
@@ -50,7 +43,6 @@ const ShowGroupType = () => {
   if (!data.groupType) return <NotFound title={title} type="group type" />;
 
   const { createdAt, name } = data.groupType;
-  const campaigns = data.paginatedCampaigns.edges;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -58,13 +50,7 @@ const ShowGroupType = () => {
         <div className="container__block -half">
           <MetaInformation
             details={{
-              Campaigns: campaigns.length
-                ? campaigns.map(item => (
-                    <a key={item.node.id} href={`/campaigns/${item.node.id}`}>
-                      {item.node.internalTitle}
-                    </a>
-                  ))
-                : '--',
+              Campaigns: <GroupTypeCampaignList groupTypeId={Number(id)} />,
             }}
           />
         </div>


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `ShowGroupType` page to display a list of campaigns that have their `groupTypeId` set to the current group type being viewed.

<img width="500" alt="Screen Shot 2020-06-17 at 8 00 59 AM" src="https://user-images.githubusercontent.com/1236811/84914678-b94edb00-b070-11ea-9e44-917415e9251f.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

At least locally, the `paginatedCampaigns` query seems awfully slow, which is why I wanted to move it into a separate component to avoid blocking loading the entire page. I'm wondering if I'm missing anything in the query that would speed things up. (Also could be worth caching it on the GraphQL side, but nothing needed for this PR -- which is all admin facing)

### Relevant tickets

Last item in [Pivotal #173101101](https://www.pivotaltracker.com/story/show/173101101).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
