### PR TITLE
Adds Group toBlinkPayload method 

### DIFF
--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -71,4 +71,20 @@ class Group extends Model
     {
         return $this->hasMany(Signup::class);
     }
+
+    /**
+     * Returns Customer.io payload attributes for given group, if exists.
+     *
+     * @param Group $group
+     * @return array
+     */
+    public static function toBlinkPayload(?self $group)
+    {
+        return [
+            'group_id' => $group ? $group->id : null,
+            'group_name' => $group ? $group->name : null,
+            'group_type_id' => $group ? $group->group_type->id : null,
+            'group_type_name' => $group ? $group->group_type->name : null,
+        ];
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -349,10 +349,7 @@ class Post extends Model
         // The associated Action for this post.
         $action = $this->actionModel;
 
-        // The associated Group for this post.
-        $group = $this->group;
-
-        return [
+        return array_merge([
             'id' => $this->id,
             'signup_id' => $this->signup_id,
             'quantity' => $quantity,
@@ -382,16 +379,12 @@ class Post extends Model
             'source_details' => $this->source_details,
             'details' => $this->details,
             'referrer_user_id' => $this->referrer_user_id,
-            'group_id' => $this->group_id,
-            'group_name' => isset($group) ? $group->name : null,
-            'group_type_id' => isset($group) ? $group->group_type_id : null,
-            'group_type_name' => isset($group) ? $group->group_type->name : null,
             'school_id' => $this->school_id,
             'school_name' => isset($school) ? $school['name'] : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
             'deleted_at' => $this->deleted_at ? $this->deleted_at->toIso8601String() : null,
-        ];
+        ], Group::toBlinkPayload($this->group));
     }
 
     /**
@@ -618,22 +611,16 @@ class Post extends Model
         $userId = $this->northstar_id;
         // The associated user for this post.
         $user = app(GraphQL::class)->getUserById($userId);
-        // The associated Group for this post.
-        $group = $this->group;
 
-        return [
+        return array_merge([
             'id' => $this->id,
             'user_id' => $userId,
             'user_display_name' => isset($user) ? $user['displayName'] : null,
             'type' => $this->type,
             'status' => $this->status,
             'action_id' => $this->action_id,
-            'group_id' => $this->group_id,
-            'group_name' => isset($group) ? $group->name : null,
-            'group_type_id' => isset($group) ? $group->group_type->id : null,
-            'group_type_name' => isset($group) ? $group->group_type->name : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
-        ];
+        ], Group::toBlinkPayload($this->group));
     }
 }

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -195,10 +195,7 @@ class Signup extends Model
         // Fetch Campaign Website information via GraphQL.
         $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
 
-        // The associated Group for this signup.
-        $group = $this->group;
-
-        return [
+        return array_merge([
             'id' => $this->id,
             'northstar_id' => $this->northstar_id,
             'campaign_id' => (string) $this->campaign_id,
@@ -211,13 +208,9 @@ class Signup extends Model
             'source' => $this->source,
             'source_details' => $this->source_details,
             'referrer_user_id' => $this->referrer_user_id,
-            'group_id' => $this->group_id,
-            'group_name' => isset($group) ? $group->name : null,
-            'group_type_id' => isset($group) ? $group->group_type->id : null,
-            'group_type_name' => isset($group) ? $group->group_type->name : null,
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
-        ];
+        ], Group::toBlinkPayload($this->group));
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds a static `toBlinkPayload` method to our `Group` model to DRY sending over group attributes for signups and posts to Customer.io, per @mendelB's great suggestion in https://github.com/DoSomething/rogue/pull/1066#discussion_r452853443

### How should this be reviewed?

👀 

### Any background context you want to provide?

⛱️ 

### Relevant tickets

References [Pivotal #173481072](https://www.pivotaltracker.com/n/projects/2417735/stories/173481072).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
