### PR TITLE
Adds filter_by_location field to GroupType resource

### DIFF
--- a/app/Http/Transformers/GroupTypeTransformer.php
+++ b/app/Http/Transformers/GroupTypeTransformer.php
@@ -18,6 +18,7 @@ class GroupTypeTransformer extends TransformerAbstract
         return [
             'id' => $groupType->id,
             'name' => $groupType->name,
+            'filter_by_location' => $groupType->filter_by_location,
             'filter_by_state' => $groupType->filter_by_state,
             'created_at' => $groupType->created_at->toIso8601String(),
             'updated_at' => $groupType->updated_at->toIso8601String(),

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -13,6 +13,8 @@ class GroupType extends Model
      * @var array
      */
     protected $casts = [
+        'filter_by_location' => 'boolean',
+        // This field will eventually be deprecated by filter_by_location.
         'filter_by_state' => 'boolean',
     ];
 
@@ -21,7 +23,12 @@ class GroupType extends Model
      *
      * @var array
      */
-    protected $fillable = ['filter_by_state', 'name'];
+    protected $fillable = [
+        'filter_by_location',
+        // This field will eventually be deprecated by filter_by_location.
+        'filter_by_state',
+        'name',
+    ];
 
     protected static function boot()
     {

--- a/database/migrations/2020_08_06_000000_add_filter_by_location_to_group_types_table.php
+++ b/database/migrations/2020_08_06_000000_add_filter_by_location_to_group_types_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFilterByLocationToGroupTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->boolean('filter_by_location')->default(false)->after('name')->comment('Whether or not group finders for this group type should filter by location.');
+        });
+
+        DB::statement("UPDATE group_types SET filter_by_location = filter_by_state");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->dropColumn('filter_by_location');
+        });
+    }
+}

--- a/database/migrations/2020_08_06_000000_add_filter_by_location_to_group_types_table.php
+++ b/database/migrations/2020_08_06_000000_add_filter_by_location_to_group_types_table.php
@@ -17,7 +17,7 @@ class AddFilterByLocationToGroupTypesTable extends Migration
             $table->boolean('filter_by_location')->default(false)->after('name')->comment('Whether or not group finders for this group type should filter by location.');
         });
 
-        DB::statement("UPDATE group_types SET filter_by_location = filter_by_state");
+        DB::statement('UPDATE group_types SET filter_by_location = filter_by_state');
     }
 
     /**

--- a/docs/endpoints/group-types.md
+++ b/docs/endpoints/group-types.md
@@ -24,7 +24,7 @@ Example Response:
     {
       "id": 2,
       "name": "College Board",
-      "filter_by_location": false,
+      "filter_by_location": true,
       "filter_by_state": true,
       "created_at": "2019-12-04T22:05:29+00:00",
       "updated_at": "2019-12-04T22:05:29+00:00"

--- a/docs/endpoints/group-types.md
+++ b/docs/endpoints/group-types.md
@@ -6,6 +6,8 @@
 GET /api/v3/group-types
 ```
 
+Note: The `filter_by_state` field will soon be removed, deprecated by `filter_by_location`.
+
 Example Response:
 
 ```
@@ -14,6 +16,7 @@ Example Response:
     {
       "id": 1,
       "name": "March For Our Lives",
+      "filter_by_location": false,
       "filter_by_state": false,
       "created_at": "2019-12-04T21:28:26+00:00",
       "updated_at": "2019-12-04T22:33:03+00:00"
@@ -21,6 +24,7 @@ Example Response:
     {
       "id": 2,
       "name": "College Board",
+      "filter_by_location": false,
       "filter_by_state": true,
       "created_at": "2019-12-04T22:05:29+00:00",
       "updated_at": "2019-12-04T22:05:29+00:00"
@@ -53,6 +57,7 @@ Example Response:
   "data": {
     "id": 1,
     "name": "March For Our Lives",
+    "filter_by_location": false,
     "filter_by_state": false,
     "created_at": "2019-12-04T21:28:26+00:00",
     "updated_at": "2019-12-04T22:33:03+00:00"


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `filter_by_location` field, to eventually deprecate the `filter_by_state` field once it's added into GraphQL and Phoenix/Rogue pull from it. Refs renaming the Group `state` field to `location` conversation from  #1079 and #1082.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🪔 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
