### PR TITLE
Adds command to import March For Our Lives groups

### DIFF
--- a/app/Console/Commands/ImportMfolGroupsCommand.php
+++ b/app/Console/Commands/ImportMfolGroupsCommand.php
@@ -4,6 +4,7 @@ namespace Rogue\Console\Commands;
 
 use League\Csv\Reader;
 use Rogue\Models\Group;
+use Rogue\Models\GroupType;
 use Illuminate\Console\Command;
 
 class ImportMfolGroupsCommand extends Command
@@ -56,14 +57,19 @@ class ImportMfolGroupsCommand extends Command
         $numImported = 0;
         $numFailed = 0;
 
-        info('rogue:mfol-groups-import: Beginning import...');
+        $groupType = GroupType::firstOrCreate([
+            'name' => 'March For Our Lives',
+        ]);
+        $groupTypeId = $groupType->id;
+
+        info('rogue:mfol-groups-import: Beginning import for group type id ' . $groupTypeId .'...');
 
         foreach ($csv->getRecords() as $record) {
             $name = $record['Chapter'];
 
             try {
                 $group = Group::firstOrCreate([
-                    'group_type_id' => 1,
+                    'group_type_id' => $groupType->id,
                     'name' => $name,
                 ]);
 

--- a/app/Console/Commands/ImportMfolGroupsCommand.php
+++ b/app/Console/Commands/ImportMfolGroupsCommand.php
@@ -60,9 +60,8 @@ class ImportMfolGroupsCommand extends Command
         $groupType = GroupType::firstOrCreate([
             'name' => 'March For Our Lives',
         ]);
-        $groupTypeId = $groupType->id;
 
-        info('rogue:mfol-groups-import: Beginning import for group type id ' . $groupTypeId .'...');
+        info('rogue:mfol-groups-import: Beginning import for group type id ' . $groupType->id .'.');
 
         foreach ($csv->getRecords() as $record) {
             $name = $record['Chapter'];

--- a/app/Console/Commands/ImportMfolGroupsCommand.php
+++ b/app/Console/Commands/ImportMfolGroupsCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use League\Csv\Reader;
+use Rogue\Models\Group;
+use Illuminate\Console\Command;
+
+class ImportMfolGroupsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:mfol-groups-import {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create March For Our Lives groups from a CSV.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $path = $this->argument('path');
+
+        info('rogue:mfol-groups-import: Loading csv from ' . $path);
+
+        // Make a local copy of the CSV.
+        $temp = tempnam(sys_get_temp_dir(), 'command_csv');
+
+        file_put_contents($temp, fopen($this->argument('path'), 'r'));
+
+        // Load CSV contents.
+        $csv = Reader::createFromPath($temp, 'r');
+
+        $csv->setHeaderOffset(0);
+
+        $numImported = 0;
+        $numFailed = 0;
+
+        info('rogue:mfol-groups-import: Beginning import...');
+
+        foreach ($csv->getRecords() as $record) {
+            $name = $record['Chapter'];
+
+            try {
+                $group = Group::firstOrCreate([
+                    'group_type_id' => 1,
+                    'name' => $name,
+                ]);
+
+                $numImported++;
+
+                info('Imported group', ['id' => $group->id, 'name' => $group->name]);
+            } catch (Exception $e) {
+                $numFailed++;
+
+                info('Error importing group with ' .$name . ':' . $e->getMessage());
+            }
+        }
+
+        info('rogue:mfol-groups-import: Import completed with ' . $numImported . ' imported and ' . $numFailed . ' failed.');
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request follows the [`ImportSignupCommand`](https://github.com/DoSomething/rogue/blob/master/app/Console/Commands/ImportSignupsCommand.php) by example to add a new `ImportMfolGroupsCommand` console command that finds or creates a Group Type with name `March For Our Lives`, and creates a group in this group type for each row in a given csv, if it doesn't exist already. I've uploaded the CSV as a Github gist, and been using the URL to test this locally.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🍰 

### Relevant tickets

References [Pivotal #172541978](https://www.pivotaltracker.com/story/show/172541978).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
