### PR TITLE
Adds cursor support to action stats index

### DIFF
--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -37,6 +37,13 @@ class ActionStatsController extends ApiController
         $orderBy = $request->query('orderBy');
         $query = $this->orderBy($query, $orderBy, ActionStat::$sortable);
 
+        if ($cursor = array_get($request->query('cursor'), 'after')) {
+            $query->whereAfterCursor($cursor);
+
+            // Using 'cursor' implies cursor pagination:
+            $this->useCursorPagination = true;
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 }

--- a/app/Http/Transformers/ActionStatTransformer.php
+++ b/app/Http/Transformers/ActionStatTransformer.php
@@ -23,6 +23,7 @@ class ActionStatTransformer extends TransformerAbstract
             'impact' => $actionStat->impact,
             'created_at' => $actionStat->created_at->toIso8601String(),
             'updated_at' => $actionStat->updated_at->toIso8601String(),
+            'cursor' => $actionStat->getCursor(),
         ];
     }
 }

--- a/app/Models/ActionStat.php
+++ b/app/Models/ActionStat.php
@@ -2,10 +2,13 @@
 
 namespace Rogue\Models;
 
+use Rogue\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
 
 class ActionStat extends Model
 {
+    use HasCursor;
+
     /**
      * The attributes that are mass assignable.
      *


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for using `?cursor[after]=` to paginate through action stats, following #976 by example.

### How should this be reviewed?

👀 

```
// http://rogue.test/api/v3/action-stats?cursor[after]=NjA=

{
  "data": [
    {
      "id": 61,
      "action_id": 72,
      "school_id": "4825422",
      "location": null,
      "impact": 46,
      "created_at": "2020-06-25T21:22:31+00:00",
      "updated_at": "2020-06-25T21:22:31+00:00",
      "cursor": "NjE="
    },
    {
      "id": 62,
      "action_id": 72,
      "school_id": "3401166",
      "location": null,
      "impact": 19,
      "created_at": "2020-06-25T21:22:31+00:00",
      "updated_at": "2020-06-25T21:22:31+00:00",
      "cursor": "NjI="
    },
   ...
```

### Any background context you want to provide?

We'll eventually use this to allow users to incrementally load a full list of action stats for school leaderboards of voter registration posts.

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
