### PR TITLE
Adds command to import NASSP groups

### DIFF
--- a/app/Console/Commands/ImportMfolGroupsCommand.php
+++ b/app/Console/Commands/ImportMfolGroupsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Console\Commands;
 
+use Exception;
 use League\Csv\Reader;
 use Rogue\Models\Group;
 use Rogue\Models\GroupType;

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use League\Csv\Reader;
+use Rogue\Models\Group;
+use Rogue\Models\GroupType;
+use Illuminate\Console\Command;
+
+class ImportNasspGroupsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:nassp-groups-import {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create National Association of Secondary School Principals group types and groups from a CSV.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @param string
+     * @return string
+     */
+    public function sanitize($value)
+    {
+        $result = trim($value);
+
+        return $result == 'NULL' ? null : $value;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $path = $this->argument('path');
+
+        info('rogue:nassp-groups-import: Loading csv from ' . $path);
+
+        // Make a local copy of the CSV.
+        $temp = tempnam(sys_get_temp_dir(), 'command_csv');
+
+        file_put_contents($temp, fopen($this->argument('path'), 'r'));
+
+        // Load CSV contents.
+        $csv = Reader::createFromPath($temp, 'r');
+
+        $csv->setHeaderOffset(0);
+
+        $numImported = 0;
+        $numFailed = 0;
+        $numSkipped = 0;
+
+        $nhsGroupType = GroupType::firstOrCreate([
+            'name' => 'National Honor Society',
+        ]);
+        $njhsGroupType = GroupType::firstOrCreate([
+            'name' => 'National Junior Honor Society',
+        ]);
+        $nascGroupType = GroupType::firstOrCreate([
+            'name' => 'National Student Council',
+        ]);
+
+        info('rogue:nassp-groups-import: Beginning import...');
+
+        /**
+         * Without specifying these column names, this command fails with error:
+         * "The header record must be an empty or a flat array with unique string value."
+         */
+        $records = $csv->getRecords(['LABEL NAME', 'NHS', 'NJHS', 'NASC', 'NASSP', 'ADDRESS1', 'ADDRESS2', 'CITY', 'STATE', 'POSTAL', 'COUNTRY', 'NCES']);
+
+        foreach ($records as $record) {
+            $name = trim($record['LABEL NAME']);
+
+            if (trim($record['NHS']) == 'NHS') {
+                $groupTypeId = $nhsGroupType->id;
+            } elseif (trim($record['NJHS']) == 'NJHS') {
+                $groupTypeId = $njhsGroupType->id;
+            } elseif (trim($record['NASC']) == 'NASC') {
+                $groupTypeId = $nascGroupType->id;
+            } else {
+                $numSkipped++;
+
+                info('rogue:nassp-groups-import: Skipped - no group type match for ' .$name . '.');
+
+                continue;
+            }
+
+            try {
+                $group = Group::firstOrCreate([
+                    'group_type_id' => $groupTypeId,
+                    'name' => $name,
+                    'city' => $this->sanitize($record['CITY']),
+                    'state' => $this->sanitize($record['STATE']),
+                    'external_id' => $this->sanitize($record['NCES']),
+                ]);
+
+                $numImported++;
+
+                info('rogue:nassp-groups-import: Imported group', ['id' => $group->id, 'name' => $group->name]);
+            } catch (Exception $e) {
+                $numFailed++;
+
+                info('rogue:nassp-groups-import: Error importing group with ' .$name . ':' . $e->getMessage());
+            }
+        }
+
+        info('rogue:nassp-groups-import: Import completed with ' . $numImported . ' imported, '. $numSkipped .' skipped, and ' . $numFailed . ' failed.');
+    }
+}

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Console\Commands;
 
+use Exception;
 use League\Csv\Reader;
 use Rogue\Models\Group;
 use Rogue\Models\GroupType;

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -35,6 +35,8 @@ class ImportNasspGroupsCommand extends Command
     }
 
     /**
+     * Returns a trimmed CSV value, or null if equal to the string "NULL".
+     *
      * @param string
      * @return string
      */
@@ -52,6 +54,8 @@ class ImportNasspGroupsCommand extends Command
      */
     public function handle()
     {
+        // Sample CSV path: https://gist.githubusercontent.com/aaronschachter/a407e9882ebe01520644cc9c257c8ec9/raw/8c837c52cfe22866ba4b49f2cf2f12336ca297d8/groups.csv
+
         $path = $this->argument('path');
 
         info('rogue:nassp-groups-import: Loading csv from ' . $path);

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -44,7 +44,7 @@ class ImportNasspGroupsCommand extends Command
     {
         $result = trim($value);
 
-        return $result == 'NULL' ? null : $value;
+        return $result == 'NULL' ? null : $result;
     }
 
     /**

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -21,6 +21,8 @@ const GROUPS_QUERY = gql`
           id
           name
           goal
+          city
+          state
         }
       }
       pageInfo {
@@ -81,6 +83,7 @@ const GroupsTable = ({ filter, groupTypeId }) => {
         <thead>
           <tr>
             <td>Group ID</td>
+            <td>Location</td>
             <td>Goal</td>
           </tr>
         </thead>
@@ -90,6 +93,7 @@ const GroupsTable = ({ filter, groupTypeId }) => {
               <td>
                 <EntityLabel id={node.id} name={node.name} path="groups" />
               </td>
+              <td>{node.city ? `${node.city}, ${node.state}` : null}</td>
               <td>{node.goal || '-'}</td>
             </tr>
           ))}
@@ -97,14 +101,14 @@ const GroupsTable = ({ filter, groupTypeId }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td colSpan="2">
+              <td colSpan="3">
                 <div className="spinner margin-horizontal-auto margin-vertical" />
               </td>
             </tr>
           ) : null}
           {hasNextPage ? (
             <tr>
-              <td colSpan="2">
+              <td colSpan="3">
                 <button
                   className="button -tertiary"
                   onClick={handleViewMore}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a console command to import a CSV from the National Association of Secondary School Principals (NASSP) as three different Group Types and their respective Groups. It also displays the `city` and `state` fields added in #1055 in our GroupsTable component, to help verify imported NASSP data.

<img width="500" alt="Screen Shot 2020-06-25 at 10 49 33 AM" src="https://user-images.githubusercontent.com/1236811/85773242-7f19b500-b6d2-11ea-8b2a-859a915e4d4c.png">
 


### How should this be reviewed?

👀 

### Any background context you want to provide?

The NCES code is used as an ID for NASSP, so we save it to our `external_id` field. The file does not provide a "universal ID" -- if it did, we could that field to link these groups to their respective School in GraphQL. 

### Relevant tickets

References [Pivotal #173408737](https://www.pivotaltracker.com/story/show/173408737).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
