### PR TITLE
Rename ActionStats accepted_quantity to impact 

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,7 +6,6 @@ enabled:
 disabled:
   - concat_without_spaces
   - no_useless_return
-  - simplified_null_return
   - phpdoc_no_package
   - phpdoc_summary
   - phpdoc_var_without_name

--- a/app/Http/Transformers/ActionStatTransformer.php
+++ b/app/Http/Transformers/ActionStatTransformer.php
@@ -19,7 +19,7 @@ class ActionStatTransformer extends TransformerAbstract
             'id' => $actionStat->id,
             'action_id' => $actionStat->action_id,
             'school_id' => $actionStat->school_id,
-            'accepted_quantity' => $actionStat->accepted_quantity,
+            'impact' => $actionStat->impact,
             'created_at' => $actionStat->created_at->toIso8601String(),
             'updated_at' => $actionStat->updated_at->toIso8601String(),
         ];

--- a/app/Models/ActionStat.php
+++ b/app/Models/ActionStat.php
@@ -12,8 +12,8 @@ class ActionStat extends Model
      * @var array
      */
     protected $fillable = [
-        'accepted_quantity',
         'action_id',
+        'impact',
         'school_id',
     ];
 
@@ -35,5 +35,5 @@ class ActionStat extends Model
      *
      * @var array
      */
