### PR TITLE
Adds proof-of-concept Algolia search interface.

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -303,6 +303,12 @@ class Campaign extends Model
             $array[$date] = optional($this->{$date})->timestamp;
         }
 
+        // If a campaign doesn't have an end date, we'll set a far-future one in
+        // Algolia to allow filtering. More context: <...>
+        if (empty($array['end_date'])) {
+            $array['end_date'] = 2147483647; // January 19th 2038
+        }
+
         // Only send data we want to search against.
         return Arr::only($array, [
             'accepted_count',

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -10,15 +10,14 @@ import SortableHeading from './utilities/SortableHeading';
 
 const CAMPAIGNS_QUERY = gql`
   query CampaignsIndexQuery(
-    $isOpen: Boolean!
-    $orderBy: String!
+    $isOpen: Boolean
+    $filter: String
     $cursor: String
   ) {
-    campaigns: paginatedCampaigns(
+    campaigns: searchCampaigns(
       isOpen: $isOpen
-      orderBy: $orderBy
-      after: $cursor
-      first: 80
+      term: $filter
+      cursor: $cursor
     ) {
       edges {
         cursor
@@ -27,9 +26,6 @@ const CAMPAIGNS_QUERY = gql`
           internalTitle
           pendingCount
           acceptedCount
-          causes {
-            name
-          }
         }
       }
       pageInfo {
@@ -39,36 +35,6 @@ const CAMPAIGNS_QUERY = gql`
     }
   }
 `;
-
-/**
- * Filter the given campaigns by current search term.
- *
- * @param  {Object} data - GraphQL response
- * @return {Object}
- */
-const filterCampaigns = (data, filter) => {
-  const search = filter.toLowerCase();
-
-  if (!data) {
-    return [];
-  }
-
-  if (filter === '') {
-    return data.campaigns.edges;
-  }
-
-  return data.campaigns.edges.filter(campaign => {
-    const { id, internalTitle, causes } = campaign.node;
-
-    const matchesId = id.toString().includes(search);
-    const matchesTitle = internalTitle.toLowerCase().includes(search);
-    const matchesCause = causes.some(cause =>
-      cause.name.toLowerCase().includes(search),
-    );
-
-    return matchesId || matchesTitle || matchesCause;
-  });
-};
 
 /**
  * This component handles fetching & paginating a list of
@@ -81,11 +47,11 @@ const CampaignsTable = ({ isOpen, filter }) => {
   const [orderBy, setOrderBy] = useState('pending_count,desc');
 
   const { error, loading, data, fetchMore } = useQuery(CAMPAIGNS_QUERY, {
-    variables: { isOpen, orderBy },
+    variables: { filter, isOpen /* orderBy */ },
     notifyOnNetworkStatusChange: true,
   });
 
-  const campaigns = filterCampaigns(data, filter);
+  const campaigns = data ? data.campaigns.edges : [];
   const noFilteredResults = campaigns.length === 0 && !loading;
   const { endCursor, hasNextPage } = get(data, 'campaigns.pageInfo', {});
 
@@ -96,13 +62,6 @@ const CampaignsTable = ({ isOpen, filter }) => {
       updateQuery,
     });
   };
-
-  // If we're filtering results & can load more, do so automatically:
-  useEffect(() => {
-    if (filter !== '' && !loading && hasNextPage) {
-      handleViewMore();
-    }
-  }, [filter, endCursor]);
 
   if (error) {
     return (


### PR DESCRIPTION
### What's this PR do?

This pull request adds a proof-of-concept campaign search interface, powered by Algolia & GraphQL.

### How should this be reviewed?

This is a "frontend" proof-of-concept, to be reviewed alongside DoSomething/graphql#247.

### Any background context you want to provide?

We're hoping to use Algolia as a managed search API (rather than manage our own Solr or ElasticSearch infrastructure) but we want to continue to query data dependencies consistently with GraphQL (especially when they eventually cross system boundaries, like loading information from Rogue & Contentful).

The nice thing about using GraphQL to make these queries, rather than something like Algolia's [InstantSearch](https://www.algolia.com/products/instantsearch/), is that we can keep the same exact query interface no matter how we're displaying data (and Algolia only needs to know about things that impact filtering, rather than adding one more place that data needs to be synced & duplicated).

### Relevant tickets

References [Pivotal #172922602](https://www.pivotaltracker.com/story/show/172922602).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
