### PR TITLE
Groups pagination

### DIFF
--- a/resources/assets/components/Campaign/index.js
+++ b/resources/assets/components/Campaign/index.js
@@ -118,12 +118,11 @@ const Campaign = ({ id }) => {
         <h4>Group Type</h4>
         <p>
           {campaign.groupType ? (
-            <a href={`/group-types/${campaign.groupType.id}`}>
-              <EntityLabel
-                id={campaign.groupType.id}
-                name={campaign.groupType.name}
-              />
-            </a>
+            <EntityLabel
+              id={campaign.groupType.id}
+              name={campaign.groupType.name}
+              path="group-types"
+            />
           ) : (
             '–'
           )}

--- a/resources/assets/components/Campaign/index.js
+++ b/resources/assets/components/Campaign/index.js
@@ -30,6 +30,10 @@ const SHOW_CAMPAIGN_ACTIONS_QUERY = gql`
       startDate
       updatedAt
       groupTypeId
+      groupType {
+        id
+        name
+      }
     }
     campaignWebsiteByCampaignId(campaignId: $idString) {
       title
@@ -110,12 +114,17 @@ const Campaign = ({ id }) => {
           <p>–</p>
         )}
 
-        <h4>Campaign Group Type ID</h4>
-        {campaign.groupTypeId ? (
-          <a href={`/group-types/${campaign.groupTypeId}`}>{campaign.groupTypeId}</a>
-        ) : (
-          <p>–</p>
-        )}
+        <h4>Group Type</h4>
+        <p>
+          {campaign.groupType ? (
+            <a href={`/group-types/${campaign.groupType.id}`}>
+              {campaign.groupType.name}
+            </a>
+          ) : (
+            '–'
+          )}
+        </p>
+
         <h4>URL</h4>
         <p>
           {campaignWebsiteByCampaignId ? (

--- a/resources/assets/components/Campaign/index.js
+++ b/resources/assets/components/Campaign/index.js
@@ -7,6 +7,7 @@ import { useQuery } from '@apollo/react-hooks';
 import Action, { ActionFragment } from '../Action';
 import Shell from '../utilities/Shell';
 import TextBlock from '../utilities/TextBlock';
+import EntityLabel from '../utilities/EntityLabel';
 import RogueClient from '../../utilities/RogueClient';
 
 import './campaign.scss';
@@ -118,7 +119,10 @@ const Campaign = ({ id }) => {
         <p>
           {campaign.groupType ? (
             <a href={`/group-types/${campaign.groupType.id}`}>
-              {campaign.groupType.name}
+              <EntityLabel
+                id={campaign.groupType.id}
+                name={campaign.groupType.name}
+              />
             </a>
           ) : (
             '–'

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react';
 
 import Empty from './Empty';
 import { updateQuery } from '../helpers';
+import EntityLabel from './utilities/EntityLabel';
 import SortableHeading from './utilities/SortableHeading';
 
 const CAMPAIGNS_QUERY = gql`
@@ -149,8 +150,7 @@ const CampaignsTable = ({ isOpen, filter }) => {
             <tr key={cursor}>
               <td>
                 <Link to={`/campaigns/${node.id}/accepted`}>
-                  {node.internalTitle}{' '}
-                  <code className="footnote">({node.id})</code>
+                  <EntityLabel name={node.internalTitle} id={node.id} />
                 </Link>
               </td>
               <td>{node.pendingCount}</td>

--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -30,8 +30,8 @@ const GroupTypeCampaignList = ({ groupTypeId }) => {
     return <>{JSON.stringify(error)}</>;
   }
 
-  if (!data.paginatedCampaigns || !data.paginatedCampaigns.edges) {
-    return <>--</>;
+  if (!data.paginatedCampaigns.edges.length) {
+    return <p>–</p>;
   }
 
   return (

--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -38,9 +38,11 @@ const GroupTypeCampaignList = ({ groupTypeId }) => {
     <ul>
       {data.paginatedCampaigns.edges.map(item => (
         <li key={item.node.id}>
-          <a href={`/campaigns/${item.node.id}`}>
-            <EntityLabel name={item.node.internalTitle} id={item.node.id} />
-          </a>
+          <EntityLabel
+            id={item.node.id}
+            name={item.node.internalTitle}
+            path="campaigns"
+          />
         </li>
       ))}
     </ul>

--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -2,6 +2,8 @@ import React from 'react';
 import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 
+import EntityLabel from './utilities/EntityLabel';
+
 const GROUP_TYPE_CAMPAIGN_LIST_QUERY = gql`
   query GroupTypeCampaignListQuery($groupTypeId: Int!) {
     paginatedCampaigns(groupTypeId: $groupTypeId) {
@@ -36,7 +38,9 @@ const GroupTypeCampaignList = ({ groupTypeId }) => {
     <ul>
       {data.paginatedCampaigns.edges.map(item => (
         <li key={item.node.id}>
-          <a href={`/campaigns/${item.node.id}`}>{item.node.internalTitle}</a>
+          <a href={`/campaigns/${item.node.id}`}>
+            <EntityLabel name={item.node.internalTitle} id={item.node.id} />
+          </a>
         </li>
       ))}
     </ul>

--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -33,13 +33,13 @@ const GroupTypeCampaignList = ({ groupTypeId }) => {
   }
 
   return (
-    <>
+    <ul>
       {data.paginatedCampaigns.edges.map(item => (
-        <a key={item.node.id} href={`/campaigns/${item.node.id}`}>
-          {item.node.internalTitle}
-        </a>
+        <li key={item.node.id}>
+          <a href={`/campaigns/${item.node.id}`}>{item.node.internalTitle}</a>
+        </li>
       ))}
-    </>
+    </ul>
   );
 };
 

--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -21,7 +21,7 @@ const GroupTypeCampaignList = ({ groupTypeId }) => {
   });
 
   if (loading) {
-    return <>...</>;
+    return <div className="spinner" />;
   }
 
   if (error) {

--- a/resources/assets/components/GroupTypeCampaignList.js
+++ b/resources/assets/components/GroupTypeCampaignList.js
@@ -27,7 +27,6 @@ const GroupTypeCampaignList = ({ groupTypeId }) => {
   if (error) {
     return <>{JSON.stringify(error)}</>;
   }
-  console.log(data);
 
   if (!data.paginatedCampaigns || !data.paginatedCampaigns.edges) {
     return <>--</>;

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -1,0 +1,118 @@
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+import React, { useState, useEffect } from 'react';
+
+import Empty from './Empty';
+import { updateQuery } from '../helpers';
+
+const GROUPS_QUERY = gql`
+  query GroupsIndexQuery($groupTypeId: Int!, $cursor: String) {
+    groups: paginatedGroups(groupTypeId: $groupTypeId, after: $cursor) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          goal
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+/**
+ * This component handles fetching & paginating a list of groups by group type ID.
+ *
+ * @param {Number} groupTypeId
+ * @param {String} filter
+ */
+const GroupsTable = ({ groupTypeId }) => {
+  const { error, loading, data, fetchMore } = useQuery(GROUPS_QUERY, {
+    variables: { groupTypeId },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (loading) {
+    return <div className="spinner margin-horizontal-auto margin-vertical" />;
+  }
+
+  const groups = data.groups.edges;
+  const noResults = groups.length === 0 && !loading;
+  const { endCursor, hasNextPage } = get(data, 'groups.pageInfo', {});
+
+  // We can use this function to load more results:
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery,
+    });
+  };
+
+  if (error) {
+    return (
+      <div className="text-center">
+        <p>There was an error. :(</p>
+        <code>{JSON.stringify(error)}</code>
+      </div>
+    );
+  }
+
+  if (noResults && !hasNextPage) {
+    return <Empty />;
+  }
+
+  return (
+    <>
+      <table className="table">
+        <thead>
+          <tr>
+            <td>Group ID</td>
+            <td>Goal</td>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map(({ node, cursor }) => (
+            <tr key={cursor}>
+              <td>
+                <Link to={`/groups/${node.id}`}>
+                  {node.name} <code className="footnote">({node.id})</code>
+                </Link>
+              </td>
+              <td>{node.goal || '--'}</td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot className="form-actions">
+          {loading ? (
+            <tr>
+              <td colSpan="5">
+                <div className="spinner margin-horizontal-auto margin-vertical" />
+              </td>
+            </tr>
+          ) : null}
+          {hasNextPage ? (
+            <tr>
+              <td colSpan="5">
+                <button
+                  className="button -tertiary"
+                  onClick={handleViewMore}
+                  disabled={loading}
+                >
+                  view more...
+                </button>
+              </td>
+            </tr>
+          ) : null}
+        </tfoot>
+      </table>
+    </>
+  );
+};
+
+export default GroupsTable;

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -47,7 +47,6 @@ const GroupsTable = ({ filter, groupTypeId }) => {
   const noResults = groups.length === 0 && !loading;
   const { endCursor, hasNextPage } = get(data, 'groups.pageInfo', {});
 
-  // We can use this function to load more results:
   const handleViewMore = () => {
     fetchMore({
       variables: { cursor: endCursor },
@@ -91,7 +90,7 @@ const GroupsTable = ({ filter, groupTypeId }) => {
               <td>
                 <EntityLabel id={node.id} name={node.name} path="groups" />
               </td>
-              <td>{node.goal || '--'}</td>
+              <td>{node.goal || '-'}</td>
             </tr>
           ))}
         </tbody>

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -1,6 +1,5 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
-import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
@@ -90,9 +89,7 @@ const GroupsTable = ({ filter, groupTypeId }) => {
           {groups.map(({ node, cursor }) => (
             <tr key={cursor}>
               <td>
-                <Link to={`/groups/${node.id}`}>
-                  <EntityLabel name={node.name} id={node.id} />
-                </Link>
+                <EntityLabel id={node.id} name={node.name} path="groups" />
               </td>
               <td>{node.goal || '--'}</td>
             </tr>

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -5,6 +5,7 @@ import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
 import Empty from './Empty';
+import EntityLabel from './utilities/EntityLabel';
 import { updateQuery } from '../helpers';
 
 const GROUPS_QUERY = gql`
@@ -90,7 +91,7 @@ const GroupsTable = ({ filter, groupTypeId }) => {
             <tr key={cursor}>
               <td>
                 <Link to={`/groups/${node.id}`}>
-                  {node.name} <code className="footnote">({node.id})</code>
+                  <EntityLabel name={node.name} id={node.id} />
                 </Link>
               </td>
               <td>{node.goal || '--'}</td>

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -8,11 +8,12 @@ import Empty from './Empty';
 import { updateQuery } from '../helpers';
 
 const GROUPS_QUERY = gql`
-  query GroupsIndexQuery($groupTypeId: Int!, $cursor: String) {
+  query GroupsIndexQuery($filter: String, $groupTypeId: Int!, $cursor: String) {
     groups: paginatedGroups(
-      groupTypeId: $groupTypeId
       after: $cursor
       first: 50
+      groupTypeId: $groupTypeId
+      name: $filter
     ) {
       edges {
         cursor
@@ -33,12 +34,12 @@ const GROUPS_QUERY = gql`
 /**
  * This component handles fetching & paginating a list of groups by group type ID.
  *
- * @param {Number} groupTypeId
  * @param {String} filter
+ * @param {Number} groupTypeId
  */
-const GroupsTable = ({ groupTypeId }) => {
+const GroupsTable = ({ filter, groupTypeId }) => {
   const { error, loading, data, fetchMore } = useQuery(GROUPS_QUERY, {
-    variables: { groupTypeId },
+    variables: { filter, groupTypeId },
     notifyOnNetworkStatusChange: true,
   });
 
@@ -64,7 +65,15 @@ const GroupsTable = ({ groupTypeId }) => {
   }
 
   if (noResults && !hasNextPage) {
-    return <Empty copy="No groups have been added for this group type." />;
+    return (
+      <Empty
+        copy={
+          filter
+            ? `Could not find any groups with name containing "${filter}".`
+            : 'No groups have been added to this group type.'
+        }
+      />
+    );
   }
 
   return (

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -9,7 +9,11 @@ import { updateQuery } from '../helpers';
 
 const GROUPS_QUERY = gql`
   query GroupsIndexQuery($groupTypeId: Int!, $cursor: String) {
-    groups: paginatedGroups(groupTypeId: $groupTypeId, after: $cursor) {
+    groups: paginatedGroups(
+      groupTypeId: $groupTypeId
+      after: $cursor
+      first: 50
+    ) {
       edges {
         cursor
         node {
@@ -38,11 +42,7 @@ const GroupsTable = ({ groupTypeId }) => {
     notifyOnNetworkStatusChange: true,
   });
 
-  if (loading) {
-    return <div className="spinner margin-horizontal-auto margin-vertical" />;
-  }
-
-  const groups = data.groups.edges;
+  const groups = data ? data.groups.edges : [];
   const noResults = groups.length === 0 && !loading;
   const { endCursor, hasNextPage } = get(data, 'groups.pageInfo', {});
 

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -91,14 +91,14 @@ const GroupsTable = ({ groupTypeId }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td colSpan="5">
+              <td colSpan="2">
                 <div className="spinner margin-horizontal-auto margin-vertical" />
               </td>
             </tr>
           ) : null}
           {hasNextPage ? (
             <tr>
-              <td colSpan="5">
+              <td colSpan="2">
                 <button
                   className="button -tertiary"
                   onClick={handleViewMore}

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -64,7 +64,7 @@ const GroupsTable = ({ groupTypeId }) => {
   }
 
   if (noResults && !hasNextPage) {
-    return <Empty />;
+    return <Empty copy="No groups have been added for this group type." />;
   }
 
   return (

--- a/resources/assets/components/utilities/EntityLabel.js
+++ b/resources/assets/components/utilities/EntityLabel.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Renders entity name and id.
+ *
+ * @param {String|Number} id
+ * @param {String} name
+ */
+const EntityLabel = ({ id, name }) => (
+  <>
+    {name} <code className="footnote">({id})</code>
+  </>
+);
+
+export default EntityLabel;

--- a/resources/assets/components/utilities/EntityLabel.js
+++ b/resources/assets/components/utilities/EntityLabel.js
@@ -1,15 +1,21 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 /**
  * Renders entity name and id.
  *
  * @param {String|Number} id
  * @param {String} name
+ * @param {String} path
  */
-const EntityLabel = ({ id, name }) => (
-  <>
-    {name} <code className="footnote">({id})</code>
-  </>
-);
+const EntityLabel = ({ id, name, path }) => {
+  const label = (
+    <>
+      {name} <code className="footnote">({id})</code>
+    </>
+  );
+
+  return path ? <Link to={`/${path}/${id}`}>{label}</Link> : label;
+};
 
 export default EntityLabel;

--- a/resources/assets/pages/GroupTypeIndex.js
+++ b/resources/assets/pages/GroupTypeIndex.js
@@ -57,9 +57,11 @@ const GroupTypeIndex = () => {
             {data.groupTypes.map(groupType => (
               <tr key={groupType.id}>
                 <td>
-                  <Link to={`/group-types/${groupType.id}`}>
-                    <EntityLabel name={groupType.name} id={groupType.id} />
-                  </Link>
+                  <EntityLabel
+                    id={groupType.id}
+                    name={groupType.name}
+                    path="group-types"
+                  />
                 </td>
               </tr>
             ))}

--- a/resources/assets/pages/GroupTypeIndex.js
+++ b/resources/assets/pages/GroupTypeIndex.js
@@ -5,6 +5,7 @@ import { useQuery } from '@apollo/react-hooks';
 
 import Empty from '../components/Empty';
 import Shell from '../components/utilities/Shell';
+import EntityLabel from '../components/utilities/EntityLabel';
 
 const GROUP_TYPE_INDEX_QUERY = gql`
   query GroupTypeIndexQuery {
@@ -57,8 +58,7 @@ const GroupTypeIndex = () => {
               <tr key={groupType.id}>
                 <td>
                   <Link to={`/group-types/${groupType.id}`}>
-                    {groupType.name}{' '}
-                    <code className="footnote">({groupType.id})</code>
+                    <EntityLabel name={groupType.name} id={groupType.id} />
                   </Link>
                 </td>
               </tr>

--- a/resources/assets/pages/GroupTypeIndex.js
+++ b/resources/assets/pages/GroupTypeIndex.js
@@ -57,7 +57,8 @@ const GroupTypeIndex = () => {
               <tr key={groupType.id}>
                 <td>
                   <Link to={`/group-types/${groupType.id}`}>
-                    {groupType.name} ({groupType.id})
+                    {groupType.name}{' '}
+                    <code className="footnote">({groupType.id})</code>
                   </Link>
                 </td>
               </tr>

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -7,6 +7,7 @@ import NotFound from './NotFound';
 import Empty from '../components/Empty';
 import { formatDateTime } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import EntityLabel from '../components/utilities/EntityLabel';
 import MetaInformation from '../components/utilities/MetaInformation';
 
 // @TODO: Paginate through signups.
@@ -77,7 +78,7 @@ const ShowGroup = () => {
         </div>
         <div className="container__block -half form-actions -inline text-right">
           <a className="button -tertiary" href={`/groups/${id}/edit`}>
-            Edit Group
+            Edit Group #{id}
           </a>
         </div>
       </div>
@@ -88,31 +89,36 @@ const ShowGroup = () => {
             <table className="table">
               <thead>
                 <tr>
-                  <td>ID</td>
+                  <td>Created</td>
                   <td>User</td>
                   <td>Campaign</td>
-                  <td>Created</td>
                 </tr>
               </thead>
-              {data.signups.map(signup => (
-                <tr>
-                  <td>
-                    <a href={`/signups/${signup.id}`}>{signup.id}</a>
-                  </td>
-                  <td>
-                    <a href={`/users/${signup.userId}`}>{signup.userId}</a>
-                  </td>
-                  <td>
-                    <a href={`/campaigns/${signup.campaign.id}`}>
-                      {signup.campaign.internalTitle} ({signup.campaign.id})
-                    </a>
-                  </td>
-                  <td>{formatDateTime(signup.createdAt)}</td>
-                </tr>
-              ))}
+              <tbody>
+                {data.signups.map(signup => (
+                  <tr key={signup.id}>
+                    <td>
+                      <a href={`/signups/${signup.id}`}>
+                        {formatDateTime(signup.createdAt)}
+                      </a>
+                    </td>
+                    <td>
+                      <a href={`/users/${signup.userId}`}>{signup.userId}</a>
+                    </td>
+                    <td>
+                      <a href={`/campaigns/${signup.campaign.id}`}>
+                        <EntityLabel
+                          id={signup.campaign.id}
+                          name={signup.campaign.internalTitle}
+                        />
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
             </table>
           ) : (
-            <Empty />
+            <Empty copy="No members have signed up for this group yet." />
           )}
         </div>
       </div>

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
@@ -98,20 +98,21 @@ const ShowGroup = () => {
                 {data.signups.map(signup => (
                   <tr key={signup.id}>
                     <td>
-                      <a href={`/signups/${signup.id}`}>
+                      <Link to={`/signups/${signup.id}`}>
                         {formatDateTime(signup.createdAt)}
-                      </a>
+                      </Link>
                     </td>
                     <td>
-                      <a href={`/users/${signup.userId}`}>{signup.userId}</a>
+                      <Link to={`/users/${signup.userId}`}>
+                        {signup.userId}
+                      </Link>
                     </td>
                     <td>
-                      <a href={`/campaigns/${signup.campaign.id}`}>
-                        <EntityLabel
-                          id={signup.campaign.id}
-                          name={signup.campaign.internalTitle}
-                        />
-                      </a>
+                      <EntityLabel
+                        id={signup.campaign.id}
+                        name={signup.campaign.internalTitle}
+                        path="campaigns"
+                      />
                     </td>
                   </tr>
                 ))}

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -6,6 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
 import NotFound from './NotFound';
 import Empty from '../components/Empty';
 import Shell from '../components/utilities/Shell';
+import GroupsTable from '../components/GroupsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 import GroupTypeCampaignList from '../components/GroupTypeCampaignList';
 
@@ -13,11 +14,6 @@ const SHOW_GROUP_TYPE_QUERY = gql`
   query ShowGroupTypeQuery($id: Int!) {
     groupType(id: $id) {
       createdAt
-      name
-    }
-    groups(groupTypeId: $id) {
-      id
-      goal
       name
     }
   }
@@ -62,30 +58,7 @@ const ShowGroupType = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          {data.groups ? (
-            <table className="table">
-              <thead>
-                <tr>
-                  <td>Group ID</td>
-                  <td>Goal</td>
-                </tr>
-              </thead>
-              <tbody>
-                {data.groups.map(group => (
-                  <tr key={group.id}>
-                    <td>
-                      <a href={`/groups/${group.id}`}>
-                        {group.name} ({group.id})
-                      </a>
-                    </td>
-                    <td>{group.goal || '--'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : (
-            <Empty />
-          )}
+          <GroupsTable groupTypeId={Number(id)} />
           <div className="container__block -narrow">
             <a
               className="button -primary"

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -20,6 +20,7 @@ const SHOW_GROUP_TYPE_QUERY = gql`
 `;
 
 const ShowGroupType = () => {
+  const [filter, setFilter] = useState('');
   const { id } = useParams();
   const title = `Group Type #${id}`;
   document.title = title;
@@ -49,6 +50,12 @@ const ShowGroupType = () => {
               Campaigns: <GroupTypeCampaignList groupTypeId={Number(id)} />,
             }}
           />
+          <input
+            type="text"
+            className="text-field -search"
+            placeholder="Filter by group name..."
+            onChange={event => setFilter(event.target.value)}
+          />
         </div>
         <div className="container__block -half form-actions -inline text-right">
           <a className="button -tertiary" href={`/group-types/${id}/edit`}>
@@ -58,7 +65,7 @@ const ShowGroupType = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <GroupsTable groupTypeId={Number(id)} />
+          <GroupsTable filter={filter} groupTypeId={Number(id)} />
           <div className="container__block -narrow">
             <a
               className="button -primary"


### PR DESCRIPTION
### What's this PR do?

This pull request adds a search filter and pagination to the list of a group type's groups, using the `paginatedGroups` query added in https://github.com/DoSomething/graphql/pull/248, as well as some additional tweaks:

* Displays group type name on campaign page if set, per https://github.com/DoSomething/graphql/pull/246
* Renders the group type campaign list as a `ul` (refs #1046)
* Adds a `EntityLabel` utility component to DRY displaying an entity's label and ID within a `code` element

### How should this be reviewed?

👀 

<img width="400" src="https://user-images.githubusercontent.com/1236811/85467432-11e61280-b560-11ea-8fce-800755d9be2a.gif">


### Any background context you want to provide?

📄 

### Relevant tickets

References [Pivotal #173275849](https://www.pivotaltracker.com/story/show/173275849).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