-    public static $sortable = ['id', 'accepted_quantity'];
+    public static $sortable = ['id', 'impact'];
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -468,9 +468,9 @@ class Post extends Model
      * Returns posts which qualify for volunteer credit.
      * (The associated Action's volunteer credit field is set to true).
      */
-    public function scopeWithVolunteerCredit($query, $volunteerCreditValue)
+    public function scopeWithVolunteerCredit($query)
     {
-        return $query->whereHas('actionModel', function ($query) use ($volunteerCreditValue) {
+        return $query->whereHas('actionModel', function ($query) {
             $query->where('volunteer_credit', true);
         });
     }
@@ -479,9 +479,9 @@ class Post extends Model
      * Returns posts which do not qualify for volunteer credit.
      * (The associated Action's volunteer credit field is set to false).
      */
-    public function scopeWithoutVolunteerCredit($query, $volunteerCreditValue)
+    public function scopeWithoutVolunteerCredit($query)
     {
-        return $query->whereHas('actionModel', function ($query) use ($volunteerCreditValue) {
+        return $query->whereHas('actionModel', function ($query) {
             $query->where('volunteer_credit', false);
         });
     }

--- a/app/Notifications/SlackTagNotification.php
+++ b/app/Notifications/SlackTagNotification.php
@@ -92,7 +92,7 @@ class SlackTagNotification extends Notification
         return (new SlackMessage)
             ->from('Rogue', ':tonguecat:')
             ->content($adminName . ' just tagged this post as "' . $this->tag->tag_name . '":')
-            ->attachment(function ($attachment) use ($userName, $adminName) {
+            ->attachment(function ($attachment) use ($userName) {
                 $permalink = route('signups.show', [$this->post->signup_id], true);
 
                 $attachment->title($userName . '\'s submission for "' . $this->post->campaign->internal_title . '"', $permalink)

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -209,7 +209,7 @@ class PostRepository
         if ($post->school_id && $post->action_id) {
             ActionStat::updateOrCreate(
                 ['action_id' => $post->action_id, 'school_id' => $post->school_id],
-                ['accepted_quantity' => Post::getAcceptedQuantitySum($post->action_id, $post->school_id)]
+                ['impact' => Post::getAcceptedQuantitySum($post->action_id, $post->school_id)]
             );
         }
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -49,7 +49,7 @@ $factory->define(ActionStat::class, function (Generator $faker) {
     return [
         'school_id' => $this->faker->school_id,
         'action_id' => factory(Action::class)->create()->id,
-        'accepted_quantity' => $faker->randomNumber(3),
+        'impact' => $faker->randomNumber(3),
     ];
 });
 

--- a/database/migrations/2020_07_27_000000_rename_accepted_quantity_to_impact_on_action_stats_table.php
+++ b/database/migrations/2020_07_27_000000_rename_accepted_quantity_to_impact_on_action_stats_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class renameAcceptedQuantityToImpactOnActionStatsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_stats', function (Blueprint $table) {
+            $table->dropIndex(['action_id', DB::raw('accepted_quantity desc')]);
+            $table->renameColumn('accepted_quantity', 'impact');
+            $table->index(['action_id', DB::raw('impact desc')]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_stats', function (Blueprint $table) {
+            $table->dropIndex(['action_id', DB::raw('impact desc')]);
+            $table->renameColumn('impact', 'accepted_quantity');
+            $table->index(['action_id', DB::raw('accepted_quantity desc')]);
+        });
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -99,7 +99,7 @@ class DatabaseSeeder extends Seeder
 
             // Create 5-10 signups with rejected posts, from troublemakers!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) use ($photoAction, $textAction) {
+                ->each(function (Signup $signup) use ($photoAction) {
                     $signup->posts()->save(factory(Post::class)->states('photo', 'rejected')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -114,7 +114,7 @@ class DatabaseSeeder extends Seeder
             // Create action stats from the approved photo posts created for the photo action.
             foreach ($approvedQuantityBySchoolId as $schoolId => $total) {
                 factory(ActionStat::class)->create([
-                    'accepted_quantity' => $total,
+                    'impact' => $total,
                     'action_id' => $photoAction->id,
                     'school_id' => $schoolId,
                 ]);

--- a/docs/endpoints/action-stats.md
+++ b/docs/endpoints/action-stats.md
@@ -16,8 +16,8 @@ GET /api/v3/action-stats
   - Use commas to filter by multiple values in a column, e.g. `/action-stats?filter[action_id]=121,122`
 
 - **orderBy** _(string)_
-  - Order results by column. Supported columns: `id`, `accepted_quantity`
-  - e.g. `/action-stats?orderBy=accepted_quantity,desc`
+  - Order results by column. Supported columns: `id`, `impact`
+  - e.g. `/action-stats?orderBy=impact,desc`
 
 Example Response:
 
@@ -28,7 +28,7 @@ Example Response:
       "id": 1,
       "action_id": 1,
       "school_id": "3401457",
-      "accepted_quantity": 37,
+      "impact": 37,
       "created_at": "2019-12-04T21:28:26+00:00",
       "updated_at": "2019-12-04T22:33:03+00:00"
     },
@@ -36,7 +36,7 @@ Example Response:
       "id": 2,
       "action_id": 1,
       "school_id": "4802532",
-      "accepted_quantity": 43,
+      "impact": 43,
       "created_at": "2019-12-04T22:05:29+00:00",
       "updated_at": "2019-12-04T22:05:29+00:00"
     }

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -50,7 +50,7 @@ class ReviewsTest extends TestCase
         ]);
         $this->assertDatabaseHas('action_stats', [
             'action_id' => $actionId,
-            'accepted_quantity' => $firstPost->quantity,
+            'impact' => $firstPost->quantity,
             'school_id' => $schoolId,
         ]);
 
@@ -72,7 +72,7 @@ class ReviewsTest extends TestCase
         ]);
         $this->assertDatabaseHas('action_stats', [
             'action_id' => $actionId,
-            'accepted_quantity' => $firstPost->quantity + $secondPost->quantity,
+            'impact' => $firstPost->quantity + $secondPost->quantity,
             'school_id' => $schoolId,
         ]);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration to rename the `accepted_quantity` int column on the `action_stats` table to `impact`. For voter registration, we'd like to store the total number of voter-reg posts with status starting with `register-` here -- so I figured it'd be simplest to rename the field to something more generic that can be re-purposed for various post types.

It also fixes the same newfound StyleCI error we saw pop up in https://github.com/DoSomething/phoenix-next/pull/2298, and then fixes new style errors that popped up after that change.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

Was debating on whether to add a separate field instead of renaming `accepted_quantity`, but the TLDR from this [Slack discussion](https://dosomething.slack.com/archives/CP2D7UGAU/p1595881689011800) made me think two separate fields would still require documentation to explain the purpose of a potential secondary field like `completed_count`.I'd think we could get away with docs that explain what the `impact` means for each post type (docs to come in a future PR if we feel good about this name change) 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
