### PR TITLE
Adds ActionStatsTable component

### DIFF
--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -17,6 +17,7 @@ import ShowCampaign from './pages/ShowCampaign';
 import ShowGroupType from './pages/ShowGroupType';
 import CampaignIndex from './pages/CampaignIndex';
 import GroupTypeIndex from './pages/GroupTypeIndex';
+import ActionStatIndex from './pages/ActionStatIndex';
 
 const Application = () => {
   const endpoint = env('GRAPHQL_URL');
@@ -25,6 +26,9 @@ const Application = () => {
     <ApolloProvider client={graphql(endpoint)}>
       <BrowserRouter>
         <Switch>
+          <Route path="/action-stats" exact>
+            <ActionStatIndex />
+          </Route>
           <Route path="/actions/:id">
             <ShowAction />
           </Route>

--- a/resources/assets/components/ActionStatsTable.js
+++ b/resources/assets/components/ActionStatsTable.js
@@ -1,0 +1,182 @@
+import gql from 'graphql-tag';
+import { assign, get } from 'lodash';
+import { useQuery } from '@apollo/react-hooks';
+import React, { useState, useEffect } from 'react';
+
+import Empty from './Empty';
+import { updateQuery } from '../helpers';
+import EntityLabel from './utilities/EntityLabel';
+
+const ACTION_STATS_QUERY = gql`
+  query ActionStatsIndexQuery(
+    $actionId: Int
+    $schoolId: String
+    $location: String
+    $cursor: String
+  ) {
+    stats: paginatedSchoolActionStats(
+      after: $cursor
+      first: 20
+      actionId: $actionId
+      location: $location
+      schoolId: $schoolId
+    ) {
+      edges {
+        cursor
+        node {
+          id
+          impact
+          action {
+            id
+            name
+            noun
+            verb
+          }
+          schoolId
+          school {
+            id
+            name
+            city
+            state
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+/**
+ * This component handles fetching & paginating a list of action stats.
+ *
+ * @param {Number} actionId
+ * @param {String} schoolId
+ */
+const ActionStatsTable = ({ actionId, schoolId }) => {
+  const variables = {};
+
+  if (actionId) {
+    assign(variables, { actionId });
+  }
+
+  if (schoolId) {
+    assign(variables, { schoolId });
+  }
+
+  const { error, loading, data, fetchMore } = useQuery(ACTION_STATS_QUERY, {
+    variables,
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const stats = data ? data.stats.edges : [];
+  const noResults = stats.length === 0 && !loading;
+  const { endCursor, hasNextPage } = get(data, 'stats.pageInfo', {});
+
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery,
+    });
+  };
+
+  if (error) {
+    return (
+      <div className="text-center">
+        <p>There was an error. :(</p>
+
+        <code>{JSON.stringify(error)}</code>
+      </div>
+    );
+  }
+
+  if (noResults && !hasNextPage) {
+    return <Empty />;
+  }
+
+  return (
+    <>
+      <table className="table">
+        <thead>
+          <tr>
+            {schoolId ? null : <td>School</td>}
+
+            {actionId ? null : <td>Action</td>}
+
+            <td>Impact</td>
+          </tr>
+        </thead>
+
+        <tbody>
+          {stats.map(({ node, cursor }) => {
+            const { action, impact, school } = node;
+
+            return (
+              <tr key={cursor}>
+                {schoolId ? null : (
+                  <td>
+                    <EntityLabel
+                      id={school.id}
+                      name={school.name}
+                      path="schools"
+                    />
+
+                    <div>
+                      {school.city ? `${school.city}, ${school.state}` : null}
+                    </div>
+                  </td>
+                )}
+
+                {actionId ? null : (
+                  <td>
+                    <EntityLabel
+                      id={action.id}
+                      name={action.name}
+                      path="actions"
+                    />
+                  </td>
+                )}
+
+                <td>
+                  {impact}{' '}
+                  {actionId ? null : (
+                    <span className="text-sm">
+                      {action.noun} {action.verb}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+        <tfoot className="form-actions">
+          {loading ? (
+            <tr>
+              <td colSpan={schoolId || actionId ? 2 : 3}>
+                <div className="spinner margin-horizontal-auto margin-vertical" />
+              </td>
+            </tr>
+          ) : null}
+
+          {hasNextPage ? (
+            <tr>
+              <td colSpan={schoolId || actionId ? 2 : 3}>
+                <button
+                  className="button -tertiary"
+                  onClick={handleViewMore}
+                  disabled={loading}
+                >
+                  view more...
+                </button>
+              </td>
+            </tr>
+          ) : null}
+        </tfoot>
+      </table>
+    </>
+  );
+};
+
+export default ActionStatsTable;

--- a/resources/assets/pages/ActionStatIndex.js
+++ b/resources/assets/pages/ActionStatIndex.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Shell from '../components/utilities/Shell';
+import ActionStatsTable from '../components/ActionStatsTable';
+
+const ActionStatIndex = () => {
+  const title = 'Action Stats';
+  document.title = title;
+
+  return (
+    <Shell title={title}>
+      <div className="container__block">
+        <ActionStatsTable />
+      </div>
+    </Shell>
+  );
+};
+
+export default ActionStatIndex;

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -5,26 +5,15 @@ import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
-import Action, { ActionFragment } from '../components/Action';
 import Shell from '../components/utilities/Shell';
+import ActionStatsTable from '../components/ActionStatsTable';
+import Action, { ActionFragment } from '../components/Action';
 import MetaInformation from '../components/utilities/MetaInformation';
 
-// @TODO: Add support for paging through schoolActionStats once posts with school get reviewed.
 const SHOW_ACTION_QUERY = gql`
   query ShowActionQuery($id: Int!) {
     action(id: $id) {
       ...ActionFragment
-      schoolActionStats {
-        schoolId
-        school {
-          id
-          name
-          city
-          state
-        }
-        acceptedQuantity
-        updatedAt
-      }
     }
   }
   ${ActionFragment}
@@ -51,11 +40,12 @@ const ShowAction = () => {
     return <NotFound title={title} type="action" />;
   }
 
-  const { campaign, name, noun, schoolActionStats, verb } = data.action;
+  const { campaign, name, noun, verb } = data.action;
 
   return (
     <Shell title={title} subtitle={name}>
       <Action action={data.action} isPermalink />
+
       <ul className="form-actions margin-vertical">
         <li>
           <a className="button -tertiary" href={`/campaigns/${campaign.id}`}>
@@ -63,48 +53,12 @@ const ShowAction = () => {
           </a>
         </li>
       </ul>
-      {schoolActionStats.length ? (
-        <div className="mb-4">
-          <h3>School Leaderboard</h3>
-          <p className="mb-4">
-            These totals are updated any time a Review is created for a Post
-            that is associated with this Action and the User's School.
-          </p>
-          <table className="table">
-            <thead>
-              <tr>
-                <td>School</td>
-                <td>Location</td>
-                <td className="text-center">
-                  Total approved {noun} {verb}
-                </td>
-              </tr>
-            </thead>
-            <tbody>
-              {schoolActionStats.map(item => (
-                <tr key={item.school.id}>
-                  <td>
-                    <strong>
-                      <a href={`/schools/${item.school.id}`}>
-                        {item.school.name}
-                      </a>
-                    </strong>
-                  </td>
-                  <td>
-                    {item.school.city}, {item.school.state}
-                  </td>
-                  <td className="text-center">
-                    <strong>{item.acceptedQuantity}</strong>
-                    <div className="text-sm">
-                      Updated {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+
+      <div className="container__row">
+        <div className="container__block">
+          <ActionStatsTable actionId={data.action.id} />
         </div>
-      ) : null}
+      </div>
     </Shell>
   );
 };

--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -7,9 +7,9 @@ import { useQuery } from '@apollo/react-hooks';
 import NotFound from './NotFound';
 import Shell from '../components/utilities/Shell';
 import EntityLabel from '../components/utilities/EntityLabel';
+import ActionStatsTable from '../components/ActionStatsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 
-// @TODO: Add support for paging through schoolActionStats once more actions collect school.
 const SHOW_SCHOOL_QUERY = gql`
   query ShowSchoolQuery($id: String!) {
     school(id: $id) {
@@ -17,20 +17,6 @@ const SHOW_SCHOOL_QUERY = gql`
       name
       city
       state
-      schoolActionStats {
-        action {
-          id
-          name
-          noun
-          verb
-          campaign {
-            id
-            internalTitle
-          }
-        }
-        acceptedQuantity
-        updatedAt
-      }
     }
     groups(schoolId: $id) {
       id
@@ -62,7 +48,7 @@ const ShowSchool = () => {
 
   if (!data.school) return <NotFound title={title} type="school" />;
 
-  const { city, name, schoolActionStats, state } = data.school;
+  const { city, name, state } = data.school;
 
   const groupList = data.groups.length ? (
     <ul>
@@ -96,43 +82,7 @@ const ShowSchool = () => {
       </div>
       <div className="container__row">
         <div className="container__block">
-          <h3>Aggregate Impact</h3>
-          <p className="mb-4">
-            These totals are updated any time a Review is created for a Post
-            that is associated with this School.
-          </p>
-          <table className="table">
-            <thead>
-              <tr>
-                <td>Action</td>
-                <td>Campaign</td>
-                <td className="text-center">Total approved quantity</td>
-              </tr>
-            </thead>
-            <tbody>
-              {schoolActionStats.map(item => (
-                <tr key={item.action.id}>
-                  <td>
-                    <a href={`/actions/${item.action.id}`}>
-                      {item.action.name}
-                    </a>
-                  </td>
-                  <td>
-                    <a href={`/campaigns/${item.action.campaign.id}`}>
-                      {item.action.campaign.internalTitle}
-                    </a>
-                  </td>
-                  <td className="text-center">
-                    <strong>{item.acceptedQuantity}</strong> {item.action.noun}{' '}
-                    {item.action.verb}
-                    <div className="text-sm">
-                      Updated {format(parse(item.updatedAt), 'M/D/YYYY h:mm a')}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <ActionStatsTable schoolId={id} />
         </div>
       </div>
     </Shell>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,9 @@ Route::resource('groups', 'GroupsController', ['except' => ['create', 'index', '
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     // Actions
+    Route::view('action-stats', 'app');
+
+    // Actions
     Route::view('actions/{id}', 'app');
 
     // Campaigns


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `ActionStatTable` component and fixes the TODOs of paginating through action stats, now that we've added support in https://github.com/DoSomething/graphql/pull/264. 

It also adds a general `/action-stats` index web view, to help spot check that action stats get created and updated correctly (refs #1084).

### How should this be reviewed?

👀 

### Any background context you want to provide?

TODO: Add an `orderBy` prop to sort the Action page stats by descending impact.

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
