### PR TITLE
Fixes DatabaseSeeder ActionStats

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -11,7 +11,6 @@ use Rogue\Models\Campaign;
 use Rogue\Models\Reaction;
 use Rogue\Models\GroupType;
 use Rogue\Types\ActionType;
-use Rogue\Models\ActionStat;
 use Rogue\Types\TimeCommitment;
 
 /**
@@ -39,17 +38,6 @@ $factory->define(Action::class, function (Generator $faker) {
         'verb' => 'done',
         'collect_school_id' => true,
         'volunteer_credit' => false,
-    ];
-});
-
-// ActionStat Factory
-$factory->define(ActionStat::class, function (Generator $faker) {
-    $faker->addProvider(new FakerSchoolId($faker));
-
-    return [
-        'school_id' => $this->faker->school_id,
-        'action_id' => factory(Action::class)->create()->id,
-        'impact' => $faker->randomNumber(3),
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -192,10 +192,18 @@ $factory->define(GroupType::class, function (Generator $faker) {
 
 // Group Factory
 $factory->define(Group::class, function (Generator $faker) {
+    $faker->addProvider(new FakerSchoolId($faker));
+
     return [
         'group_type_id' => function () {
             return factory(GroupType::class)->create()->id;
         },
         'name' => title_case($faker->unique()->company),
+    ];
+});
+
+$factory->state(Group::class, 'school', function (Generator $faker) {
+    return [
+        'school_id' => $faker->school_id,
     ];
 });

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rogue\Models\Post;
+use Rogue\Models\Group;
 use Rogue\Models\Action;
 use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
@@ -29,11 +30,14 @@ class DatabaseSeeder extends Seeder
             // Create 10-20 signups with one accepted photo post & some pending photo and text posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
                 ->each(function (Signup $signup) use ($photoAction, $textAction) {
+                    $group = factory(Group::class)->states('school')->create();
+
                     $signup->posts()->save(factory(Post::class)->states('photo', 'accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
+                        'group_id' => $group->id,
                     ]));
 
                     $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('photo', 'pending')->create([
@@ -41,6 +45,7 @@ class DatabaseSeeder extends Seeder
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
+                        'group_id' => $group->id,
                     ]));
 
                     $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('text', 'pending')->create([

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -4,7 +4,6 @@ use Rogue\Models\Post;
 use Rogue\Models\Action;
 use Rogue\Models\Signup;
 use Rogue\Models\Campaign;
-use Rogue\Models\ActionStat;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -22,37 +21,20 @@ class DatabaseSeeder extends Seeder
                 'post_type' => 'photo',
                 'campaign_id' => $campaign->id,
             ]);
-
             $textAction = factory(Action::class)->create([
                 'post_type' => 'text',
                 'campaign_id' => $campaign->id,
             ]);
 
-            $approvedQuantityBySchoolId = [];
-
             // Create 10-20 signups with one accepted photo post & some pending photo and text posts.
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) use (&$approvedQuantityBySchoolId, $photoAction, $textAction) {
-                    $acceptedPhotoPost = factory(Post::class)->states('photo', 'accepted')->create([
+                ->each(function (Signup $signup) use ($photoAction, $textAction) {
+                    $signup->posts()->save(factory(Post::class)->states('photo', 'accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
-                    ]);
-
-                    $schoolId = $acceptedPhotoPost->school_id;
-
-                    /**
-                     * If this accepted photo post has a school, add its quantity to a running total
-                     * of the school's approved quantity, that we'll use to create an ActionStat.
-                     */
-                    if (isset($schoolId) && ! isset($approvedQuantityBySchoolId[$schoolId])) {
-                        $approvedQuantityBySchoolId[$schoolId] = $acceptedPhotoPost->quantity;
-                    } elseif (isset($schoolId)) {
-                        $approvedQuantityBySchoolId[$schoolId] += $acceptedPhotoPost->quantity;
-                    }
-
-                    $signup->posts()->save($acceptedPhotoPost);
+                    ]));
 
                     $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('photo', 'pending')->create([
                         'action_id' => $photoAction->id,
@@ -71,23 +53,13 @@ class DatabaseSeeder extends Seeder
 
             // Create 5-10 signups with only accepted posts, from lil' angels!
             factory(Signup::class, rand(10, 20))->create(['campaign_id' => $campaign->id])
-                ->each(function (Signup $signup) use (&$approvedQuantityBySchoolId, $photoAction, $textAction) {
-                    $acceptedPhotoPost = factory(Post::class)->states('photo', 'accepted')->create([
+                ->each(function (Signup $signup) use ($photoAction, $textAction) {
+                    $signup->posts()->save(factory(Post::class)->states('photo', 'accepted')->create([
                         'action_id' => $photoAction->id,
                         'signup_id' => $signup->id,
                         'campaign_id' => $signup->campaign_id,
                         'northstar_id' => $signup->northstar_id,
-                    ]);
-
-                    $schoolId = $acceptedPhotoPost->school_id;
-
-                    if (isset($schoolId) && ! isset($approvedQuantityBySchoolId[$schoolId])) {
-                        $approvedQuantityBySchoolId[$schoolId] = $acceptedPhotoPost->quantity;
-                    } elseif (isset($schoolId)) {
-                        $approvedQuantityBySchoolId[$schoolId] += $acceptedPhotoPost->quantity;
-                    }
-
-                    $signup->posts()->save($acceptedPhotoPost);
+                    ]));
 
                     $signup->posts()->saveMany(factory(Post::class, rand(2, 4))->states('text', 'accepted')->create([
                         'action_id' => $textAction->id,
@@ -110,15 +82,6 @@ class DatabaseSeeder extends Seeder
 
             // Create 100 signups with no posts yet.
             factory(Signup::class, 100)->create(['campaign_id' => $campaign->id]);
-
-            // Create action stats from the approved photo posts created for the photo action.
-            foreach ($approvedQuantityBySchoolId as $schoolId => $total) {
-                factory(ActionStat::class)->create([
-                    'impact' => $total,
-                    'action_id' => $photoAction->id,
-                    'school_id' => $schoolId,
-                ]);
-            }
         });
 
         // And two campaigns with no activity yet.


### PR DESCRIPTION
### What's this PR do?

This pull request simplifies seeding the `action_stats` table, starting by reverting the original code added in #984 to do this.

In #1079, we added a `PostObserver` that calculates stats upon creating or updating a post. This PR changes the seeder to create approved photo posts for groups that have schools, seeding the `action_stats` table with what we'd expect per the seeded `posts`.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🧑‍🌾 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
