### PR TITLE
Adds location field to Group and ActionStat resources

### DIFF
--- a/app/Http/Transformers/ActionStatTransformer.php
+++ b/app/Http/Transformers/ActionStatTransformer.php
@@ -19,6 +19,7 @@ class ActionStatTransformer extends TransformerAbstract
             'id' => $actionStat->id,
             'action_id' => $actionStat->action_id,
             'school_id' => $actionStat->school_id,
+            'location' => $actionStat->location,
             'impact' => $actionStat->impact,
             'created_at' => $actionStat->created_at->toIso8601String(),
             'updated_at' => $actionStat->updated_at->toIso8601String(),

--- a/app/Http/Transformers/GroupTransformer.php
+++ b/app/Http/Transformers/GroupTransformer.php
@@ -21,6 +21,7 @@ class GroupTransformer extends TransformerAbstract
             'name' => $group->name,
             'city' => $group->city,
             'state' => $group->state,
+            'location' => $group->location,
             'school_id' => $group->school_id,
             'goal' => $group->goal,
             'created_at' => $group->created_at->toIso8601String(),

--- a/app/Models/ActionStat.php
+++ b/app/Models/ActionStat.php
@@ -14,6 +14,7 @@ class ActionStat extends Model
     protected $fillable = [
         'action_id',
         'impact',
+        'location',
         'school_id',
     ];
 
@@ -25,7 +26,7 @@ class ActionStat extends Model
      *
      * @var array
      */
-    public static $indexes = ['action_id', 'school_id'];
+    public static $indexes = ['action_id', 'location', 'school_id'];
 
     /**
      * Attributes that can be sorted by.

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -18,6 +18,7 @@ class Group extends Model
         'city',
         'goal',
         'group_type_id',
+        'location',
         'name',
         'school_id',
         'state',
@@ -34,6 +35,7 @@ class Group extends Model
     public static $indexes = [
         'group_type_id',
         'id',
+        'location',
         'school_id',
         'state',
     ];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -606,7 +606,7 @@ class Post extends Model
          * group -- but there aren't any current school finder campaigns that would create posts
          * with a school and not a group.
          */
-        $location = $this->group->location;
+        $location = $this->group ? $this->group->location : null;
 
         // If completed voter-reg post, update school impact as completed count for this action.
         if ($this->type === 'voter-reg' && in_array($this->status, self::getCompletedVoterRegStatuses())) {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -601,6 +601,13 @@ class Post extends Model
             return;
         }
 
+        /**
+         * TODO: We can eventually query GraphQL for school location if we have a school but no
+         * group -- but there aren't any current school finder campaigns that would create posts
+         * with a school and not a group.
+         */
+        $location = $this->group->location;
+
         // If completed voter-reg post, update school impact as completed count for this action.
         if ($this->type === 'voter-reg' && in_array($this->status, self::getCompletedVoterRegStatuses())) {
             $impact = (new self)->newModelQuery()
@@ -612,7 +619,7 @@ class Post extends Model
 
             return ActionStat::updateOrCreate(
                 ['action_id' => $this->action_id, 'school_id' => $this->school_id],
-                ['impact' => $impact]
+                ['impact' => $impact, 'location' => $location]
             );
         }
 
@@ -626,7 +633,7 @@ class Post extends Model
 
             return ActionStat::updateOrCreate(
                 ['action_id' => $this->action_id, 'school_id' => $this->school_id],
-                ['impact' => $impact]
+                ['impact' => $impact, 'location' => $location]
             );
         }
     }

--- a/database/migrations/2020_07_30_000000_add_location_to_action_stats_and_groups_tables.php
+++ b/database/migrations/2020_07_30_000000_add_location_to_action_stats_and_groups_tables.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLocationToActionStatsAndGroupsTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_stats', function (Blueprint $table) {
+            $table->string('location', 6)->nullable()->after('school_id');
+        });
+
+        Schema::table('groups', function (Blueprint $table) {
+            $table->string('location', 6)->nullable()->after('state');
+        });
+
+        // Execute SQL query to find all groups.
+        foreach (DB::table('groups')->select('id','state')->get() as $result) {
+            if (! $result->state) {
+                continue;
+            }
+            // Execute update query to populate location.
+            DB::table('groups')
+                ->where('id', $result->id)
+                ->update(['location' => 'US-' . $result->state]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_stats', function (Blueprint $table) {
+            $table->dropColumn('location');
+        });
+
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('location');
+        });
+    }
+}

