### PR TITLE
Create ActionStats for completed voter registrations

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -520,7 +520,7 @@ class Post extends Model
             return;
         }
 
-        return $query->whereIn('status', ['accepted', 'register-form', 'register-OVR'])
+        return $query->whereIn('status', array_merge(['accepted'], self::getCompletedVoterRegStatuses()))
             ->orWhere('northstar_id', auth()->id())
             ->orWhere(function ($query) {
                 $query->whereNotNull('referrer_user_id')
@@ -655,7 +655,7 @@ class Post extends Model
     }
 
     /**
-     * Returns all status values of completed voter registrations.
+     * Returns all status values for completed voter registrations.
      *
      * @return array
      */

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -607,7 +607,7 @@ class Post extends Model
                 ->where('school_id', $this->school_id)
                 ->where('type', 'voter-reg')
                 ->where('action_id', $this->action_id)
-                ->where('status', 'in', self::getCompletedVoterRegStatuses())
+                ->whereIn('status', self::getCompletedVoterRegStatuses())
                 ->count();
 
             return ActionStat::updateOrCreate(

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -4,6 +4,7 @@ namespace Rogue\Observers;
 
 use Rogue\Models\Post;
 use Rogue\Models\Group;
+use Rogue\Models\ActionStat;
 
 class PostObserver
 {
@@ -24,5 +25,28 @@ class PostObserver
         if ($post->group_id && (! $post->school_id) && $group = $post->group) {
             $post->school_id = $group->school_id;
         }
+    }
+
+    /**
+     * Handle the Post "created" event.
+     *
+     * @param  \Rogue\Models\Post  $post
+     * @return void
+     */
+    public function created(Post $post)
+    {
+        $post->updateOrCreateActionStats();
+
+    }
+
+    /**
+     * Handle the Post "created" event.
+     *
+     * @param  \Rogue\Models\Post  $post
+     * @return void
+     */
+    public function updated(Post $post)
+    {
+        $post->updateOrCreateActionStats();
     }
 }

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -4,7 +4,6 @@ namespace Rogue\Observers;
 
 use Rogue\Models\Post;
 use Rogue\Models\Group;
-use Rogue\Models\ActionStat;
 
 class PostObserver
 {
@@ -36,7 +35,6 @@ class PostObserver
     public function created(Post $post)
     {
         $post->updateOrCreateActionStats();
-
     }
 
     /**

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -38,7 +38,7 @@ class PostObserver
     }
 
     /**
-     * Handle the Post "created" event.
+     * Handle the Post "updated" event.
      *
      * @param  \Rogue\Models\Post  $post
      * @return void

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -6,7 +6,6 @@ use Rogue\Models\Post;
 use Rogue\Models\Action;
 use Rogue\Models\Review;
 use Rogue\Models\Signup;
-use Rogue\Models\ActionStat;
 use Rogue\Services\ImageStorage;
 use Intervention\Image\Facades\Image;
 use Illuminate\Validation\ValidationException;

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -205,14 +205,6 @@ class PostRepository
         // Update the "counter cache" on the Post Campaign:
         $post->campaign->refreshCounts();
 
-        // If the Post has a School ID, upsert an ActionStat.
-        if ($post->school_id && $post->action_id) {
-            ActionStat::updateOrCreate(
-                ['action_id' => $post->action_id, 'school_id' => $post->school_id],
-                ['impact' => Post::getAcceptedQuantitySum($post->action_id, $post->school_id)]
-            );
-        }
-
         return $post;
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request creates or updates an `ActionStat` for a school upon creating or updating a completed `voter-reg` post. We'll eventually use this data to display a leaderboard of voter registrations by school (details in #[2417735](https://www.pivotaltracker.com/n/projects/2417735)).

It implements this by refactoring the existing Post `getAcceptedQuantitySum` method as `updateOrCreateActionStats`, and by calling it from newly added `created` and `updated` hooks in the PostObserver.

Also adds a static `getCompletedVoterRegStatuses` method to the Post model to DRY getting list of statuses considered completed.

### How should this be reviewed?

👀 

### Any background context you want to provide?

* We have existing test coverage for creating ActionStats for approved posts in test for the Reviews endpoint, so didn't add it into our model test for now. Might be worth moving it later to keep the tests in one place.

* A followup PR will add a `state` field to the `action_stats` table, in order to filter action stats by state. Holding on adding that in this PR to hopefully keep this easier to review.

### Relevant tickets

References [Pivotal #2417735](https://www.pivotaltracker.com/n/projects/2417735).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
