### PR TITLE
Adds referral_signup_created Customer.io Event

### DIFF
--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -38,10 +38,10 @@ class SignupManager
         $signup = $this->signup->create($data, $northstarId, $campaignId);
 
         // Send to Blink unless 'dont_send_to_blink' is TRUE
-        $should_send_to_blink = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
+        $shouldSendToCustomerIo = ! (array_key_exists('dont_send_to_blink', $data) && $data['dont_send_to_blink']);
 
         // Save the new signup in Customer.io, via Blink.
-        if (config('features.blink') && $should_send_to_blink) {
+        if (config('features.blink') && $shouldSendToCustomerIo) {
             SendSignupToCustomerIo::dispatch($signup);
         }
 

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Managers;
 
+use Rogue\Jobs\CreateCustomerIoEvent;
 use Rogue\Jobs\SendSignupToCustomerIo;
 use Rogue\Repositories\SignupRepository;
 
@@ -43,6 +44,10 @@ class SignupManager
         // Save the new signup in Customer.io, via Blink.
         if (config('features.blink') && $shouldSendToCustomerIo) {
             SendSignupToCustomerIo::dispatch($signup);
+        }
+
+        if ($signup->referrer_user_id && $shouldSendToCustomerIo) {
+            CreateCustomerIoEvent::dispatch($signup->referrer_user_id, 'referral_signup_created', $signup->getReferralSignupEventPayload());
         }
 
         // Log that a signup was created.

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -248,4 +248,25 @@ class Signup extends Model
             }
         }]);
     }
+
+    /**
+     * Gets event payload for a referral signup, on behalf of the referrer user ID.
+     */
+    public function getReferralSignupEventPayload()
+    {
+        $userId = $this->northstar_id;
+        $user = app(GraphQL::class)->getUserById($userId);
+
+        $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId($this->campaign_id);
+
+        return [
+            'id' => $this->id,
+            'user_id' => $userId,
+            'user_display_name' => isset($user) ? $user['displayName'] : null,
+            'campaign_id' => (string) $this->campaign_id,
+            'campaign_title' => $campaignWebsite['title'],
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
 }

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -82,7 +82,7 @@ class PostTest extends TestCase
 
         // Mock the GraphQL API calls.
         $this->mock(GraphQL::class)
-            ->shouldReceive('getUserById');
+            ->shouldReceive('getUserById', 'getCampaignWebsiteByCampaignId');
 
         // Mock the Customer.io API calls.
         $this->mock(CustomerIo::class)

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -7,7 +7,9 @@ use Rogue\Models\Post;
 use Rogue\Models\User;
 use Rogue\Models\Group;
 use Rogue\Models\Signup;
+use Rogue\Services\GraphQL;
 use DoSomething\Gateway\Blink;
+use Rogue\Services\CustomerIo;
 
 class SignupTest extends TestCase
 {
@@ -94,6 +96,14 @@ class SignupTest extends TestCase
         $campaignId = $this->faker->randomNumber(4);
 
         $this->mock(Blink::class)->shouldReceive('userSignup');
+
+        // Mock the GraphQL API calls.
+        $this->mock(GraphQL::class)
+            ->shouldReceive('getUserById', 'getCampaignWebsiteByCampaignId');
+
+        // Mock the Customer.io API calls.
+        $this->mock(CustomerIo::class)
+            ->shouldReceive('trackEvent');
 
         $response = $this->withAccessToken($northstarId)->postJson('api/v3/signups', [
             'campaign_id' => $campaignId,

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -21,7 +21,6 @@ class SignupTest extends TestCase
     {
         $northstarId = $this->faker->northstar_id;
         $campaignId = $this->faker->randomNumber(4);
-        $referrerUserId = $this->faker->northstar_id;
 
         // Mock the Blink API call.
         $this->mock(Blink::class)->shouldReceive('userSignup');
@@ -29,7 +28,6 @@ class SignupTest extends TestCase
         $response = $this->withAccessToken($northstarId)->postJson('api/v3/signups', [
             'campaign_id' => $campaignId,
             'details' => 'affiliate-messaging',
-            'referrer_user_id' => $referrerUserId,
         ]);
 
         // Make sure we get the 201 Created response
@@ -41,7 +39,6 @@ class SignupTest extends TestCase
                 'quantity' => null,
                 'source' => 'phpunit',
                 'why_participated' => null,
-                'referrer_user_id' => $referrerUserId,
                 'group_id' => null,
             ],
         ]);

--- a/tests/Unit/Models/SignupModelTest.php
+++ b/tests/Unit/Models/SignupModelTest.php
@@ -47,4 +47,29 @@ class SignupModelTest extends TestCase
         $this->assertEquals($result['group_type_name'], null);
         $this->assertEquals($result['referrer_user_id'], null);
     }
+
+    /**
+     * Test expected payload for a referral signup event.
+     *
+     * @return void
+     */
+    public function testGetReferralSignupEventPayload()
+    {
+        $signup = factory(Signup::class)->create([
+            'northstar_id' =>  $this->faker->unique()->northstar_id,
+            'referrer_user_id' => $this->faker->unique()->northstar_id,
+        ]);
+
+        $result = $signup->getReferralSignupEventPayload();
+
+        $this->assertEquals($result['created_at'], $signup->created_at->toIso8601String());
+        $this->assertEquals($result['id'], $signup->id);
+        $this->assertEquals($result['updated_at'], $signup->updated_at->toIso8601String());
+        $this->assertEquals($result['user_id'], $signup->northstar_id);
+        $this->assertEquals($result['campaign_id'], $signup->campaign_id);
+
+        // Test expected data was retrieved from GraphQL.
+        $this->assertEquals($result['user_display_name'], 'Daisy D.');
+        $this->assertEquals($result['campaign_title'], 'Test Example Campaign');
+    }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request follows the excellent #1018 by example to dispatch a `referral_signup_created` event to customer.io when a Signup is created with a `referral_user_id` so that we can send a dedicated email to the referrer.

### How should this be reviewed?
commit-by-commit. You can refer to #1018 for slightly more context, but hopefully, this is super straightforward as-is!

### Any background context you want to provide?
See the Pivotal Ticket for the list of requested payload attributes.

### Relevant tickets

References [Pivotal #173563077](https://www.pivotaltracker.com/story/show/173563077).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
