### PR TITLE
Add pagination to Group signups

### DIFF
--- a/resources/assets/components/SignupsTable.js
+++ b/resources/assets/components/SignupsTable.js
@@ -1,0 +1,135 @@
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/react-hooks';
+import React, { useState, useEffect } from 'react';
+
+import Empty from './Empty';
+import EntityLabel from './utilities/EntityLabel';
+import { formatDateTime, updateQuery } from '../helpers';
+
+const SIGNUPS_TABLE_QUERY = gql`
+  query SignupsIndexQuery($groupId: Int, $cursor: String) {
+    signups: paginatedSignups(after: $cursor, first: 50, groupId: $groupId) {
+      edges {
+        cursor
+        node {
+          id
+          userId
+          campaign {
+            id
+            internalTitle
+          }
+          createdAt
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+/**
+ * This component handles fetching & paginating a list of signups.
+ *
+ * @param {Number} groupId
+ */
+const SignupsTable = ({ groupId }) => {
+  const { error, loading, data, fetchMore } = useQuery(SIGNUPS_TABLE_QUERY, {
+    variables: { groupId },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const signups = data ? data.signups.edges : [];
+  const noResults = signups.length === 0 && !loading;
+  const { endCursor, hasNextPage } = get(data, 'signups.pageInfo', {});
+
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery,
+    });
+  };
+
+  if (error) {
+    return (
+      <div className="text-center">
+        <p>There was an error. :(</p>
+        <code>{JSON.stringify(error)}</code>
+      </div>
+    );
+  }
+
+  if (noResults && !hasNextPage) {
+    return (
+      <Empty
+        copy={
+          groupId
+            ? `No signups found for group #${groupId}.`
+            : 'No signups found.'
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      <table className="table">
+        <thead>
+          <tr>
+            <td>Signup</td>
+            <td>User</td>
+            <td>Campaign</td>
+          </tr>
+        </thead>
+        <tbody>
+          {signups.map(({ node, cursor }) => (
+            <tr key={cursor}>
+              <td>
+                <Link to={`/signups/${node.id}`}>
+                  {formatDateTime(node.createdAt)}
+                </Link>
+              </td>
+              <td>
+                <Link to={`/users/${node.userId}`}>{node.userId}</Link>
+              </td>
+              <td>
+                <EntityLabel
+                  id={node.campaign.id}
+                  name={node.campaign.internalTitle}
+                  path="campaigns"
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot className="form-actions">
+          {loading ? (
+            <tr>
+              <td colSpan="2">
+                <div className="spinner margin-horizontal-auto margin-vertical" />
+              </td>
+            </tr>
+          ) : null}
+          {hasNextPage ? (
+            <tr>
+              <td colSpan="2">
+                <button
+                  className="button -tertiary"
+                  onClick={handleViewMore}
+                  disabled={loading}
+                >
+                  view more...
+                </button>
+              </td>
+            </tr>
+          ) : null}
+        </tfoot>
+      </table>
+    </>
+  );
+};
+
+export default SignupsTable;

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -7,28 +7,20 @@ import NotFound from './NotFound';
 import Empty from '../components/Empty';
 import { formatDateTime } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import SignupsTable from '../components/SignupsTable';
 import EntityLabel from '../components/utilities/EntityLabel';
 import MetaInformation from '../components/utilities/MetaInformation';
 
-// @TODO: Paginate through signups.
 const SHOW_GROUP_QUERY = gql`
   query ShowGroupQuery($id: Int!) {
     group(id: $id) {
+      id
       goal
       groupType {
         id
         name
       }
       name
-    }
-    signups(groupId: $id, count: 50) {
-      id
-      userId
-      campaign {
-        id
-        internalTitle
-      }
-      createdAt
     }
     posts(
       groupId: $id
@@ -84,43 +76,7 @@ const ShowGroup = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <h3>Signups</h3>
-          {data.signups.length ? (
-            <table className="table">
-              <thead>
-                <tr>
-                  <td>Created</td>
-                  <td>User</td>
-                  <td>Campaign</td>
-                </tr>
-              </thead>
-              <tbody>
-                {data.signups.map(signup => (
-                  <tr key={signup.id}>
-                    <td>
-                      <Link to={`/signups/${signup.id}`}>
-                        {formatDateTime(signup.createdAt)}
-                      </Link>
-                    </td>
-                    <td>
-                      <Link to={`/users/${signup.userId}`}>
-                        {signup.userId}
-                      </Link>
-                    </td>
-                    <td>
-                      <EntityLabel
-                        id={signup.campaign.id}
-                        name={signup.campaign.internalTitle}
-                        path="campaigns"
-                      />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : (
-            <Empty copy="No members have signed up for this group yet." />
-          )}
+          <SignupsTable groupId={data.group.id} />
         </div>
       </div>
       <ul className="form-actions margin-vertical">

--- a/resources/assets/pages/ShowSignup.js
+++ b/resources/assets/pages/ShowSignup.js
@@ -26,6 +26,7 @@ const SHOW_SIGNUP_QUERY = gql`
       createdAt
       deleted
 
+      userId
       user {
         id
         displayName
@@ -61,7 +62,9 @@ const ShowCampaign = () => {
   const { signup } = data;
   const exists = signup && !signup.deleted;
   const subtitle = exists
-    ? `${signup.user.displayName} / ${signup.campaign.internalTitle}`
+    ? `${signup.user ? signup.user.displayName : signup.userId} / ${
+        signup.campaign.internalTitle
+      }`
     : 'Not found.';
 
   return (
@@ -75,8 +78,8 @@ const ShowCampaign = () => {
                 <MetaInformation
                   details={{
                     'User ID': (
-                      <Link to={`/users/${signup.user.id}`}>
-                        {signup.user.id}
+                      <Link to={`/users/${signup.userId}`}>
+                        {signup.userId}
                       </Link>
                     ),
                     Source: (


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the TODO of paginating the list of signups displayed on a Group page in the admin UI, borrowing from the paginated `GroupsTable` added in #1052. 

It also adds a check into the Signup page for a null user, which can happen when seeding the DB.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🛩️ 

### Relevant tickets

References [Pivotal #173275849](https://www.pivotaltracker.com/story/show/173275849).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
