### PR TITLE
Fixes exception if campaign doens't have a website.

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -3,6 +3,7 @@
 namespace Rogue\Models;
 
 use Hashids\Hashids;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Rogue\Services\GraphQL;
 use Rogue\Models\Traits\HasCursor;
@@ -350,8 +351,8 @@ class Post extends Model
             'why_participated' => $this->signup->why_participated,
             'campaign_id' => (string) $this->campaign_id,
             'campaign_run_id' => (string) $this->signup->campaign_run_id,
-            'campaign_title' => $campaignWebsite['title'],
-            'campaign_slug' => $campaignWebsite['slug'],
+            'campaign_title' => Arr::get($campaignWebsite, 'title'),
+            'campaign_slug' => Arr::get($campaignWebsite, 'slug'),
             'campaign_cause' => $campaign_cause,
             'northstar_id' => $this->northstar_id,
             'type' => $this->type,


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an exception thrown if a campaign doesn't have a website configured:

```
production.ERROR: Trying to access array offset on value of type null {"exception":"[object] (ErrorException(code: 0): Trying to access array offset on value of type null at /app/app/Models/Post.php:353)
```

This is happening because the campaign these posts are created for doesn't have a website, and so it's trying to read a property `'title'` and `'slug'` off of a null response from `campaignWebsiteByCampaignId`.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is due to the [new way PHP 7.4 treats array-access on null](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.non-array-access).

### Relevant tickets

References [Pivotal #173629223](https://www.pivotaltracker.com/story/show/173629223).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
