### PR TITLE
Use voterRegistrationsCountByGroupId

### DIFF
--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -25,17 +25,7 @@ const SHOW_GROUP_QUERY = gql`
       schoolId
       state
     }
-    posts(
-      groupId: $id
-      type: "voter-reg"
-      status: [REGISTER_FORM, REGISTER_OVR]
-      count: 50
-    ) {
-      id
-      user {
-        displayName
-      }
-    }
+    voterRegistrationsCountByGroupId(groupId: $id)
   }
 `;
 
@@ -67,7 +57,8 @@ const ShowGroup = () => {
           <MetaInformation
             details={{
               'Voter Registrations Goal': goal || '--',
-              'Voter Registrations Completed': data.posts.length,
+              'Voter Registrations Completed':
+                data.voterRegistrationsCountByGroupId,
               City: city || '--',
               State: state || '--',
               School: schoolId ? (


### PR DESCRIPTION
### What's this PR do?

This pull request uses the `voterRegistrationsCountByGroupId` query added in https://github.com/DoSomething/graphql/pull/252 (and fixed in https://github.com/DoSomething/graphql/pull/253) to display a group's total number of voter registrations, beginning to DRY the logic of finding that count within this repo and Phoenix.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🤿 

### Relevant tickets

References [Pivotal #172541916](https://www.pivotaltracker.com/story/show/172541916).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
