### PR TITLE
Use regexp for Groups name filter instead of equals

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -33,6 +33,10 @@ class GroupsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Group::$indexes);
 
+        if (isset($filters['name'])) {
+            $query->where('name', 'REGEXP', $filters['name']);
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -22,7 +22,7 @@ class Group extends Model
      *
      * @var array
      */
-    public static $indexes = ['id', 'group_type_id', 'name'];
+    public static $indexes = ['id', 'group_type_id'];
 
     protected static function boot()
     {

--- a/docs/endpoints/groups.md
+++ b/docs/endpoints/groups.md
@@ -6,6 +6,20 @@
 GET /api/v3/groups
 ```
 
+### Optional Query Parameters
+
+- **filter[id]** _(integer)_
+
+  - Filter results by Group ID or ID's.
+
+- **filter[group_type_id]** _(integer)_
+
+  - Filter results by Group Type ID or ID's.
+
+- **filter[name]** _(string)_
+
+  - Filter results by names that include the given filter, e.g. `filter[name]=New`.
+
 Example Response:
 
 ```

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -16,40 +16,23 @@ class GroupTest extends TestCase
     public function testGroupTypeIndex()
     {
         $groupType = factory(GroupType::class)->create();
-        $groupTypeId = $groupType->id;
+        $groupNames = [
+            'Chicago',
+            'New Jersey',
+            'New York',
+            'Newfoundland',
+            'Philadelphia',
+            'San Diego',
+            'San Francisco',
+            'Santeria',
+        ];
 
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Chicago',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'New Jersey',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'New York',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Newfoundland',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Philadelphia',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'San Diego',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'San Francisco',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Sangria',
-        ]);
+        foreach ($groupNames as $groupName) {
+            factory(Group::class)->create([
+                'group_type_id' => $groupType->id,
+                'name' => $groupName,
+            ]);
+        }
 
         $response = $this->getJson('api/v3/groups');
         $decodedResponse = $response->decodeResponseJson();
@@ -63,7 +46,7 @@ class GroupTest extends TestCase
         $response->assertStatus(200);
         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
 
-        $response = $this->getJson('api/v3/groups?filter[name]=new');
+        $response = $this->getJson('api/v3/groups?filter[name]=san');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -17,14 +17,12 @@ class GroupTest extends TestCase
     {
         $groupType = factory(GroupType::class)->create();
         $groupNames = [
-            'Chicago',
-            'New Jersey',
-            'New York',
-            'Newfoundland',
-            'Philadelphia',
-            'San Diego',
-            'San Francisco',
-            'Santeria',
+            'Batman Begins',
+            'Bipartisan',
+            'Brave New World',
+            'If I Never Knew You',
+            'San Dimas High School',
+            'Santa Claus',
         ];
 
         foreach ($groupNames as $groupName) {
@@ -38,13 +36,13 @@ class GroupTest extends TestCase
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
-        $this->assertEquals(8, $decodedResponse['meta']['pagination']['count']);
+        $this->assertEquals(6, $decodedResponse['meta']['pagination']['count']);
 
         $response = $this->getJson('api/v3/groups?filter[name]=new');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
-        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+        $this->assertEquals(2, $decodedResponse['meta']['pagination']['count']);
 
         $response = $this->getJson('api/v3/groups?filter[name]=san');
         $decodedResponse = $response->decodeResponseJson();

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Http;
+
+use Tests\TestCase;
+use Rogue\Models\Group;
+use Rogue\Models\GroupType;
+
+class GroupTest extends TestCase
+{
+    /**
+     * Test that a GET request to /api/v3/groups returns an index of all group types.
+     *
+     * @return void
+     */
+    public function testGroupTypeIndex()
+    {
+        $groupType = factory(GroupType::class)->create();
+        $groupTypeId = $groupType->id;
+
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Chicago',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'New Jersey',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'New York',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Newfoundland',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Philadelphia',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'San Diego',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'San Francisco',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Sangria',
+        ]);
+
+        $response = $this->getJson('api/v3/groups');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(8, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson('api/v3/groups?filter[name]=new');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson('api/v3/groups?filter[name]=new');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+    }
+
+    /**
+     * Test that a GET request to /api/v3/groups/:id returns the intended group type.
+     *
+     * @return void
+     */
+    public function testGroupShow()
+    {
+        factory(Group::class, 5)->create();
+
+        // Create a specific group type to search for.
+        $group = factory(Group::class)->create();
+
+        $response = $this->getJson('api/v3/groups/' . $group->id);
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals($group->id, $decodedResponse['data']['id']);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `filters[name]` in a `GET /groups` index request to return all groups that have names that contain the filter value, instead of looking for an exact match.

Example response:
```
// http://rogue.test/api/v3/groups?filter[name]=new

{
  "data": [
    {
      "id": 1,
      "group_type_id": 1,
      "name": "New York City",
      "goal": 200,
      "created_at": "2020-03-24T18:33:56+00:00",
      "updated_at": "2020-06-03T17:40:52+00:00"
    },
    {
      "id": 114,
      "group_type_id": 1,
      "name": "Newark, OH",
      "goal": null,
      "created_at": "2020-06-18T18:10:41+00:00",
      "updated_at": "2020-06-18T18:10:41+00:00"
    },
    {
      "id": 222,
      "group_type_id": 1,
      "name": "The New School, NY",
      "goal": null,
      "created_at": "2020-06-18T18:10:41+00:00",
      "updated_at": "2020-06-18T18:10:41+00:00"
    },
   ...
```



### How should this be reviewed?

👀 

### Any background context you want to provide?

We'll be asking users to begin typing their group name on the Group Finder, and want to return matches as they begin typing.

### Relevant tickets

References [Pivotal #173232032](https://www.pivotaltracker.com/story/show/173232032).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
