### PR TITLE
Add state select to Groups list if Group Type filters by state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1984,7 +1984,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2101,7 +2101,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -2135,7 +2135,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -2581,7 +2581,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2618,7 +2618,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2802,7 +2802,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3070,7 +3070,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
@@ -3274,7 +3274,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -3287,7 +3287,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -3360,7 +3360,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -3606,7 +3606,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -4140,7 +4140,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -5769,7 +5769,7 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hoist-non-react-statics": {
@@ -7582,7 +7582,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -7861,7 +7861,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -7889,7 +7889,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -8107,7 +8107,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -8273,7 +8273,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -8748,13 +8748,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -8763,7 +8763,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -8930,7 +8930,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -9571,7 +9571,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -9957,7 +9957,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -10127,7 +10127,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -10648,7 +10648,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10962,7 +10962,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -11066,7 +11066,7 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
@@ -11351,6 +11351,11 @@
           "dev": true
         }
       }
+    },
+    "usa-states": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/usa-states/-/usa-states-0.0.5.tgz",
+      "integrity": "sha1-OojJct71NFrpuHGG/EQCOFuGG7c="
     },
     "use": {
       "version": "3.1.1",
@@ -11842,7 +11847,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -12000,7 +12005,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "react-dom": "^16.10.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
-    "react-useportal": "^1.0.13"
+    "react-useportal": "^1.0.13",
+    "usa-states": "0.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -8,12 +8,18 @@ import EntityLabel from './utilities/EntityLabel';
 import { updateQuery } from '../helpers';
 
 const GROUPS_QUERY = gql`
-  query GroupsIndexQuery($filter: String, $groupTypeId: Int!, $cursor: String) {
+  query GroupsIndexQuery(
+    $filter: String
+    $groupTypeId: Int!
+    $state: String
+    $cursor: String
+  ) {
     groups: paginatedGroups(
       after: $cursor
       first: 50
       groupTypeId: $groupTypeId
       name: $filter
+      state: $state
     ) {
       edges {
         cursor
@@ -34,14 +40,21 @@ const GROUPS_QUERY = gql`
 `;
 
 /**
- * This component handles fetching & paginating a list of groups by group type ID.
+ * This component handles fetching & paginating a list of groups in a group type ID.
  *
  * @param {String} filter
+ * @param {String} groupState
  * @param {Number} groupTypeId
  */
-const GroupsTable = ({ filter, groupTypeId }) => {
+const GroupsTable = ({ filter, groupState, groupTypeId }) => {
+  const variables = { filter, groupTypeId };
+
+  if (groupState) {
+    variables.state = groupState;
+  }
+
   const { error, loading, data, fetchMore } = useQuery(GROUPS_QUERY, {
-    variables: { filter, groupTypeId },
+    variables,
     notifyOnNetworkStatusChange: true,
   });
 

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -58,13 +58,18 @@ const ShowGroupType = () => {
           />
 
           {filterByState ? (
-            <select onChange={event => setGroupState(event.target.value)}>
-              <option value={null}>--Select State--</option>
+            <div className="mb-4">
+              <select
+                className="text-field"
+                onChange={event => setGroupState(event.target.value)}
+              >
+                <option value={null}>-- Select State --</option>
 
-              {usaStateOptions.map(state => (
-                <option value={state.abbreviation}>{state.name}</option>
-              ))}
-            </select>
+                {usaStateOptions.map(state => (
+                  <option value={state.abbreviation}>{state.name}</option>
+                ))}
+              </select>
+            </div>
           ) : null}
 
           <input

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { UsaStates } from 'usa-states';
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
@@ -14,13 +15,18 @@ const SHOW_GROUP_TYPE_QUERY = gql`
   query ShowGroupTypeQuery($id: Int!) {
     groupType(id: $id) {
       createdAt
+      filterByState
       name
     }
   }
 `;
 
+const usaStateOptions = new UsaStates().states;
+
 const ShowGroupType = () => {
   const [filter, setFilter] = useState('');
+  const [groupState, setGroupState] = useState(null);
+
   const { id } = useParams();
   const title = `Group Type #${id}`;
   document.title = title;
@@ -39,7 +45,7 @@ const ShowGroupType = () => {
 
   if (!data.groupType) return <NotFound title={title} type="group type" />;
 
-  const { createdAt, name } = data.groupType;
+  const { createdAt, filterByState, name } = data.groupType;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -50,6 +56,17 @@ const ShowGroupType = () => {
               Campaigns: <GroupTypeCampaignList groupTypeId={Number(id)} />,
             }}
           />
+
+          {filterByState ? (
+            <select onChange={event => setGroupState(event.target.value)}>
+              <option value={null}>--Select State--</option>
+
+              {usaStateOptions.map(state => (
+                <option value={state.abbreviation}>{state.name}</option>
+              ))}
+            </select>
+          ) : null}
+
           <input
             type="text"
             className="text-field -search"
@@ -65,7 +82,12 @@ const ShowGroupType = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <GroupsTable filter={filter} groupTypeId={Number(id)} />
+          <GroupsTable
+            filter={filter}
+            groupState={groupState}
+            groupTypeId={Number(id)}
+          />
+
           <div className="container__block -narrow">
             <a
               className="button -primary"


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to mimic a Phoenix Group Finder search (https://github.com/DoSomething/phoenix-next/pull/2238) by filtering a group type's group list by the `state` field if the group type is configured to filter by state (refs #1057).

<img width="1148" alt="Screen Shot 2020-06-29 at 10 13 11 AM" src="https://user-images.githubusercontent.com/1236811/86036208-666f0f00-b9f2-11ea-876f-9271a8823960.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

* We don't have any dev or QA group types with `filter_by_state` yet, still working on getting final import files in https://www.pivotaltracker.com/story/show/173408737. I've been testing locally with data I added via executing the first pass of the import in #1056 

* Once we do have live group types that filter by state, it'll be convenient for staff to filter by state through Rogue to mimic a user's search (vs visiting the campaign's group finder anonymously, which will only work as long as the campaign is open for)

* I was curious to add this without the help of [React Select's `AsyncSelect`](https://react-select.com/async), which is what we use in the Phoenix School and Group Finders-- because I'm running into some odd bugs in https://github.com/DoSomething/phoenix-next/pull/2238 when I clear the input name search value, sometimes it seems to prevent the AsyncSelect to avoid reloading. It's helpful to have a homegrown version to see if I can mimic the same bugs.

### Relevant tickets

References [Pivotal #173231765](https://www.pivotaltracker.com/story/show/173231765).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
