### PR TITLE
Move position of group_type_id field on campaigns table

### DIFF
--- a/database/migrations/2020_06_24_000000_move_group_type_id_on_campaigns_table.php
+++ b/database/migrations/2020_06_24_000000_move_group_type_id_on_campaigns_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class moveGroupTypeIdOnCampaignsTable extends Migration
+{
+    /**
+     * Run the migration to recreate group_type_id column in correct position.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tableName = 'campaigns';
+        $columnName = 'group_type_id';
+
+        // Drop foreign index and the column.
+        Schema::table($tableName, function ($table) use ($columnName) {
+            $table->dropForeign([$columnName]);
+            $table->dropColumn($columnName);
+        });
+
+        // Recreate the column in the correct position.
+        Schema::table($tableName, function (Blueprint $table) use ($columnName) {
+            $table->unsignedInteger($columnName)->after('secondary_causes')->nullable()->index()->comment('The group type id the group is for.');
+            $table->foreign($columnName)->references('id')->on('group_types');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        return;
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request drops the `group_type_id` column from the `campaigns` table and recreates it so it doesn't appear last in the table... which is something we missed in the migration added in #1032. This is a cosmetic change, but I do think it makes it easier to scan the SQL data. 

I tried both of the top answers in this [SO thread](https://stackoverflow.com/questions/20340778/laravel-migration-re-organising-column-order), but ran into errors with both conflicts around the foreign key. Because we currently only have one `campaign` that has this field populated, and it's not live yet -- we're in a good spot to wipe the column and re-add the correct `group_type_id` for [campaign 9075](https://activity.dosomething.org/campaigns/9075) has completed.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

I've been back and forth on whether to keep the foreign key, but think I prefer the assurance that we can't mistakenly save a non-existing value to the campaign `group_type_id` field -- as the issues a foreign key can cause with migrations seem to be a rarity for our purposes.

### Relevant tickets

References [Pivotal #173101101](https://www.pivotaltracker.com/story/show/173101101).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
