### PR TITLE
Action->Volunteer Credit field in Post's Blink Payload

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -361,6 +361,7 @@ class Post extends Model
             'quiz' => $action['quiz'],
             'online' => $action['online'],
             'time_commitment' => $action['time_commitment'],
+            'volunteer_credit' => $action['volunteer_credit'],
             'url' => $this->getMediaUrl(),
             'caption' => $this->text,
             'text' => $this->text,

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Models;
 
 use Tests\TestCase;
 use Rogue\Models\Post;
+use Rogue\Models\Action;
 use Rogue\Models\Signup;
 
 class PostModelTest extends TestCase
@@ -60,7 +61,12 @@ class PostModelTest extends TestCase
      */
     public function testBlinkPayload()
     {
+        $action = factory(Action::class)->create([
+            'volunteer_credit' => true,
+        ]);
+
         $post = factory(Post::class)->create([
+            'action_id' => $action->id,
             'school_id' => 'Example School ID',
         ]);
         $result = $post->toBlinkPayload();
@@ -69,6 +75,9 @@ class PostModelTest extends TestCase
         $this->assertEquals($result['campaign_slug'], 'test-example-campaign');
         $this->assertEquals($result['campaign_title'], 'Test Example Campaign');
         $this->assertEquals($result['school_name'], 'San Dimas High School');
+
+        // Test expected post->action attributes were added to the Blink payload.
+        $this->assertEquals($result['volunteer_credit'], $action->volunteer_credit);
 
         $post = factory(Post::class)->create([
             'school_id' => null,


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `post->action->volunteer_credit` attribute to the Post Model's Blink payload to inform us on the messaging side regarding Volunteer Creditworthy Reportbacks.

### How should this be reviewed?
👀 

I wasn't sure about the test. I always feel confused about whether to add tests for what might be built-in or extremely straightforward steps such as an attribute in a payload. My logic ended up being - and correct me here - that in the interest of ensuring that _generally_, action attributes are making it over to the payload (which would e.g. catch instances where the post-action relationship is somehow borked), we could test one example attribute.


### Relevant tickets

References [Pivotal #173110670](https://www.pivotaltracker.com/story/show/173110670).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
