### PR TITLE
Adds group attributes to Customer.io events

### DIFF
--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -57,6 +57,14 @@ class Group extends Model
     }
 
     /**
+     * Get the posts associated with this group.
+     */
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    /**
      * Get the signups associated with this group.
      */
     public function signups()

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -49,12 +49,10 @@ class Group extends Model
     public static $sortable = ['name'];
 
     /**
-     * Get the Group Type model associated with the group_type_id attribute.
-     *
-     * @return Rogue\Models\GroupType
+     * Get the group type associated with this group.
      */
-    public function getGroupTypeAttribute()
+    public function group_type()
     {
-        return GroupType::find($this->group_type_id);
+        return $this->hasOne(GroupType::class, 'id');
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -53,6 +53,6 @@ class Group extends Model
      */
     public function group_type()
     {
-        return $this->hasOne(GroupType::class, 'id');
+        return $this->belongsTo(GroupType::class);
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -47,4 +47,14 @@ class Group extends Model
      * @var array
      */
     public static $sortable = ['name'];
+
+    /**
+     * Get the Group Type model associated with the group_type_id attribute.
+     *
+     * @return Rogue\Models\GroupType
+     */
+    public function getGroupTypeAttribute()
+    {
+        return GroupType::find($this->group_type_id);
+    }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -55,4 +55,12 @@ class Group extends Model
     {
         return $this->belongsTo(GroupType::class);
     }
+
+    /**
+     * Get the signups associated with this group.
+     */
+    public function signups()
+    {
+        return $this->hasMany(Signup::class);
+    }
 }

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -33,6 +33,14 @@ class GroupType extends Model
     }
 
     /**
+     * Get the groups associated with this group type.
+     */
+    public function groups()
+    {
+        return $this->hasMany(Groups::class, 'id');
+    }
+
+    /**
      * Creates an array of grouptype labels, where the key is the id and the value is the grouptype name.
      *
      * @return array

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -37,7 +37,7 @@ class GroupType extends Model
      */
     public function groups()
     {
-        return $this->hasMany(Groups::class, 'id');
+        return $this->hasMany(Group::class);
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -253,6 +253,16 @@ class Post extends Model
     }
 
     /**
+     * Get the Group model associated with the group_id attribute.
+     *
+     * @return Rogue\Models\Group
+     */
+    public function getGroupAttribute()
+    {
+        return $this->group_id ? Group::find($this->group_id) : null;
+    }
+
+    /**
      * Create a hard-to-guess "hash" ID.
      *
      * @return string

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -632,7 +632,7 @@ class Post extends Model
             'action_id' => $this->action_id,
             'group_id' => $this->group_id,
             'group_name' => isset($group) ? $group->name : null,
-            'group_type_id' => isset($group) ? $group->group_type_id : null,
+            'group_type_id' => isset($group) ? $group->group_type->id : null,
             'group_type_name' => isset($group) ? $group->group_type->name : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -145,6 +145,14 @@ class Post extends Model
     }
 
     /**
+     * Get the group associated with this signup.
+     */
+    public function group()
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /**
      * Each post belongs to a signup.
      */
     public function signup()

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -618,7 +618,10 @@ class Post extends Model
     public function getReferralPostEventPayload()
     {
         $userId = $this->northstar_id;
+        // The associated user for this post.
         $user = app(GraphQL::class)->getUserById($userId);
+        // The associated Group for this post.
+        $group = $this->group;
 
         return [
             'id' => $this->id,
@@ -627,6 +630,10 @@ class Post extends Model
             'type' => $this->type,
             'status' => $this->status,
             'action_id' => $this->action_id,
+            'group_id' => $this->group_id,
+            'group_name' => isset($group) ? $group->name : null,
+            'group_type_id' => isset($group) ? $group->group_type_id : null,
+            'group_type_name' => isset($group) ? $group->group_type->name : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -386,6 +386,8 @@ class Post extends Model
             'referrer_user_id' => $this->referrer_user_id,
             'group_id' => $this->group_id,
             'group_name' => isset($group) ? $group->name : null,
+            'group_type_id' => isset($group) ? $group->group_type_id : null,
+            'group_type_name' => isset($group) ? $group->group_type->name : null,
             'school_id' => $this->school_id,
             'school_name' => isset($school) ? $school['name'] : null,
             'created_at' => $this->created_at->toIso8601String(),

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -261,16 +261,6 @@ class Post extends Model
     }
 
     /**
-     * Get the Group model associated with the group_id attribute.
-     *
-     * @return Rogue\Models\Group
-     */
-    public function getGroupAttribute()
-    {
-        return $this->group_id ? Group::find($this->group_id) : null;
-    }
-
-    /**
      * Create a hard-to-guess "hash" ID.
      *
      * @return string

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -351,6 +351,9 @@ class Post extends Model
         // The associated Action for this post.
         $action = $this->actionModel;
 
+        // The associated Group for this post.
+        $group = $this->group;
+
         return [
             'id' => $this->id,
             'signup_id' => $this->signup_id,
@@ -381,6 +384,8 @@ class Post extends Model
             'source_details' => $this->source_details,
             'details' => $this->details,
             'referrer_user_id' => $this->referrer_user_id,
+            'group_id' => $this->group_id,
+            'group_name' => isset($group) ? $group->name : null,
             'school_id' => $this->school_id,
             'school_name' => isset($school) ? $school['name'] : null,
             'created_at' => $this->created_at->toIso8601String(),

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -215,7 +215,7 @@ class Signup extends Model
             'referrer_user_id' => $this->referrer_user_id,
             'group_id' => $this->group_id,
             'group_name' => isset($group) ? $group->name : null,
-            'group_type_id' => isset($group) ? $group->group_type_id : null,
+            'group_type_id' => isset($group) ? $group->group_type->id : null,
             'group_type_name' => isset($group) ? $group->group_type->name : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -98,6 +98,14 @@ class Signup extends Model
     }
 
     /**
+     * Get the group associated with this signup.
+     */
+    public function group()
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /**
      * Get the posts associated with this signup.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
@@ -168,16 +176,6 @@ class Signup extends Model
     public function scopeIncludePostStatusCounts($query)
     {
         return $query->withCount(['accepted', 'pending', 'rejected']);
-    }
-
-    /**
-     * Get the Group model associated with the group_id attribute.
-     *
-     * @return Rogue\Models\Group
-     */
-    public function getGroupAttribute()
-    {
-        return $this->group_id ? Group::find($this->group_id) : null;
     }
 
     /**

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -171,6 +171,16 @@ class Signup extends Model
     }
 
     /**
+     * Get the Group model associated with the group_id attribute.
+     *
+     * @return Rogue\Models\Group
+     */
+    public function getGroupAttribute()
+    {
+        return $this->group_id ? Group::find($this->group_id) : null;
+    }
+
+    /**
      * Transform the signup model for Blink.
      *
      * @return array
@@ -187,6 +197,9 @@ class Signup extends Model
         // Fetch Campaign Website information via GraphQL.
         $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
 
+        // The associated Group for this signup.
+        $group = $this->group;
+
         return [
             'id' => $this->id,
             'northstar_id' => $this->northstar_id,
@@ -200,6 +213,10 @@ class Signup extends Model
             'source' => $this->source,
             'source_details' => $this->source_details,
             'referrer_user_id' => $this->referrer_user_id,
+            'group_id' => $this->group_id,
+            'group_name' => isset($group) ? $group->name : null,
+            'group_type_id' => isset($group) ? $group->group_type_id : null,
+            'group_type_name' => isset($group) ? $group->group_type->name : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -16,9 +16,7 @@ class PostObserver
     public function creating(Post $post)
     {
         // If we have a group_id but no school_id, save the group's school_id if exists.
-        if ($post->group_id && ! $post->school_id) {
-            $group = Group::find($post->group_id);
-
+        if ($post->group_id && (! $post->school_id) && $group = $post->group) {
             $post->school_id = $group->school_id;
         }
     }

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -148,7 +148,9 @@ class PostModelTest extends TestCase
      */
     public function testGetReferralPostEventPayload()
     {
+        $group = factory(Group::class)->create();
         $post = factory(Post::class)->create([
+            'group_id' => $group->id,
             'northstar_id' =>  $this->faker->unique()->northstar_id,
             'referrer_user_id' => $this->faker->unique()->northstar_id,
         ]);
@@ -157,6 +159,10 @@ class PostModelTest extends TestCase
 
         $this->assertEquals($result['action_id'], $post->action_id);
         $this->assertEquals($result['created_at'], $post->created_at->toIso8601String());
+        $this->assertEquals($result['group_id'], $group->id);
+        $this->assertEquals($result['group_name'], $group->name);
+        $this->assertEquals($result['group_type_id'], $group->group_type_id);
+        $this->assertEquals($result['group_type_name'], $group->group_type->name);
         $this->assertEquals($result['id'], $post->id);
         $this->assertEquals($result['status'], $post->status);
         $this->assertEquals($result['type'], $post->type);

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -107,6 +107,8 @@ class PostModelTest extends TestCase
 
         $this->assertEquals($result['group_id'], $group->id);
         $this->assertEquals($result['group_name'], $group->name);
+        $this->assertEquals($result['group_type_id'], $group->group_type_id);
+        $this->assertEquals($result['group_type_name'], $group->group_type->name);
         $this->assertEquals($result['referrer_user_id'], $post->referrer_user_id);
         $this->assertEquals($result['school_id'], $post->school_id);
 
@@ -132,6 +134,8 @@ class PostModelTest extends TestCase
 
         $this->assertEquals($result['group_id'], null);
         $this->assertEquals($result['group_name'], null);
+        $this->assertEquals($result['group_type_id'], null);
+        $this->assertEquals($result['group_type_name'], null);
         $this->assertEquals($result['school_id'], null);
         $this->assertEquals($result['school_name'], null);
         $this->assertEquals($result['referrer_user_id'], null);

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -161,7 +161,7 @@ class PostModelTest extends TestCase
         $this->assertEquals($result['created_at'], $post->created_at->toIso8601String());
         $this->assertEquals($result['group_id'], $group->id);
         $this->assertEquals($result['group_name'], $group->name);
-        $this->assertEquals($result['group_type_id'], $group->group_type_id);
+        $this->assertEquals($result['group_type_id'], $group->group_type->id);
         $this->assertEquals($result['group_type_name'], $group->group_type->name);
         $this->assertEquals($result['id'], $post->id);
         $this->assertEquals($result['status'], $post->status);

--- a/tests/Unit/Models/SignupModelTest.php
+++ b/tests/Unit/Models/SignupModelTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use Rogue\Models\Group;
+use Rogue\Models\Signup;
+
+class SignupModelTest extends TestCase
+{
+    /**
+     * Test expected payload for Blink.
+     *
+     * @return void
+     */
+    public function testBlinkPayload()
+    {
+        $group = factory(Group::class)->create();
+        $signup = factory(Signup::class)->create([
+            'group_id' => $group->id,
+            'referrer_user_id' => $this->faker->northstar_id,
+        ]);
+
+        $result = $signup->toBlinkPayload();
+
+        $this->assertEquals($result['group_id'], $group->id);
+        $this->assertEquals($result['group_name'], $group->name);
+        $this->assertEquals($result['group_type_id'], $group->group_type_id);
+        $this->assertEquals($result['group_type_name'], $group->group_type->name);
+        $this->assertEquals($result['referrer_user_id'], $signup->referrer_user_id);
+    }
+
+    /**
+     * Test expected payload when various attributes are not set.
+     *
+     * @return void
+     */
+    public function testBlinkPayloadForNullValues()
+    {
+        $signup = factory(Signup::class)->create();
+
+        $result = $signup->toBlinkPayload();
+
+        $this->assertEquals($result['group_id'], null);
+        $this->assertEquals($result['group_name'], null);
+        $this->assertEquals($result['group_type_id'], null);
+        $this->assertEquals($result['group_type_name'], null);
+        $this->assertEquals($result['referrer_user_id'], null);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds `group_id`, `group_name`, `group_type_id`, and `group_type_name` attributes to Customer.io events for signups and posts. This enables support for displaying a group's info within Customer.io message templates.

Example message template: 
`Thanks for signing up with your {{event.group_name}} chapter of {{event.group_type_name}}!`

Example message text:
`Thanks for signing up with your Monmouth County, NJ chapter of March For Our Lives!`

### How should this be reviewed?

👀 

### Any background context you want to provide?

This PR also modifies `PostObserver` from #1064 to use the new `$post->group` attribute added in this PR, to DRY.

### Relevant tickets

References [Pivotal #173481072](https://www.pivotaltracker.com/story/show/173481072).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
