### PR TITLE
Cleanup referrals page

### DIFF
--- a/resources/assets/components/ReferralsTable.js
+++ b/resources/assets/components/ReferralsTable.js
@@ -1,11 +1,11 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
-import React, { useState } from 'react';
-import { parse, format } from 'date-fns';
 
 import Empty from './Empty';
+import { formatDateTime } from '../helpers';
 
 const USER_REFERRALS_QUERY = gql`
   query UserReferralsQuery($userId: String) {
@@ -73,7 +73,7 @@ const ReferralsTable = ({ userId }) => {
             <tr key={post.id}>
               <td>
                 <Link to={`/posts/${post.id}`}>
-                  {format(parse(post.createdAt), 'M/D/YYYY h:m:s')}
+                  {formatDateTime(post.createdAt)}
                 </Link>
               </td>
               <td>

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -74,7 +74,7 @@ const ShowUser = ({ selectedTab }) => {
         {selectedTab === 'referrals' ? (
           <React.Fragment>
             <h2 className="heading -emphasized -padded mb-4">
-              <span>Referrals</span>
+              <span>Referral Posts</span>
             </h2>
             <ReferralsTable userId={user.id} />
           </React.Fragment>


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the datetime display on the User Referrals page (/users/:id/referrals), changing it from `7/13/2020 7:12:9` to `7/13/2020 7:12 PM`.

Also updates the headline to clarify that this page currently on displays Referral Posts.

### How should this be reviewed?

👀 

### Any background context you want to provide?

The `formatDateTime` helper was introduced in https://github.com/DoSomething/rogue/pull/1039. 

### Relevant tickets

References [Pivotal #172084266](https://www.pivotaltracker.com/n/projects/2441250/stories/172084266).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
