### PR TITLE
Add cursor support to groups index

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -37,6 +37,18 @@ class GroupsController extends ApiController
             $query->where('name', 'REGEXP', $filters['name']);
         }
 
+        // This endpoint always returns groups in alphabetical order by name. We'll
+        // therefore "force" the query string so that we can use it in `getCursor`.
+        // @TODO: There must be a more elegant way of doing this...
+        $query->orderBy('name', 'asc');
+
+        $request->query->set('orderBy', 'name,asc');
+
+        if ($cursor = array_get($request->query('cursor'), 'after')) {
+            $query->whereAfterCursor($cursor);
+            $this->useCursorPagination = true;
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 

--- a/app/Http/Transformers/GroupTransformer.php
+++ b/app/Http/Transformers/GroupTransformer.php
@@ -22,6 +22,7 @@ class GroupTransformer extends TransformerAbstract
             'goal' => $group->goal,
             'created_at' => $group->created_at->toIso8601String(),
             'updated_at' => $group->updated_at->toIso8601String(),
+            'cursor' => $group->getCursor(),
         ];
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -2,11 +2,14 @@
 
 namespace Rogue\Models;
 
+use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
 class Group extends Model
 {
+    use HasCursor;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -24,12 +27,13 @@ class Group extends Model
      */
     public static $indexes = ['id', 'group_type_id'];
 
-    protected static function boot()
-    {
-        parent::boot();
-
-        static::addGlobalScope('order', function (Builder $builder) {
-            $builder->orderBy('name', 'asc');
-        });
-    }
+    /**
+     * Attributes that we can sort by with the '?orderBy' query parameter.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
+    public static $sortable = ['name'];
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -4,7 +4,6 @@ namespace Rogue\Models;
 
 use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
 
 class Group extends Model
 {

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -16,6 +16,7 @@ class GroupTest extends TestCase
     public function testGroupTypeIndex()
     {
         $groupType = factory(GroupType::class)->create();
+<<<<<<< HEAD
         $groupNames = [
             'Batman Begins',
             'Bipartisan',
@@ -31,20 +32,66 @@ class GroupTest extends TestCase
                 'name' => $groupName,
             ]);
         }
+=======
+        $groupTypeId = $groupType->id;
+
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Chicago',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'New Jersey',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'New York',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Newfoundland',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Philadelphia',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'San Diego',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'San Francisco',
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $groupTypeId,
+            'name' => 'Sangria',
+        ]);
+>>>>>>> Adds tests for Groups API
 
         $response = $this->getJson('api/v3/groups');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
+<<<<<<< HEAD
         $this->assertEquals(6, $decodedResponse['meta']['pagination']['count']);
+=======
+        $this->assertEquals(8, $decodedResponse['meta']['pagination']['count']);
+>>>>>>> Adds tests for Groups API
 
         $response = $this->getJson('api/v3/groups?filter[name]=new');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
+<<<<<<< HEAD
         $this->assertEquals(2, $decodedResponse['meta']['pagination']['count']);
 
         $response = $this->getJson('api/v3/groups?filter[name]=san');
+=======
+        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson('api/v3/groups?filter[name]=new');
+>>>>>>> Adds tests for Groups API
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -16,7 +16,6 @@ class GroupTest extends TestCase
     public function testGroupTypeIndex()
     {
         $groupType = factory(GroupType::class)->create();
-<<<<<<< HEAD
         $groupNames = [
             'Batman Begins',
             'Bipartisan',
@@ -32,66 +31,20 @@ class GroupTest extends TestCase
                 'name' => $groupName,
             ]);
         }
-=======
-        $groupTypeId = $groupType->id;
-
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Chicago',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'New Jersey',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'New York',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Newfoundland',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Philadelphia',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'San Diego',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'San Francisco',
-        ]);
-        factory(Group::class)->create([
-            'group_type_id' => $groupTypeId,
-            'name' => 'Sangria',
-        ]);
->>>>>>> Adds tests for Groups API
 
         $response = $this->getJson('api/v3/groups');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
-<<<<<<< HEAD
         $this->assertEquals(6, $decodedResponse['meta']['pagination']['count']);
-=======
-        $this->assertEquals(8, $decodedResponse['meta']['pagination']['count']);
->>>>>>> Adds tests for Groups API
 
         $response = $this->getJson('api/v3/groups?filter[name]=new');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
-<<<<<<< HEAD
         $this->assertEquals(2, $decodedResponse['meta']['pagination']['count']);
 
         $response = $this->getJson('api/v3/groups?filter[name]=san');
-=======
-        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
-
-        $response = $this->getJson('api/v3/groups?filter[name]=new');
->>>>>>> Adds tests for Groups API
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for using `cursor[after]=` to paginate through groups, following PR's like https://github.com/DoSomething/rogue/pull/976 by example.

### How should this be reviewed?

👀 

Example response:
```
// http://rogue.test/api/v3/groups?cursor[after]=MjM3LkRlZXJpbmcgSGlnaCBTY2hvb2wsIE1F

{
  "data": [
    {
      "id": 58,
      "group_type_id": 1,
      "name": "Denver Metro, CO",
      "goal": null,
      "created_at": "2020-06-18T18:10:40+00:00",
      "updated_at": "2020-06-18T18:10:40+00:00",
      "cursor": "NTguRGVudmVyIE1ldHJvLCBDTw=="
    },
    {
      "id": 92,
      "group_type_id": 1,
      "name": "Des Plaines, IL",
      "goal": null,
      "created_at": "2020-06-18T18:10:41+00:00",
      "updated_at": "2020-06-18T18:10:41+00:00",
      "cursor": "OTIuRGVzIFBsYWluZXMsIElM"
    },
    {
      "id": 205,
      "group_type_id": 1,
      "name": "Dickinson College, PA",
      "goal": null,
      "created_at": "2020-06-18T18:10:41+00:00",
      "updated_at": "2020-06-18T18:10:41+00:00",
      "cursor": "MjA1LkRpY2tpbnNvbiBDb2xsZWdlLCBQQQ=="
    },
```

### Any background context you want to provide?

Per description in #976, this additionally follows the same pattern established in #930 and #937 per the [GraphQL Pagination RFC](https://github.com/DoSomething/rfcs/pull/6).


### Relevant tickets

References [Pivotal #173275849](https://www.pivotaltracker.com/story/show/173275849).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
