### PR TITLE
Filter Action Stats, Groups by location

### DIFF
--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -107,7 +107,7 @@ class ImportNasspGroupsCommand extends Command
 
             try {
                 $city = $this->sanitize($record['city']);
-                $state = $this->sanitize($record['state']);
+                $location = 'US-' . $this->sanitize($record['state']);
                 $schoolId = $this->sanitize($record['universalid']);
 
                 if ($groupTypeId) {
@@ -115,7 +115,7 @@ class ImportNasspGroupsCommand extends Command
                         'group_type_id' => $groupTypeId,
                         'name' => $name,
                         'city' => $city,
-                        'state' => $state,
+                        'location' => $location,
                         'school_id' => $schoolId,
                     ]);
 
@@ -128,7 +128,7 @@ class ImportNasspGroupsCommand extends Command
                     'group_type_id' => $nasspGroupType->id,
                     'name' => $name,
                     'city' => $city,
-                    'state' => $state,
+                    'location' => $location,
                     'school_id' => $schoolId,
                 ]);
 

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -76,19 +76,19 @@ class ImportNasspGroupsCommand extends Command
 
         $nhsGroupType = GroupType::firstOrCreate([
             'name' => 'National Honor Society',
-            'filter_by_state' => true,
+            'filter_by_location' => true,
         ]);
         $njhsGroupType = GroupType::firstOrCreate([
             'name' => 'National Junior Honor Society',
-            'filter_by_state' => true,
+            'filter_by_location' => true,
         ]);
         $nascGroupType = GroupType::firstOrCreate([
             'name' => 'National Student Council',
-            'filter_by_state' => true,
+            'filter_by_location' => true,
         ]);
         $nasspGroupType = GroupType::firstOrCreate([
             'name' => 'National Association of Secondary School Principals',
-            'filter_by_state' => true,
+            'filter_by_location' => true,
         ]);
 
         info('rogue:nassp-groups-import: Beginning import...');

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -107,7 +107,7 @@ class ImportNasspGroupsCommand extends Command
 
             try {
                 $city = $this->sanitize($record['city']);
-                $location = 'US-' . $this->sanitize($record['state']);
+                $location = 'US-'.$this->sanitize($record['state']);
                 $schoolId = $this->sanitize($record['universalid']);
 
                 if ($groupTypeId) {

--- a/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
+++ b/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
@@ -86,7 +86,7 @@ class ImportRhodeIslandGroupsCommand extends Command
                     'group_type_id' => $groupTypeId,
                     'name' => $name,
                     'city' => trim($record['city']),
-                    'state' => trim($record['state']),
+                    'location' => 'US-' . trim($record['state']),
                     'school_id' => $schoolId,
                 ]);
 

--- a/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
+++ b/app/Console/Commands/ImportRhodeIslandGroupsCommand.php
@@ -86,7 +86,7 @@ class ImportRhodeIslandGroupsCommand extends Command
                     'group_type_id' => $groupTypeId,
                     'name' => $name,
                     'city' => trim($record['city']),
-                    'location' => 'US-' . trim($record['state']),
+                    'location' => 'US-'.trim($record['state']),
                     'school_id' => $schoolId,
                 ]);
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -205,7 +205,8 @@ $factory->state(Campaign::class, 'voter-registration', function (Generator $fake
 $factory->define(GroupType::class, function (Generator $faker) {
     return [
         'name' => 'National ' . Str::title($faker->unique()->jobTitle) . ' Society',
-        'filter_by_state' => false,
+        'filter_by_location' => true,
+        'filter_by_state' => true,
     ];
 });
 
@@ -218,6 +219,8 @@ $factory->define(Group::class, function (Generator $faker) {
             return factory(GroupType::class)->create()->id;
         },
         'name' => Str::title($faker->unique()->company),
+        'city' => $faker->city,
+        'location' => 'US-' . $faker->stateAbbr,
     ];
 });
 

