### PR TITLE
Groups admin cleanup

### DIFF
--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -54,7 +54,7 @@ class ImportNasspGroupsCommand extends Command
      */
     public function handle()
     {
-        // Sample CSV path: https://gist.githubusercontent.com/aaronschachter/9cd40a703a43e22077e78e12e011a7de/raw/e5a119d8f2873e839473713c30a5d0b54aaacb7a/nassp.csv
+        // Sample CSV path: https://gist.githubusercontent.com/aaronschachter/cb7c2c75f15d67abea548bb586370dd7/raw/3cb12bb44e8d7b30436588c36c3a6280a501d1f4/nassp.csv
 
         $path = $this->argument('path');
 

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -39,6 +39,9 @@ const Application = () => {
           <Route path="/campaigns/:id/:status">
             <ShowCampaign />
           </Route>
+          <Route path="/groups" exact>
+            <GroupTypeIndex />
+          </Route>
           <Route path="/group-types" exact>
             <GroupTypeIndex />
           </Route>

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -15,12 +15,15 @@ const SHOW_GROUP_QUERY = gql`
   query ShowGroupQuery($id: Int!) {
     group(id: $id) {
       id
+      city
       goal
       groupType {
         id
         name
       }
       name
+      schoolId
+      state
     }
     posts(
       groupId: $id
@@ -55,7 +58,7 @@ const ShowGroup = () => {
 
   if (!data.group) return <NotFound title={title} type="group" />;
 
-  const { goal, groupType, name } = data.group;
+  const { city, goal, groupType, name, schoolId, state } = data.group;
 
   return (
     <Shell title={title} subtitle={`${name} (${groupType.name})`}>
@@ -65,6 +68,13 @@ const ShowGroup = () => {
             details={{
               'Voter Registrations Goal': goal || '--',
               'Voter Registrations Completed': data.posts.length,
+              City: city || '--',
+              State: state || '--',
+              School: schoolId ? (
+                <Link to={`/schools/${schoolId}`}>{schoolId}</Link>
+              ) : (
+                '--'
+              ),
             }}
           />
         </div>

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -63,9 +63,7 @@ const ShowGroupType = () => {
                 className="text-field"
                 onChange={event => setGroupState(event.target.value)}
               >
-                <option key="null" value={null}>
-                  -- Select State --
-                </option>
+                <option value={''}>-- Select State --</option>
 
                 {usaStateOptions.map(state => (
                   <option key={state.abbreviation} value={state.abbreviation}>

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -63,10 +63,14 @@ const ShowGroupType = () => {
                 className="text-field"
                 onChange={event => setGroupState(event.target.value)}
               >
-                <option value={null}>-- Select State --</option>
+                <option key="null" value={null}>
+                  -- Select State --
+                </option>
 
                 {usaStateOptions.map(state => (
-                  <option value={state.abbreviation}>{state.name}</option>
+                  <option key={state.abbreviation} value={state.abbreviation}>
+                    {state.name}
+                  </option>
                 ))}
               </select>
             </div>

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -6,6 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
+import EntityLabel from '../components/utilities/EntityLabel';
 import MetaInformation from '../components/utilities/MetaInformation';
 
 // @TODO: Add support for paging through schoolActionStats once more actions collect school.
@@ -29,6 +30,14 @@ const SHOW_SCHOOL_QUERY = gql`
         }
         acceptedQuantity
         updatedAt
+      }
+    }
+    groups(schoolId: $id) {
+      id
+      groupTypeId
+      groupType {
+        id
+        name
       }
     }
   }
@@ -55,6 +64,22 @@ const ShowSchool = () => {
 
   const { city, name, schoolActionStats, state } = data.school;
 
+  const groupList = data.groups.length ? (
+    <ul>
+      {data.groups.map(group => (
+        <li key={group.id}>
+          <EntityLabel
+            id={group.id}
+            name={group.groupType.name}
+            path="groups"
+          />
+        </li>
+      ))}
+    </ul>
+  ) : (
+    '--'
+  );
+
   return (
     <Shell title={title} subtitle={name}>
       <div className="container__row">
@@ -64,6 +89,7 @@ const ShowSchool = () => {
               ID: id,
               City: city,
               State: state,
+              Groups: groupList,
             }}
           />
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::get('campaigns/{id}/actions/create', 'ActionsController@create');
 Route::resource('campaigns', 'CampaignsController', ['except' => ['index', 'show']]);
 Route::resource('group-types', 'GroupTypesController', ['except' => ['index', 'show']]);
 Route::get('group-types/{id}/groups/create', 'GroupsController@create');
-Route::resource('groups', 'GroupsController', ['except' => ['create', 'show']]);
+Route::resource('groups', 'GroupsController', ['except' => ['create', 'index', 'show']]);
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
@@ -36,6 +36,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     Route::view('campaigns/{id}/{status}', 'app');
 
     // Groups
+    Route::view('groups', 'app');
     Route::view('groups/{id}', 'app');
 
     // Group Types


### PR DESCRIPTION
### What's this PR do?

This pull request makes a few tweaks to the admin UI to make the spot checking the NASSP import (#1059) easier:

* Displays Group `state`, `city` attributes if present, links to the School page if `schoolId` is present
* Displays Groups associated with a School on a School page
* Adds a `/groups` route on web that renders the group-types list (available at `/group-types`, which is longer to type!)

Group page:

<img width="500" alt="Group page" src="https://user-images.githubusercontent.com/1236811/86155057-bdd7b280-bab8-11ea-9a77-befe377faf5c.png">

School page:

<img width="500" alt="School page" src="https://user-images.githubusercontent.com/1236811/86154966-a00a4d80-bab8-11ea-9a4b-16013f372b63.png">
 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🦉 

### Relevant tickets

References [Pivotal #173408737](https://www.pivotaltracker.com/story/show/173408737).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
