### PR TITLE
Adds filter_by_state field to Group Types

### DIFF
--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -76,12 +76,15 @@ class ImportNasspGroupsCommand extends Command
 
         $nhsGroupType = GroupType::firstOrCreate([
             'name' => 'National Honor Society',
+            'filter_by_state' => true,
         ]);
         $njhsGroupType = GroupType::firstOrCreate([
             'name' => 'National Junior Honor Society',
+            'filter_by_state' => true,
         ]);
         $nascGroupType = GroupType::firstOrCreate([
             'name' => 'National Student Council',
+            'filter_by_state' => true,
         ]);
 
         info('rogue:nassp-groups-import: Beginning import...');

--- a/app/Http/Controllers/Web/GroupTypesController.php
+++ b/app/Http/Controllers/Web/GroupTypesController.php
@@ -40,6 +40,8 @@ class GroupTypesController extends Controller
         $values = $this->validate($request, array_merge_recursive($this->rules, [
             'name' => [Rule::unique('group_types')],
         ]));
+        // @see ActionsController->fillInOmittedCheckboxes
+        $values['filter_by_state'] = $request->has('filter_by_state');
 
         $groupType = GroupType::create($values);
 
@@ -72,6 +74,8 @@ class GroupTypesController extends Controller
         $values = $this->validate($request, array_merge_recursive($this->rules, [
             'name' => [Rule::unique('group_types')->ignore($groupType->id)],
         ]));
+        // @see ActionsController->fillInOmittedCheckboxes
+        $values['filter_by_state'] = $request->has('filter_by_state');
 
         $groupType->update($values);
 

--- a/app/Http/Transformers/GroupTypeTransformer.php
+++ b/app/Http/Transformers/GroupTypeTransformer.php
@@ -18,6 +18,7 @@ class GroupTypeTransformer extends TransformerAbstract
         return [
             'id' => $groupType->id,
             'name' => $groupType->name,
+            'filter_by_state' => $groupType->filter_by_state,
             'created_at' => $groupType->created_at->toIso8601String(),
             'updated_at' => $groupType->updated_at->toIso8601String(),
         ];

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -8,11 +8,20 @@ use Illuminate\Database\Eloquent\Builder;
 class GroupType extends Model
 {
     /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'filter_by_state' => 'boolean',
+    ];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array
      */
-    protected $fillable = ['name'];
+    protected $fillable = ['filter_by_state', 'name'];
 
     protected static function boot()
     {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -204,6 +204,7 @@ $factory->defineAs(Campaign::class, 'closed', function (Generator $faker) use ($
 $factory->define(GroupType::class, function (Generator $faker) {
     return [
         'name' => title_case($faker->unique()->company),
+        'filter_by_state' => false,
     ];
 });
 

--- a/database/migrations/2020_06_25_000000_add_filter_by_state_to_group_types.php
+++ b/database/migrations/2020_06_25_000000_add_filter_by_state_to_group_types.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFilterByStateToGroupTypes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->boolean('filter_by_state')->default(false)->after('name')->comment('Whether or not group finders for this group type should filter by state.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->dropColumn('filter_by_state');
+        });
+    }
+}

--- a/docs/endpoints/group-types.md
+++ b/docs/endpoints/group-types.md
@@ -14,12 +14,14 @@ Example Response:
     {
       "id": 1,
       "name": "March For Our Lives",
+      "filter_by_state": false,
       "created_at": "2019-12-04T21:28:26+00:00",
       "updated_at": "2019-12-04T22:33:03+00:00"
     },
     {
       "id": 2,
       "name": "College Board",
+      "filter_by_state": true,
       "created_at": "2019-12-04T22:05:29+00:00",
       "updated_at": "2019-12-04T22:05:29+00:00"
     }
@@ -51,6 +53,7 @@ Example Response:
   "data": {
     "id": 1,
     "name": "March For Our Lives",
+    "filter_by_state": false,
     "created_at": "2019-12-04T21:28:26+00:00",
     "updated_at": "2019-12-04T22:33:03+00:00"
   };

--- a/resources/views/group-types/create.blade.php
+++ b/resources/views/group-types/create.blade.php
@@ -15,6 +15,11 @@
                         @include('forms.text', ['name' => 'name', 'placeholder' => 'e.g. March For Our Lives, DoSomething Clubs'])
                     </div>
 
+                    <div class="form-item">
+                        <label class="field-label">Group Finder</label>
+                        @include('forms.option', ['name' => 'filter_by_state', 'label' => 'Filter by state'])
+                    </div>
+
                     <ul class="form-actions -inline -padded">
                         <li><input type="submit" class="button" value="Create"></li>
                     </ul>

--- a/resources/views/group-types/edit.blade.php
+++ b/resources/views/group-types/edit.blade.php
@@ -19,6 +19,11 @@
                         @include('forms.text', ['name' => 'name', 'placeholder' => 'e.g. March For Our Lives, DoSomething Clubs', 'value' => $groupType->name])
                     </div>
 
+                    <div class="form-item">
+                        <label class="field-label">Group Finder</label>
+                        @include('forms.option', ['name' => 'filter_by_state', 'label' => 'Filter by state', 'value' => $groupType->filter_by_state])
+                    </div>
+
                     <ul class="form-actions -inline -padded">
                         <li><input type="submit" class="button" value="Update"></li>
                     </ul>

--- a/tests/Http/Web/GroupTypeTest.php
+++ b/tests/Http/Web/GroupTypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Http\Web;
 
 use Tests\TestCase;
+use Rogue\Models\GroupType;
 
 class GroupTypeTest extends TestCase
 {
@@ -13,11 +14,12 @@ class GroupTypeTest extends TestCase
 
         // Verify redirected to new resource.
         $this->actingAsAdmin()
-            ->postJson('group-types', ['name' => $name])
+            ->postJson('group-types', ['name' => $name, 'filter_by_state' => true])
             ->assertStatus(302);
 
         $this->assertDatabaseHas('group_types', [
             'name' => $name,
+            'filter_by_state' => 1,
         ]);
 
         // Verify cannot duplicate resource name.
@@ -38,6 +40,22 @@ class GroupTypeTest extends TestCase
 
         $this->assertDatabaseMissing('group_types', [
             'name' => $name,
+        ]);
+    }
+
+    /** @test */
+    public function testUnsettingFilterByState()
+    {
+        $groupType = factory(GroupType::class)->create(['filter_by_state' => true]);
+
+        // Verify redirected upon success.
+        $this->actingAsAdmin()
+            ->putJson('group-types/'.$groupType->id, ['name' => 'Test 123'])
+            ->assertStatus(302);
+
+        $this->assertDatabaseHas('group_types', [
+            'id' => $groupType->id,
+            'filter_by_state' => 0,
         ]);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a boolean `filter_by_state` attribute to the `GroupType` model. If this is set, a group finder for the group type should display a "Select State" dropdown first, in order to filter the groups search by state as well as name.

We'll want to set this field to `true` in the NASSP import per https://github.com/DoSomething/rogue/pull/1056#discussion_r445749156.

<img width="400" alt="Screen Shot 2020-06-25 at 12 30 11 PM" src="https://user-images.githubusercontent.com/1236811/85786969-a5921d00-b6df-11ea-8308-c0cc30b0c3d6.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

☑️ 

### Relevant tickets

References [Pivotal #173231765](https://www.pivotaltracker.com/story/show/173231765).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