--- a/database/migrations/2020_07_30_000000_add_location_to_action_stats_and_groups_tables.php
+++ b/database/migrations/2020_07_30_000000_add_location_to_action_stats_and_groups_tables.php
@@ -15,17 +15,21 @@ class AddLocationToActionStatsAndGroupsTables extends Migration
     {
         Schema::table('action_stats', function (Blueprint $table) {
             $table->string('location', 6)->nullable()->after('school_id');
+            $table->index(['action_id', 'location']);
         });
 
         Schema::table('groups', function (Blueprint $table) {
+            // We'll deprecate the state column once all GraphQL queries are changed.
             $table->string('location', 6)->nullable()->after('state');
+            $table->index(['group_type_id', 'location']);
         });
 
         // Execute SQL query to find all groups.
-        foreach (DB::table('groups')->select('id','state')->get() as $result) {
+        foreach (DB::table('groups')->select('id', 'state')->get() as $result) {
             if (! $result->state) {
                 continue;
             }
+
             // Execute update query to populate location.
             DB::table('groups')
                 ->where('id', $result->id)

--- a/database/migrations/2020_07_30_000000_add_location_to_action_stats_and_groups_tables.php
+++ b/database/migrations/2020_07_30_000000_add_location_to_action_stats_and_groups_tables.php
@@ -24,17 +24,7 @@ class AddLocationToActionStatsAndGroupsTables extends Migration
             $table->index(['group_type_id', 'location']);
         });
 
-        // Execute SQL query to find all groups.
-        foreach (DB::table('groups')->select('id', 'state')->get() as $result) {
-            if (! $result->state) {
-                continue;
-            }
-
-            // Execute update query to populate location.
-            DB::table('groups')
-                ->where('id', $result->id)
-                ->update(['location' => 'US-' . $result->state]);
-        }
+        DB::statement("UPDATE groups SET location = CONCAT('US-', state) WHERE state IS NOT NULL");
     }
 
     /**
@@ -45,10 +35,12 @@ class AddLocationToActionStatsAndGroupsTables extends Migration
     public function down()
     {
         Schema::table('action_stats', function (Blueprint $table) {
+            $table->dropIndex(['action_id', 'location']);
             $table->dropColumn('location');
         });
 
         Schema::table('groups', function (Blueprint $table) {
+            $table->dropIndex(['group_type_id', 'location']);
             $table->dropColumn('location');
         });
     }

--- a/docs/endpoints/action-stats.md
+++ b/docs/endpoints/action-stats.md
@@ -12,7 +12,7 @@ GET /api/v3/action-stats
 
 - **filter[column]** _(string)_
 
-  - Filter results by column. Supported columns: `action_id`, `school_id`
+  - Filter results by column. Supported columns: `action_id`, `location`, `school_id`
   - Use commas to filter by multiple values in a column, e.g. `/action-stats?filter[action_id]=121,122`
 
 - **orderBy** _(string)_
@@ -28,6 +28,7 @@ Example Response:
       "id": 1,
       "action_id": 1,
       "school_id": "3401457",
+      "location": "US-SC",
       "impact": 37,
       "created_at": "2019-12-04T21:28:26+00:00",
       "updated_at": "2019-12-04T22:33:03+00:00"
@@ -36,6 +37,7 @@ Example Response:
       "id": 2,
       "action_id": 1,
       "school_id": "4802532",
+      "location": "US-NJ",
       "impact": 43,
       "created_at": "2019-12-04T22:05:29+00:00",
       "updated_at": "2019-12-04T22:05:29+00:00"

--- a/docs/endpoints/groups.md
+++ b/docs/endpoints/groups.md
@@ -16,6 +16,10 @@ GET /api/v3/groups
 
   - Filter results by Group ID or ID's.
 
+- **filter[location]** _(string)_
+
+  - Filter results by given location, e.g. `filter[state]=US-SC`.
+
 - **filter[name]** _(string)_
 
   - Filter results by names that include the given filter, e.g. `filter[name]=New`.
@@ -24,7 +28,7 @@ GET /api/v3/groups
 
   - Filter results by given school_id, e.g. `filter[external_id]=13000419`.
 
-- **filter[state]** _(string)_
+- **filter[state]** _(string)_ -- Deprecated
 
   - Filter results by given state, e.g. `filter[state]=SC`.
 
@@ -39,6 +43,7 @@ Example Response:
       "name": "A C Flora High School",
       "city": "Charleston",
       "state": "SC",
+      "location": "US-SC",
       "school_id": "3600737",
       "goal": 150,
       "created_at": "2019-12-04T21:28:26+00:00",
@@ -50,6 +55,7 @@ Example Response:
       "name": "Afton Central School",
       "city": "Afton",
       "state": "NY",
+      "location": "US-NY",
       "school_id": null,
       "goal": null,
       "created_at": "2019-12-04T22:05:29+00:00",
@@ -86,6 +92,7 @@ Example Response:
     "name": "A C Flora High School",
     "city": "Charleston",
     "state": "SC",
+    "location": "US-SC",
     "school_id": "3600737",
     "goal": 150,
     "created_at": "2019-12-04T21:28:26+00:00",

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -182,21 +182,28 @@ class PostModelTest extends TestCase
     {
         $actionId = factory(Action::class)->create()->id;
         $schoolId = $this->faker->school_id;
+        $location = 'US-FL';
+
+        $group = factory(Group::class)->create([
+            'location' => $location,
+            'school_id' => $schoolId,
+        ]);
 
         factory(Post::class, 7)->states(['voter-reg', 'register-form'])->create([
             'action_id' => $actionId,
-            'school_id' => $schoolId,
+            'group_id' => $group->id,
         ]);
 
         $this->assertDatabaseHas('action_stats', [
             'action_id' => $actionId,
             'impact' => 7,
             'school_id' => $schoolId,
+            'location' => $location,
         ]);
 
         $post = factory(Post::class)->states(['voter-reg', 'step-1'])->create([
             'action_id' => $actionId,
-            'school_id' => $schoolId,
+            'group_id' => $group->id,
         ]);
 
         // Verify impact wasn't updated.
@@ -204,6 +211,7 @@ class PostModelTest extends TestCase
             'action_id' => $actionId,
             'impact' => 7,
             'school_id' => $schoolId,
+            'location' => $location,
         ]);
 
         $post->status = 'step-2';
@@ -214,6 +222,7 @@ class PostModelTest extends TestCase
             'action_id' => $actionId,
             'impact' => 7,
             'school_id' => $schoolId,
+            'location' => $location,
         ]);
 
         $post->status = 'register-OVR';
@@ -224,6 +233,7 @@ class PostModelTest extends TestCase
             'action_id' => $actionId,
             'impact' => 8,
             'school_id' => $schoolId,
+            'location' => $location,
         ]);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration to add `location` column to the `action_stats` and `groups` tables, and populates the `location` field with the `state` values as  ISO-3166-2 codes, to keep consistent with the `location` field values found on the `posts` table (refs https://github.com/DoSomething/rogue/pull/1079#issuecomment-666484121).

It also modifies the `updateOrCreateActionStats` method introduced in #1079 to write a post group's location to the related action stat, and adds support to filter to the `action_stats` table by `location`. This will be used to display leaderboards by US state.

```
// http://rogue.test/api/v3/action-stats?filter[location]=US-TX

{
  "data": [
    {
      "id": 72,
      "action_id": 11,
      "school_id": "4809500",
      "location": "US-TX",
      "impact": 7,
      "created_at": "2020-07-30T00:07:46+00:00",
      "updated_at": "2020-07-30T21:10:41+00:00"
    }
  ],
  "meta": {
    "pagination": {
      "total": 1,
  ...
```

### How should this be reviewed?

👀 

### Any background context you want to provide?

Once these fields are added to GraphQL and the relevant components in Phoenix and Rogue query for `location` instead of `state`, we can drop the group `state` field to clean this up a bit.

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
