### PR TITLE
Save group's school_id when creating post if school_id not given

### DIFF
--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rogue\Observers;
+
+use Rogue\Models\Post;
+use Rogue\Models\Group;
+
+class PostObserver
+{
+    /**
+     * Handle the Post "creating" event.
+     *
+     * @param  \Rogue\Models\Post  $post
+     * @return void
+     */
+    public function creating(Post $post)
+    {
+        // If we have a group_id but no school_id, save the group's school_id if exists.
+        if ($post->group_id && ! $post->school_id) {
+            $group = Group::find($post->group_id);
+
+            $post->school_id = $group->school_id;
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,10 @@ namespace Rogue\Providers;
 
 use Closure;
 use Hashids\Hashids;
+use Rogue\Models\Post;
 use Rogue\Auth\CustomGate;
 use InvalidArgumentException;
+use Rogue\Observers\PostObserver;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -24,6 +26,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // Attach model observer(s):
+        Post::observe(PostObserver::class);
+
         $this->app->singleton(GateContract::class, function ($app) {
             return new CustomGate($app, function () use ($app) {
                 return call_user_func($app['auth']->userResolver());

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -78,12 +78,6 @@ $factory->define(Post::class, function (Generator $faker) {
         'northstar_id' => $this->faker->northstar_id,
         'text' => $faker->sentence(),
         'location' => 'US-'.$faker->stateAbbr(),
-        /**
-         * Although our action models are set to collect school, not all users will create posts
-         * on behalf of their school (because they don't have a school_id set on their
-         * Northstar profile).
-         */
-        'school_id' => $this->faker->optional()->school_id,
         'source' => 'phpunit',
     ];
 });

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -10,7 +10,13 @@ use Rogue\Models\Signup;
 
 class PostModelTest extends TestCase
 {
-    public function testSettingSchoolIdFromGroupId() {
+    /**
+     * Test that a post school_id is set when its group has a school_id.
+     *
+     * @return void
+     */
+    public function testSettingSchoolIdFromGroupId()
+    {
         $action = factory(Action::class)->create();
         $group = factory(Group::class)->create([
             'school_id' =>  $this->faker->unique()->school_id,

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -4,11 +4,36 @@ namespace Tests\Unit\Models;
 
 use Tests\TestCase;
 use Rogue\Models\Post;
+use Rogue\Models\Group;
 use Rogue\Models\Action;
 use Rogue\Models\Signup;
 
 class PostModelTest extends TestCase
 {
+    public function testSettingSchoolIdFromGroupId() {
+        $action = factory(Action::class)->create();
+        $group = factory(Group::class)->create([
+            'school_id' =>  $this->faker->unique()->school_id,
+        ]);
+
+        $groupPostWithoutSchool = factory(Post::class)->states('voter-reg')->create([
+            'northstar_id' => $this->faker->northstar_id,
+            'action_id' => $action->id,
+            'group_id' => $group->id,
+        ]);
+
+        $this->assertEquals($groupPostWithoutSchool->school_id, $group->school_id);
+
+        $groupPostWithSchool = factory(Post::class)->states('voter-reg')->create([
+            'northstar_id' => $this->faker->northstar_id,
+            'action_id' => $action->id,
+            'group_id' => $group->id,
+            'school_id' => $this->faker->unique()->school_id,
+        ]);
+
+        $this->assertNotEquals($groupPostWithSchool->school_id, $group->school_id);
+    }
+
     /**
      * Test that a signup's updated_at updates when a post is updated.
      *


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new [Laravel observer](https://laravel.com/docs/5.5/eloquent#observers) on the Post model with a `creating` hook, which populates the post `school_id`  field with a group's `school_id` field if the post `school_id` wasn't provided, but a `group_id` was.

This will make it easier to find all `voter-reg` posts for a school, vs having to SQL join on groups to find their associated school IDs. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

I went with adding a new Observer vs adding the logic into the `PostRepository`, because it seemed to make sense for this rule to be applied globally (e.g. when creating model factories), vs only when posting via API. I followed by example from the Northstar's UserObserver, which made auto-updating users' various subscription fields based on other values easy to maintain and test.

### Relevant tickets

References [Pivotal #173573456](https://www.pivotaltracker.com/story/show/173573456).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
