### PR TITLE
Removing deprecated or operator.

### DIFF
--- a/resources/views/forms/select.blade.php
+++ b/resources/views/forms/select.blade.php
@@ -1,6 +1,6 @@
 <div class="select">
     <select name="{{ $name }}">
-        <option value="" {{ ! old($name) && ! isset($value) ? 'selected' : '' }} {{ !isset($optional) ? 'disabled' : ''}}>{{ $placeholder or '–' }}</option>
+        <option value="" {{ ! old($name) && ! isset($value) ? 'selected' : '' }} {{ !isset($optional) ? 'disabled' : ''}}>{{ $placeholder ?? '–' }}</option>
         @foreach($options as $option => $label)
             @if (old($name))
                 <option value="{{ $option }}" {{ old($name) === $option ? 'selected': '' }}>{{ $label }}</option>


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a quick bug that is caused due to having missed replacing the `or` operator in a select form input to use the `??` instead. The `or` operator was removed from Laravel in favor of the `??` null coalescing operator which essentially does the same behavior but is native to PHP.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This was causing a bug on a form in the admin side of things on Rogue.

### Relevant tickets

References [Pivotal #172383643](https://www.pivotaltracker.com/story/show/172383643).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
