### PR TITLE
If signup has a group_id, save it on the post as well

### DIFF
--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -15,6 +15,11 @@ class PostObserver
      */
     public function creating(Post $post)
     {
+        // If the post's signup has a group_id, save it on the post as well
+        if ($post->signup->group_id) {
+            $post->group_id = $post->signup->group_id;
+        }
+
         // If we have a group_id but no school_id, save the group's school_id if exists.
         if ($post->group_id && (! $post->school_id) && $group = $post->group) {
             $post->school_id = $group->school_id;

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -16,7 +16,7 @@ class PostObserver
     public function creating(Post $post)
     {
         // If the post's signup has a group_id, save it on the post as well
-        if (!$post->group_id && $post->signup->group_id) {
+        if (! $post->group_id && $post->signup->group_id) {
             $post->group_id = $post->signup->group_id;
         }
 

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -16,7 +16,7 @@ class PostObserver
     public function creating(Post $post)
     {
         // If the post's signup has a group_id, save it on the post as well
-        if ($post->signup->group_id) {
+        if (!$post->group_id && $post->signup->group_id) {
             $post->group_id = $post->signup->group_id;
         }
 

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1628,4 +1628,56 @@ class PostTest extends TestCase
             'details' => json_encode($details),
         ]);
     }
+
+
+
+    /**
+     * Test that when a post is created for a signup with a group_id
+     * the group_id is saved to the post as well.
+     *
+     * @return void
+     */
+    public function testCreatingAPostForSignupWithGroupId()
+    {
+        $groupId = factory(Group::class)->create()->id;
+        $signup = factory(Signup::class)->create(['group_id' => $groupId]);
+
+        // Attributes for the post that we'll create
+        $quantity = $this->faker->numberBetween(10, 1000);
+        $text = $this->faker->sentence;
+        $action = factory(Action::class)->create(['campaign_id' => $signup->campaign_id]);
+
+        // Mock the Blink API call.
+        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+
+        // Create the post!
+        $response = $this->withAccessToken($signup->northstar_id)->postJson('api/v3/posts', [
+            'northstar_id'     => $signup->northstar_id,
+            'campaign_id'      => $signup->campaign_id,
+            'type'             => $action->post_type,
+            'action'           => $action->name,
+            'action_id'        => $action->id,
+            'quantity'         => $quantity,
+            'text'             => $text,
+            'file'             => UploadedFile::fake()->image('photo.jpg', 450, 450),
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertPostStructure($response);
+
+        $this->assertDatabaseHas('posts', [
+            'signup_id' => $signup->id,
+            'group_id' => $signup->group_id,
+            'northstar_id' => $signup->northstar_id,
+            'campaign_id' => $signup->campaign_id,
+            'type' => $action->post_type,
+            'action' => $action->name,
+            'action_id' => $action->id,
+            'status' => 'pending',
+            'quantity' => $quantity,
+        ]);
+    }
+
+
 }
+

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1676,4 +1676,3 @@ class PostTest extends TestCase
         ]);
     }
 }
-

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1629,8 +1629,6 @@ class PostTest extends TestCase
         ]);
     }
 
-
-
     /**
      * Test that when a post is created for a signup with a group_id
      * the group_id is saved to the post as well.
@@ -1677,7 +1675,5 @@ class PostTest extends TestCase
             'quantity' => $quantity,
         ]);
     }
-
-
 }
 


### PR DESCRIPTION
### What's this PR do?

When a post is being created, we'll check to see if its signup has a `group_id` set and if it does, we'll save the same `group_id` to the post as well.

### How should this be reviewed?

I wrote the test failing test first, added the logic in the `PostObserver`, made sure the test was passing as well as testing manually. Did I miss anything? Does this mess with the `school_id` logic at all?

### Any background context you want to provide?

It's all in the ticket!

### Relevant tickets

References [Pivotal #173750109](https://www.pivotaltracker.com/story/show/173750109).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
