### PR TITLE
Refactors ReferralsTable as PostsTable and adds additional web views

### DIFF
--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -6,6 +6,7 @@ import { env } from './helpers';
 import graphql from './graphql';
 import ShowPost from './pages/ShowPost';
 import ShowUser from './pages/ShowUser';
+import PostIndex from './pages/PostIndex';
 import UserIndex from './pages/UserIndex';
 import ShowGroup from './pages/ShowGroup';
 import ShowAction from './pages/ShowAction';
@@ -60,6 +61,9 @@ const Application = () => {
           </Route>
           <Route path="/users/:id">
             <ShowUser />
+          </Route>
+          <Route path="/posts" exact>
+            <PostIndex />
           </Route>
           <Route path="/posts/:id">
             <ShowPost />

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -59,6 +59,9 @@ const Application = () => {
           <Route path="/users" exact>
             <UserIndex />
           </Route>
+          <Route path="/users/:id/posts" exact>
+            <ShowUser selectedTab="posts" />
+          </Route>
           <Route path="/users/:id/referrals" exact>
             <ShowUser selectedTab="referrals" />
           </Route>

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -50,6 +50,9 @@ const Application = () => {
           <Route path="/group-types/:id">
             <ShowGroupType />
           </Route>
+          <Route path="/groups/:id/posts" exact>
+            <ShowGroup selectedTab="posts" />
+          </Route>
           <Route path="/groups/:id">
             <ShowGroup />
           </Route>

--- a/resources/assets/components/PostsTable.js
+++ b/resources/assets/components/PostsTable.js
@@ -9,10 +9,17 @@ import EntityLabel from './utilities/EntityLabel';
 import { formatDateTime, updateQuery } from '../helpers';
 
 const POSTS_INDEX_QUERY = gql`
-  query PostsIndexQuery($referrerUserId: String, $cursor: String) {
+  query PostsIndexQuery(
+    $campaignId: String
+    $groupId: Int
+    $referrerUserId: String
+    $cursor: String
+  ) {
     posts: paginatedPosts(
       after: $cursor
       first: 50
+      campaignId: $campaignId
+      groupId: $groupId
       referrerUserId: $referrerUserId
     ) {
       edges {
@@ -45,6 +52,8 @@ const POSTS_INDEX_QUERY = gql`
 /**
  * This component handles fetching & paginating a list of posts.
  *
+ * @param {String} campaignId
+ * @param {Number} groupId
  * @param {String} referrerUserId
  */
 const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
@@ -83,7 +92,7 @@ const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
       <table className="table">
         <thead>
           <tr>
-            <td>Created</td>
+            <td>Post</td>
 
             <td>User</td>
 

--- a/resources/assets/components/PostsTable.js
+++ b/resources/assets/components/PostsTable.js
@@ -5,7 +5,8 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import Empty from './Empty';
-import { formatDateTime } from '../helpers';
+import EntityLabel from './utilities/EntityLabel';
+import { formatDateTime, updateQuery } from '../helpers';
 
 const POSTS_INDEX_QUERY = gql`
   query PostsIndexQuery($referrerUserId: String, $cursor: String) {
@@ -22,6 +23,15 @@ const POSTS_INDEX_QUERY = gql`
           userId
           type
           status
+          campaign {
+            id
+            internalTitle
+          }
+          groupId
+          group {
+            id
+            name
+          }
         }
       }
       pageInfo {
@@ -37,38 +47,35 @@ const POSTS_INDEX_QUERY = gql`
  *
  * @param {String} referrerUserId
  */
-const PostsTable = ({ referrerUserId }) => {
-  const { error, loading, data } = useQuery(POSTS_INDEX_QUERY, {
-    variables: { referrerUserId },
+const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
+  const { error, loading, data, fetchMore } = useQuery(POSTS_INDEX_QUERY, {
+    variables: { campaignId, groupId, referrerUserId },
     notifyOnNetworkStatusChange: true,
   });
+
+  const posts = data ? data.posts.edges : [];
+  const noResults = posts.length === 0 && !loading;
+  const { endCursor, hasNextPage } = get(data, 'posts.pageInfo', {});
+
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery,
+    });
+  };
 
   if (error) {
     return (
       <div className="text-center">
         <p>There was an error. :(</p>
+
         <code>{JSON.stringify(error)}</code>
       </div>
     );
   }
 
-  if (loading) {
-    return (
-      <div className="h-content flex-center-xy">
-        <div className="spinner" />
-      </div>
-    );
-  }
-
-  const posts = data ? data.posts.edges : [];
-  console.log(posts);
-
-  if (posts.length == 0) {
-    return (
-      <div className="h-content flex-center-xy">
-        <Empty copy="No posts found." />
-      </div>
-    );
+  if (noResults && !hasNextPage) {
+    return <Empty copy="No posts found." />;
   }
 
   return (
@@ -77,9 +84,16 @@ const PostsTable = ({ referrerUserId }) => {
         <thead>
           <tr>
             <td>Created</td>
+
             <td>User</td>
+
+            {campaignId ? null : <td>Campaign</td>}
+
             <td>Type</td>
+
             <td>Status</td>
+
+            {groupId ? null : <td>Group</td>}
           </tr>
         </thead>
         <tbody>
@@ -90,14 +104,61 @@ const PostsTable = ({ referrerUserId }) => {
                   {formatDateTime(node.createdAt)}
                 </Link>
               </td>
+
               <td>
                 <Link to={`/users/${node.userId}`}>{node.userId}</Link>
               </td>
+
+              {campaignId ? null : (
+                <td>
+                  <EntityLabel
+                    id={node.campaign.id}
+                    name={node.campaign.internalTitle}
+                    path="campaigns"
+                  />
+                </td>
+              )}
+
               <td>{node.type}</td>
+
               <td>{node.status}</td>
+
+              {groupId ? null : (
+                <td>
+                  {node.groupId ? (
+                    <EntityLabel
+                      id={node.group.id}
+                      name={node.group.name}
+                      path="groups"
+                    />
+                  ) : null}
+                </td>
+              )}
             </tr>
           ))}
         </tbody>
+        <tfoot className="form-actions">
+          {loading ? (
+            <tr>
+              <td colSpan={campaignId || groupId ? 5 : 6}>
+                <div className="spinner margin-horizontal-auto margin-vertical" />
+              </td>
+            </tr>
+          ) : null}
+          {hasNextPage ? (
+            <tr>
+              <td colSpan={campaignId || groupId ? 5 : 6}>
+                <button
+                  className="button -tertiary"
+                  onClick={handleViewMore}
+                  disabled={loading}
+                >
+                  view more...
+                </button>
+              </td>
+            </tr>
+          ) : null}
+        </tfoot>
       </table>
     </>
   );

--- a/resources/assets/components/PostsTable.js
+++ b/resources/assets/components/PostsTable.js
@@ -8,13 +8,26 @@ import Empty from './Empty';
 import { formatDateTime } from '../helpers';
 
 const POSTS_INDEX_QUERY = gql`
-  query PostsIndexQuery($referrerUserId: String) {
-    posts(referrerUserId: $referrerUserId) {
-      id
-      createdAt
-      userId
-      type
-      status
+  query PostsIndexQuery($referrerUserId: String, $cursor: String) {
+    posts: paginatedPosts(
+      after: $cursor
+      first: 50
+      referrerUserId: $referrerUserId
+    ) {
+      edges {
+        cursor
+        node {
+          id
+          createdAt
+          userId
+          type
+          status
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
     }
   }
 `;
@@ -47,12 +60,13 @@ const PostsTable = ({ referrerUserId }) => {
     );
   }
 
-  const { posts } = data;
+  const posts = data ? data.posts.edges : [];
+  console.log(posts);
 
   if (posts.length == 0) {
     return (
       <div className="h-content flex-center-xy">
-        <Empty copy="No referrals found for this user." />
+        <Empty copy="No posts found." />
       </div>
     );
   }
@@ -69,18 +83,18 @@ const PostsTable = ({ referrerUserId }) => {
           </tr>
         </thead>
         <tbody>
-          {data.posts.map(post => (
-            <tr key={post.id}>
+          {posts.map(({ node, cursor }) => (
+            <tr key={node.id}>
               <td>
-                <Link to={`/posts/${post.id}`}>
-                  {formatDateTime(post.createdAt)}
+                <Link to={`/posts/${node.id}`}>
+                  {formatDateTime(node.createdAt)}
                 </Link>
               </td>
               <td>
-                <Link to={`/users/${post.userId}`}>{post.userId}</Link>
+                <Link to={`/users/${node.userId}`}>{node.userId}</Link>
               </td>
-              <td>{post.type}</td>
-              <td>{post.status}</td>
+              <td>{node.type}</td>
+              <td>{node.status}</td>
             </tr>
           ))}
         </tbody>

--- a/resources/assets/components/PostsTable.js
+++ b/resources/assets/components/PostsTable.js
@@ -13,6 +13,7 @@ const POSTS_INDEX_QUERY = gql`
     $campaignId: String
     $groupId: Int
     $referrerUserId: String
+    $userId: String
     $cursor: String
   ) {
     posts: paginatedPosts(
@@ -21,6 +22,7 @@ const POSTS_INDEX_QUERY = gql`
       campaignId: $campaignId
       groupId: $groupId
       referrerUserId: $referrerUserId
+      userId: $userId
     ) {
       edges {
         cursor
@@ -55,10 +57,11 @@ const POSTS_INDEX_QUERY = gql`
  * @param {String} campaignId
  * @param {Number} groupId
  * @param {String} referrerUserId
+ * @param {String} userId
  */
-const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
+const PostsTable = ({ campaignId, groupId, referrerUserId, userId }) => {
   const { error, loading, data, fetchMore } = useQuery(POSTS_INDEX_QUERY, {
-    variables: { campaignId, groupId, referrerUserId },
+    variables: { campaignId, groupId, referrerUserId, userId },
     notifyOnNetworkStatusChange: true,
   });
 
@@ -94,7 +97,7 @@ const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
           <tr>
             <td>Post</td>
 
-            <td>User</td>
+            {userId ? null : <td>User</td>}
 
             {campaignId ? null : <td>Campaign</td>}
 
@@ -114,9 +117,11 @@ const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
                 </Link>
               </td>
 
-              <td>
-                <Link to={`/users/${node.userId}`}>{node.userId}</Link>
-              </td>
+              {userId ? null : (
+                <td>
+                  <Link to={`/users/${node.userId}`}>{node.userId}</Link>
+                </td>
+              )}
 
               {campaignId ? null : (
                 <td>
@@ -149,14 +154,14 @@ const PostsTable = ({ campaignId, groupId, referrerUserId }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td colSpan={campaignId || groupId ? 5 : 6}>
+              <td colSpan={campaignId || groupId || userId ? 5 : 6}>
                 <div className="spinner margin-horizontal-auto margin-vertical" />
               </td>
             </tr>
           ) : null}
           {hasNextPage ? (
             <tr>
-              <td colSpan={campaignId || groupId ? 5 : 6}>
+              <td colSpan={campaignId || groupId || userId ? 5 : 6}>
                 <button
                   className="button -tertiary"
                   onClick={handleViewMore}

--- a/resources/assets/components/PostsTable.js
+++ b/resources/assets/components/PostsTable.js
@@ -7,9 +7,9 @@ import { useQuery } from '@apollo/react-hooks';
 import Empty from './Empty';
 import { formatDateTime } from '../helpers';
 
-const USER_REFERRALS_QUERY = gql`
-  query UserReferralsQuery($userId: String) {
-    posts(referrerUserId: $userId) {
+const POSTS_INDEX_QUERY = gql`
+  query PostsIndexQuery($referrerUserId: String) {
+    posts(referrerUserId: $referrerUserId) {
       id
       createdAt
       userId
@@ -20,13 +20,13 @@ const USER_REFERRALS_QUERY = gql`
 `;
 
 /**
- * This component handles fetches referrals for a given user, displaying only posts for now.
+ * This component handles fetching & paginating a list of posts.
  *
- * @param String userId
+ * @param {String} referrerUserId
  */
-const ReferralsTable = ({ userId }) => {
-  const { error, loading, data } = useQuery(USER_REFERRALS_QUERY, {
-    variables: { userId },
+const PostsTable = ({ referrerUserId }) => {
+  const { error, loading, data } = useQuery(POSTS_INDEX_QUERY, {
+    variables: { referrerUserId },
     notifyOnNetworkStatusChange: true,
   });
 
@@ -89,4 +89,4 @@ const ReferralsTable = ({ userId }) => {
   );
 };
 
-export default ReferralsTable;
+export default PostsTable;

--- a/resources/assets/components/SignupsTable.js
+++ b/resources/assets/components/SignupsTable.js
@@ -44,6 +44,7 @@ const SIGNUPS_TABLE_QUERY = gql`
 /**
  * This component handles fetching & paginating a list of signups.
  *
+ * @param {String} campaignId
  * @param {Number} groupId
  */
 const SignupsTable = ({ campaignId, groupId }) => {

--- a/resources/assets/pages/PostIndex.js
+++ b/resources/assets/pages/PostIndex.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Shell from '../components/utilities/Shell';
+import PostsTable from '../components/PostsTable';
+
+const PostIndex = () => {
+  const title = 'Posts';
+  document.title = title;
+
+  return (
+    <Shell title={title}>
+      <div className="container__block">
+        <PostsTable />
+      </div>
+    </Shell>
+  );
+};
+
+export default PostIndex;

--- a/resources/assets/pages/ShowCampaign.js
+++ b/resources/assets/pages/ShowCampaign.js
@@ -8,6 +8,7 @@ import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import Select from '../components/utilities/Select';
 import Campaign from '../components/Campaign';
+import PostsTable from '../components/PostsTable';
 import SignupsTable from '../components/SignupsTable';
 import HelpLink from '../components/utilities/HelpLink';
 import ReviewablePostGallery from '../components/ReviewablePostGallery';
@@ -58,7 +59,7 @@ const ShowCampaign = () => {
     );
   }
 
-  if (status === 'signups') {
+  if (status === 'signups' || status === 'posts') {
     return (
       <Shell title={title} subtitle={data.campaign.internalTitle}>
         <div className="container__row">
@@ -69,7 +70,11 @@ const ShowCampaign = () => {
           </div>
         </div>
         <div className="container__row">
-          <SignupsTable campaignId={id} />
+          {status === 'signups' ? (
+            <SignupsTable campaignId={id} />
+          ) : (
+            <PostsTable campaignId={id} />
+          )}
         </div>
       </Shell>
     );

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -31,7 +31,7 @@ const SHOW_GROUP_QUERY = gql`
 `;
 
 /**
- * @param string selectedTab
+ * @param {String} selectedTab
  */
 const ShowGroup = ({ selectedTab }) => {
   const { id } = useParams();

--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -7,6 +7,7 @@ import NotFound from './NotFound';
 import Empty from '../components/Empty';
 import { formatDateTime } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import PostsTable from '../components/PostsTable';
 import SignupsTable from '../components/SignupsTable';
 import EntityLabel from '../components/utilities/EntityLabel';
 import MetaInformation from '../components/utilities/MetaInformation';
@@ -29,7 +30,10 @@ const SHOW_GROUP_QUERY = gql`
   }
 `;
 
-const ShowGroup = () => {
+/**
+ * @param string selectedTab
+ */
+const ShowGroup = ({ selectedTab }) => {
   const { id } = useParams();
   const title = `Group #${id}`;
   document.title = title;
@@ -77,7 +81,11 @@ const ShowGroup = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <SignupsTable groupId={data.group.id} />
+          {selectedTab === 'posts' ? (
+            <PostsTable groupId={data.group.id} />
+          ) : (
+            <SignupsTable groupId={data.group.id} />
+          )}
         </div>
       </div>
       <ul className="form-actions margin-vertical">

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -71,12 +71,18 @@ const ShowUser = ({ selectedTab }) => {
         </UserInformation>
       </div>
       <div className="container__block">
-        {selectedTab === 'referrals' ? (
+        {selectedTab ? (
           <React.Fragment>
             <h2 className="heading -emphasized -padded mb-4">
-              <span>Referral Posts</span>
+              <span>
+                {selectedTab === 'referrals' ? 'Referral Posts' : 'Posts'}
+              </span>
             </h2>
-            <PostsTable referrerUserId={user.id} />
+            {selectedTab === 'referrals' ? (
+              <PostsTable referrerUserId={user.id} />
+            ) : (
+              <PostsTable userId={user.id} />
+            )}
           </React.Fragment>
         ) : (
           <React.Fragment>

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -26,7 +26,7 @@ const SHOW_USER_QUERY = gql`
 `;
 
 /**
- * @param string selectedTab
+ * @param {String} selectedTab
  */
 const ShowUser = ({ selectedTab }) => {
   const { id } = useParams();

--- a/resources/assets/pages/ShowUser.js
+++ b/resources/assets/pages/ShowUser.js
@@ -5,9 +5,9 @@ import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
+import PostsTable from '../components/PostsTable';
 import Shell from '../components/utilities/Shell';
 import SignupGallery from '../components/SignupGallery';
-import ReferralsTable from '../components/ReferralsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 import UserInformation, {
   UserInformationFragment,
@@ -76,7 +76,7 @@ const ShowUser = ({ selectedTab }) => {
             <h2 className="heading -emphasized -padded mb-4">
               <span>Referral Posts</span>
             </h2>
-            <ReferralsTable userId={user.id} />
+            <PostsTable referrerUserId={user.id} />
           </React.Fragment>
         ) : (
           <React.Fragment>

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Users
     Route::view('users', 'app')->name('users.index');
     Route::view('users/{id}', 'app')->name('users.show');
+    Route::view('users/{id}/posts', 'app')->name('users.show');
     Route::view('users/{id}/referrals', 'app')->name('users.show');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     Route::view('group-types/{id}', 'app');
 
     // Posts
+    Route::view('posts', 'app');
     Route::view('posts/{id}', 'app')->name('posts.show');
 
     // Schools

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Groups
     Route::view('groups', 'app');
     Route::view('groups/{id}', 'app');
+    Route::view('groups/{id}/posts', 'app');
 
     // Group Types
     Route::view('group-types', 'app');


### PR DESCRIPTION
### What's this PR do?

This pull request refactors the `ReferralsTable` as a `PostsTable`, continuing the work done in #1070 to build out better admin views to spot check voter registration data by paginating through the results of `GET /posts` index queries. 

It also adds new web views for:

* All posts (/posts)

* A group's posts (/group/:id/posts)

* A user's posts (/users/:id/posts)

* A campaign's posts (/users/:id/posts)

### How should this be reviewed?

👀 

### Any background context you want to provide?

The `ReviewablePost` component doesn't display voter registration data very well, it doesn't show the post status, nor should it be reviewable. This PR adds simple table views to spot check that posts are being created with group ID's (when users are registering via a group OVRD page)

### Relevant tickets

References [Pivotal #173927241](https://www.pivotaltracker.com/story/show/173927241).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
