### PR TITLE
Adds command to import Rhode Island Dept of Education groups 

### DIFF
--- a/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
+++ b/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Exception;
+use League\Csv\Reader;
+use Rogue\Models\Group;
+use Rogue\Models\GroupType;
+use Illuminate\Console\Command;
+
+class ImportRhodeIslandGroupsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:rhode-island-groups-import {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create Rhode Island Department of Education groups from a CSV.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Example path: https://gist.githubusercontent.com/aaronschachter/79d0d78289d4d9ee09287155d84a5d39/raw/ba602f249e1562a2b04b206dcb0da0ba83fd5dd5/groups.csv
+
+        $path = $this->argument('path');
+
+        info('rogue:rhode-island-groups-import: Loading csv from ' . $path);
+
+        // Make a local copy of the CSV.
+        $temp = tempnam(sys_get_temp_dir(), 'command_csv');
+
+        file_put_contents($temp, fopen($this->argument('path'), 'r'));
+
+        // Load CSV contents.
+        $csv = Reader::createFromPath($temp, 'r');
+
+        $csv->setHeaderOffset(0);
+
+        $numImported = 0;
+        $numFailed = 0;
+        $numSkipped = 0;
+
+        $groupType = GroupType::firstOrCreate([
+            // This name is user facing (which is why we're not naming it "Rhode Island Dept of Education").
+            'name' => 'Rhode Island',
+        ]);
+        $groupTypeId = $groupType->id;
+
+        info('rogue:rhode-island-groups-import: Beginning import for group type id ' . $groupTypeId .'.');
+
+        foreach ($csv->getRecords() as $record) {
+            $name = $record['name'];
+            $schoolId = $record['universalid'];
+
+            if (!$name) {
+                info('rogue:rhode-island-groups-import: Skipping row without name', ['school_id' => $schoolId]);
+
+                $numSkipped++;
+
+                continue;
+            }
+
+            try {
+                $group = Group::firstOrCreate([
+                    'group_type_id' => $groupTypeId,
+                    'name' => $name,
+                    'city' => $record['city'],
+                    'state' => $record['state'],
+                    'school_id' => $schoolId,
+                ]);
+
+                $numImported++;
+
+                info('rogue:rhode-island-groups-import: Imported group', ['id' => $group->id, 'name' => $group->name]);
+            } catch (Exception $e) {
+                $numFailed++;
+
+                info('rogue:rhode-island-groups-import: Error importing group with ' .$name . ':' . $e->getMessage());
+            }
+        }
+
+        info('rogue:rhode-island-import: Import completed with ' . $numImported . ' imported, ' . $numSkipped . ' skipped, and ' . $numFailed . ' failed.');
+    }
+}

--- a/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
+++ b/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
@@ -73,7 +73,7 @@ class ImportRhodeIslandGroupsCommand extends Command
             $name = $record['name'];
             $schoolId = $record['universalid'];
 
-            if (!$name) {
+            if (! $name) {
                 info('rogue:rhode-island-groups-import: Skipping row without name', ['school_id' => $schoolId]);
 
                 $numSkipped++;

--- a/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
+++ b/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
@@ -70,8 +70,8 @@ class ImportRhodeIslandGroupsCommand extends Command
         info('rogue:rhode-island-groups-import: Beginning import for group type id ' . $groupTypeId .'.');
 
         foreach ($csv->getRecords() as $record) {
-            $name = $record['name'];
-            $schoolId = $record['universalid'];
+            $name = trim($record['name']);
+            $schoolId = trim($record['universalid']);
 
             if (! $name) {
                 info('rogue:rhode-island-groups-import: Skipping row without name', ['school_id' => $schoolId]);
@@ -85,8 +85,8 @@ class ImportRhodeIslandGroupsCommand extends Command
                 $group = Group::firstOrCreate([
                     'group_type_id' => $groupTypeId,
                     'name' => $name,
-                    'city' => $record['city'],
-                    'state' => $record['state'],
+                    'city' => trim($record['city']),
+                    'state' => trim($record['state']),
                     'school_id' => $schoolId,
                 ]);
 

--- a/tests/Console/ImportRhodeIslandGroupsCommandTest.php
+++ b/tests/Console/ImportRhodeIslandGroupsCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Console;
+
+use Tests\TestCase;
+use Rogue\Models\GroupType;
+
+class ImportRhodeIslandGroupsCommandTest extends TestCase
+{
+    public function testImportingGroups()
+    {
+        $this->artisan('rogue:rhode-island-groups-import', ['path' => 'tests/Console/example-rhode-island-groups.csv']);
+
+        $this->assertDatabaseHas('group_types', [
+            'name' => 'Rhode Island',
+            'filter_by_state' => false,
+        ]);
+
+        $groupType = GroupType::where('name', 'Rhode Island')->first();
+        $groupTypeId = $groupType->id;
+
+        // Spot check groups were imported successfully.
+        $this->assertDatabaseHas('groups', [
+            'name' => 'Veazie Street School',
+            'group_type_id' => $groupTypeId,
+            'city' => 'Providence',
+            'state' => 'RI',
+            'school_id' => '4400192',
+        ]);
+        $this->assertDatabaseHas('groups', [
+            'name' => 'Portsmouth High School',
+            'group_type_id' => $groupTypeId,
+            'city' => 'Portsmouth',
+            'state' => 'RI',
+            'school_id' => '4400190',
+        ]);
+        // This row was a duplicate name/city/state with school_id 4400190.
+        $this->assertDatabaseMissing('groups', [
+            'school_id' => '4400189',
+        ]);
+        // This row did not have a name column specified, so should not have been imported.
+        $this->assertDatabaseMissing('groups', [
+            'school_id' => '4400188',
+        ]);
+    }
+}

--- a/tests/Console/example-rhode-island-groups.csv
+++ b/tests/Console/example-rhode-island-groups.csv
@@ -1,0 +1,10 @@
+name,city,state,universalid
+Veazie Street School,Providence,RI,4400192
+Charles N. Fortes Elementary School,Providence,RI,4400202
+Feinstein High School,Providence,RI,4400195
+,Portsmouth,RI,4400188
+Portsmouth High School,Portsmouth,RI,4400190
+Portsmouth High School,Portsmouth,RI,4400189
+Prudence Island School,Prudence Island,RI,4400191
+Charlotte Woods Elementary School,Providence,RI,4400203
+Frank D. Spaziano Annex Elementary School,Providence,RI,4400198


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new console command to create groups for a `Rhode Island` group type from a CSV, similar to commands added in #1056 and #1047. I've uploaded the source file as a [gist](https://gist.githubusercontent.com/aaronschachter/79d0d78289d4d9ee09287155d84a5d39/raw/ba602f249e1562a2b04b206dcb0da0ba83fd5dd5/groups.csv) and have been using that for testing (as well as to use for the import in each environment upon merge).

### How should this be reviewed?

👀 

### Any background context you want to provide?

⚓ 🦞 ⛵ 

### Relevant tickets

References [Pivotal #173687221](https://www.pivotaltracker.com/story/show/173687221).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