--- a/database/migrations/2020_08_06_000100_alter_unique_indexes_on_groups_table.php
+++ b/database/migrations/2020_08_06_000100_alter_unique_indexes_on_groups_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterUniqueIndexesOnGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            // We'll stop populating the state field in imports soon, once we drop this field.
+            $table->dropUnique(['group_type_id', 'name', 'city', 'state']);
+            // Instead we want to make sure location is unique along with group type + name + city.
+            $table->unique(['group_type_id', 'name', 'city', 'location']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropUnique(['group_type_id', 'name', 'city', 'state']);
+            $table->unique(['group_type_id', 'name', 'city', 'location']);
+        });
+    }
+}

--- a/resources/assets/components/ActionStatsTable.js
+++ b/resources/assets/components/ActionStatsTable.js
@@ -26,6 +26,7 @@ const ACTION_STATS_QUERY = gql`
         node {
           id
           impact
+          location
           action {
             id
             name
@@ -37,7 +38,6 @@ const ACTION_STATS_QUERY = gql`
             id
             name
             city
-            state
           }
         }
       }
@@ -55,11 +55,15 @@ const ACTION_STATS_QUERY = gql`
  * @param {Number} actionId
  * @param {String} schoolId
  */
-const ActionStatsTable = ({ actionId, schoolId }) => {
+const ActionStatsTable = ({ actionId, location, schoolId }) => {
   const variables = {};
 
   if (actionId) {
     assign(variables, { actionId });
+  }
+
+  if (location) {
+    assign(variables, { location });
   }
 
   if (schoolId) {
@@ -111,7 +115,7 @@ const ActionStatsTable = ({ actionId, schoolId }) => {
 
         <tbody>
           {stats.map(({ node, cursor }) => {
-            const { action, impact, school } = node;
+            const { action, impact, location, school } = node;
 
             return (
               <tr key={cursor}>
@@ -124,7 +128,7 @@ const ActionStatsTable = ({ actionId, schoolId }) => {
                     />
 
                     <div>
-                      {school.city ? `${school.city}, ${school.state}` : null}
+                      {school.city ? `${school.city}, ${location}` : null}
                     </div>
                   </td>
                 )}

--- a/resources/assets/components/ActionStatsTable.js
+++ b/resources/assets/components/ActionStatsTable.js
@@ -12,6 +12,7 @@ const ACTION_STATS_QUERY = gql`
     $actionId: Int
     $schoolId: String
     $location: String
