### PR TITLE
Fix GET /api/v3/action-stats

### DIFF
--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -2,6 +2,7 @@
 
 namespace Rogue\Http\Controllers;
 
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Rogue\Models\ActionStat;
 use Rogue\Http\Transformers\ActionStatTransformer;
@@ -37,7 +38,7 @@ class ActionStatsController extends ApiController
         $orderBy = $request->query('orderBy');
         $query = $this->orderBy($query, $orderBy, ActionStat::$sortable);
 
-        if ($cursor = array_get($request->query('cursor'), 'after')) {
+        if ($cursor = Arr::get($request->query('cursor'), 'after')) {
             $query->whereAfterCursor($cursor);
 
             // Using 'cursor' implies cursor pagination:


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a `GET /api/v3/action-stats` request --  there was an astray `array_get` 🐛  that likely got lost in the mix of rebasing for the Laravel update in #1080. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐞 

### Relevant tickets

#1080 

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