+    $orderBy: String
     $cursor: String
   ) {
     stats: paginatedSchoolActionStats(
@@ -19,6 +20,7 @@ const ACTION_STATS_QUERY = gql`
       first: 20
       actionId: $actionId
       location: $location
+      orderBy: $orderBy
       schoolId: $schoolId
     ) {
       edges {
@@ -55,7 +57,7 @@ const ACTION_STATS_QUERY = gql`
  * @param {Number} actionId
  * @param {String} schoolId
  */
-const ActionStatsTable = ({ actionId, location, schoolId }) => {
+const ActionStatsTable = ({ actionId, location, orderBy, schoolId }) => {
   const variables = {};
 
   if (actionId) {
@@ -64,6 +66,10 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
 
   if (location) {
     assign(variables, { location });
+  }
+
+  if (orderBy) {
+    assign(variables, { orderBy });
   }
 
   if (schoolId) {

--- a/resources/assets/components/ActionStatsTable.js
+++ b/resources/assets/components/ActionStatsTable.js
@@ -161,6 +161,7 @@ const ActionStatsTable = ({ actionId, location, orderBy, schoolId }) => {
             );
           })}
         </tbody>
+
         <tfoot className="form-actions">
           {loading ? (
             <tr>

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -28,7 +28,7 @@ const GROUPS_QUERY = gql`
           name
           goal
           city
-          state
+          location
         }
       }
       pageInfo {
@@ -49,8 +49,8 @@ const GROUPS_QUERY = gql`
 const GroupsTable = ({ filter, groupLocation, groupTypeId }) => {
   const variables = { filter, groupTypeId };
 
-  if (groupState) {
-    variables.state = groupState;
+  if (groupLocation) {
+    variables.location = groupLocation;
   }
 
   const { error, loading, data, fetchMore } = useQuery(GROUPS_QUERY, {
@@ -106,7 +106,7 @@ const GroupsTable = ({ filter, groupLocation, groupTypeId }) => {
               <td>
                 <EntityLabel id={node.id} name={node.name} path="groups" />
               </td>
-              <td>{node.city ? `${node.city}, ${node.state}` : null}</td>
+              <td>{node.city ? `${node.city}, ${node.location}` : null}</td>
               <td>{node.goal || '-'}</td>
             </tr>
           ))}

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -11,15 +11,15 @@ const GROUPS_QUERY = gql`
   query GroupsIndexQuery(
     $filter: String
     $groupTypeId: Int!
-    $state: String
+    $location: String
     $cursor: String
   ) {
     groups: paginatedGroups(
       after: $cursor
       first: 50
       groupTypeId: $groupTypeId
+      location: $location
       name: $filter
-      state: $state
     ) {
       edges {
         cursor
@@ -43,10 +43,10 @@ const GROUPS_QUERY = gql`
  * This component handles fetching & paginating a list of groups in a group type ID.
  *
  * @param {String} filter
- * @param {String} groupState
+ * @param {String} groupLocation
  * @param {Number} groupTypeId
  */
-const GroupsTable = ({ filter, groupState, groupTypeId }) => {
+const GroupsTable = ({ filter, groupLocation, groupTypeId }) => {
   const variables = { filter, groupTypeId };
 
   if (groupState) {

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -32,7 +32,9 @@ export const TAGS = {
 };
 
 /**
- * Valid locations and their readable names
+ * Returns map of ISO format of all US states, and their readable names.
+ *
+ * @return {Object}
  */
 export const getLocations = () => {
   const result = {};

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -1,5 +1,6 @@
 /* global document */
 
+import { UsaStates } from 'usa-states';
 import { parse, format } from 'date-fns';
 import { isArray, isNull, mergeWith, omitBy } from 'lodash';
 
@@ -28,6 +29,20 @@ export const TAGS = {
   test: 'Test',
   'incomplete-action': 'Incomplete Action',
   bulk: 'Bulk',
+};
+
+/**
+ * Valid locations and their readable names
+ */
+export const getLocations = () => {
+  const result = {};
+  const usaStateOptions = new UsaStates().states;
+
+  usaStateOptions.map(usaState => {
+    result[`US-${usaState.abbreviation}`] = usaState.name;
+  });
+
+  return result;
 };
 
 /**

--- a/resources/assets/pages/ActionStatIndex.js
+++ b/resources/assets/pages/ActionStatIndex.js
@@ -1,16 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
 
+import { getLocations } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import Select from '../components/utilities/Select';
 import ActionStatsTable from '../components/ActionStatsTable';
 
 const ActionStatIndex = () => {
   const title = 'Action Stats';
   document.title = title;
 
+  const [location, setLocation] = useState(null);
+
   return (
     <Shell title={title}>
-      <div className="container__block">
-        <ActionStatsTable />
+      <div className="container__row">
+        <div className="container__block -half">
+          <Select
+            value={location || ''}
+            values={getLocations()}
+            onChange={setLocation}
+          />
+        </div>
+      </div>
+      <div className="container__row">
+        <div className="container__block">
+          <ActionStatsTable location={location} />
+        </div>
       </div>
     </Shell>
   );

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -5,7 +5,9 @@ import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
+import { getLocations } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import Select from '../components/utilities/Select';
 import ActionStatsTable from '../components/ActionStatsTable';
 import Action, { ActionFragment } from '../components/Action';
 import MetaInformation from '../components/utilities/MetaInformation';
@@ -23,6 +25,8 @@ const ShowAction = () => {
   const { id } = useParams();
   const title = `Action #${id}`;
   document.title = title;
+
+  const [location, setLocation] = useState(null);
 
   const { loading, error, data } = useQuery(SHOW_ACTION_QUERY, {
     variables: { id: Number(id) },
@@ -55,8 +59,17 @@ const ShowAction = () => {
       </ul>
 
       <div className="container__row">
+        <div className="container__row">
+          <div className="container__block -half">
+            <Select
+              value={location || ''}
+              values={getLocations()}
+              onChange={setLocation}
+            />
+          </div>
+        </div>
         <div className="container__block">
-          <ActionStatsTable actionId={data.action.id} />
+          <ActionStatsTable actionId={data.action.id} location={location} />
         </div>
       </div>
     </Shell>

--- a/resources/assets/pages/ShowAction.js
+++ b/resources/assets/pages/ShowAction.js
@@ -69,7 +69,11 @@ const ShowAction = () => {
           </div>
         </div>
         <div className="container__block">
-          <ActionStatsTable actionId={data.action.id} location={location} />
+          <ActionStatsTable
+            actionId={data.action.id}
+            location={location}
+            orderBy="impact,desc"
+          />
         </div>
       </div>
     </Shell>

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -13,6 +13,8 @@ import GroupsTable from '../components/GroupsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 import GroupTypeCampaignList from '../components/GroupTypeCampaignList';
 
+// TODO: Use filterByLocation instead of filterByState once available in GraphQL.
+// @see https://github.com/DoSomething/graphql/pull/267
 const SHOW_GROUP_TYPE_QUERY = gql`
   query ShowGroupTypeQuery($id: Int!) {
     groupType(id: $id) {

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -25,7 +25,7 @@ const usaStateOptions = new UsaStates().states;
 
 const ShowGroupType = () => {
   const [filter, setFilter] = useState('');
-  const [groupState, setGroupState] = useState(null);
+  const [groupLocation, setGroupLocation] = useState(null);
 
   const { id } = useParams();
   const title = `Group Type #${id}`;
@@ -61,12 +61,15 @@ const ShowGroupType = () => {
             <div className="mb-4">
               <select
                 className="text-field"
-                onChange={event => setGroupState(event.target.value)}
+                onChange={event => setGroupLocation(event.target.value)}
               >
                 <option value={''}>-- Select State --</option>
 
                 {usaStateOptions.map(state => (
-                  <option key={state.abbreviation} value={state.abbreviation}>
+                  <option
+                    key={state.abbreviation}
+                    value={`US-${state.abbreviation}`}
+                  >
                     {state.name}
                   </option>
                 ))}
@@ -91,7 +94,7 @@ const ShowGroupType = () => {
         <div className="container__block">
           <GroupsTable
             filter={filter}
-            groupState={groupState}
+            groupLocation={groupLocation}
             groupTypeId={Number(id)}
           />
 

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -13,13 +13,11 @@ import GroupsTable from '../components/GroupsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 import GroupTypeCampaignList from '../components/GroupTypeCampaignList';
 
-// TODO: Use filterByLocation instead of filterByState once available in GraphQL.
-// @see https://github.com/DoSomething/graphql/pull/267
 const SHOW_GROUP_TYPE_QUERY = gql`
   query ShowGroupTypeQuery($id: Int!) {
     groupType(id: $id) {
       createdAt
-      filterByState
+      filterByLocation
       name
     }
   }
@@ -49,7 +47,7 @@ const ShowGroupType = () => {
 
   if (!data.groupType) return <NotFound title={title} type="group type" />;
 
-  const { createdAt, filterByState, name } = data.groupType;
+  const { createdAt, filterByLocation, name } = data.groupType;
 
   return (
     <Shell title={title} subtitle={name}>
@@ -61,7 +59,7 @@ const ShowGroupType = () => {
             }}
           />
 
-          {filterByState ? (
+          {filterByLocation ? (
             <div className="mb-4">
               <Select
                 value={groupLocation || ''}

--- a/resources/assets/pages/ShowGroupType.js
+++ b/resources/assets/pages/ShowGroupType.js
@@ -6,7 +6,9 @@ import { useQuery } from '@apollo/react-hooks';
 
 import NotFound from './NotFound';
 import Empty from '../components/Empty';
+import { getLocations } from '../helpers';
 import Shell from '../components/utilities/Shell';
+import Select from '../components/utilities/Select';
 import GroupsTable from '../components/GroupsTable';
 import MetaInformation from '../components/utilities/MetaInformation';
 import GroupTypeCampaignList from '../components/GroupTypeCampaignList';
@@ -59,21 +61,11 @@ const ShowGroupType = () => {
 
           {filterByState ? (
             <div className="mb-4">
-              <select
-                className="text-field"
-                onChange={event => setGroupLocation(event.target.value)}
-              >
-                <option value={''}>-- Select State --</option>
-
-                {usaStateOptions.map(state => (
-                  <option
-                    key={state.abbreviation}
-                    value={`US-${state.abbreviation}`}
-                  >
-                    {state.name}
-                  </option>
-                ))}
-              </select>
+              <Select
+                value={groupLocation || ''}
+                values={getLocations()}
+                onChange={setGroupLocation}
+              />
             </div>
           ) : null}
 

--- a/tests/Console/ImportNasspGroupsCommandTest.php
+++ b/tests/Console/ImportNasspGroupsCommandTest.php
@@ -46,14 +46,14 @@ class ImportNasspGroupsCommandTest extends TestCase
             'name' => $groupName,
             'group_type_id' => $nhsGroupTypeId,
             'city' => 'Bayard',
-            'state' => 'NM',
+            'location' => 'US-NM',
             'school_id' => '3500277',
         ]);
         $this->assertDatabaseHas('groups', [
             'name' => $groupName,
             'group_type_id' => $nasspGroupTypeId,
             'city' => 'Bayard',
-            'state' => 'NM',
+            'location' => 'US-NM',
             'school_id' => '3500277',
         ]);
         $this->assertDatabaseMissing('groups', [
@@ -72,21 +72,21 @@ class ImportNasspGroupsCommandTest extends TestCase
             'name' => $groupName,
             'group_type_id' => $nasspGroupTypeId,
             'city' => 'Scio',
-            'state' => 'NY',
+            'location' => 'US-NY',
             'school_id' => '3603585',
         ]);
         $this->assertDatabaseHas('groups', [
             'name' => $groupName,
             'group_type_id' => $nhsGroupTypeId,
             'city' => 'Scio',
-            'state' => 'NY',
+            'location' => 'US-NY',
             'school_id' => '3603585',
         ]);
         $this->assertDatabaseHas('groups', [
             'name' => $groupName,
             'group_type_id' => $njhsGroupTypeId,
             'city' => 'Scio',
-            'state' => 'NY',
+            'location' => 'US-NY',
             'school_id' => '3603585',
         ]);
         $this->assertDatabaseMissing('groups', [

--- a/tests/Console/ImportRhodeIslandGroupsCommandTest.php
+++ b/tests/Console/ImportRhodeIslandGroupsCommandTest.php
@@ -24,14 +24,14 @@ class ImportRhodeIslandGroupsCommandTest extends TestCase
             'name' => 'Veazie Street School',
             'group_type_id' => $groupTypeId,
             'city' => 'Providence',
-            'state' => 'RI',
+            'location' => 'US-RI',
             'school_id' => '4400192',
         ]);
         $this->assertDatabaseHas('groups', [
             'name' => 'Portsmouth High School',
             'group_type_id' => $groupTypeId,
             'city' => 'Portsmouth',
-            'state' => 'RI',
+            'location' => 'US-RI',
             'school_id' => '4400190',
         ]);
         // This row was a duplicate name/city/state with school_id 4400190.


### PR DESCRIPTION
### What's this PR do?

This pull request adds a filter to the `ActionStatsTable` component to allow filtering by `location`, and modifies the `GroupsTable` component to filter by `location` (instead of `state` -- which we'll soon drop as a column completely once we make the same corresponding changes in the [Phoenix Group Finder](https://github.com/DoSomething/phoenix-next/blob/5673c030db0525da0ee0639ad037bc7b5a83955e/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js#L15)).

It also adds some cleanup around migrating from the `state` to `location` field:

* Modifies the NASSP and RIDE imports to populate `location` and `filter_by_location` instead of `state` and `filter_by_state`, should we ever need to run those imports again (I do often for database seeding / local testing)

* Modifies the `groups` table to have a unique index on group type + name + city + location (missed this in #1082)

* Modifies the `Group` factory to populate with a location, so that running the `VoterRegistrationSeeder` (#1086) will generate action stats with valid `location` values and allow filtering by location.

* Uses `GroupType.filterByLocation` instead of `filterByState` (refs https://github.com/DoSomething/graphql/pull/267)

### How should this be reviewed?

👀 

From the `/actions/:id` page, for action created in #1086:

<img src="https://user-images.githubusercontent.com/1236811/89592431-75bb5680-d801-11ea-87e6-3e3fd58e655d.png">

### Any background context you want to provide?

🍁 

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
