### PR TITLE
Fix two more places where a query may return null.

### DIFF
--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -256,9 +256,9 @@ class Signup extends Model
         return [
             'id' => $this->id,
             'user_id' => $userId,
-            'user_display_name' => isset($user) ? $user['displayName'] : null,
+            'user_display_name' => Arr::get($user, 'displayName'),
             'campaign_id' => (string) $this->campaign_id,
-            'campaign_title' => isset($campaignWebsite) ? $campaignWebsite['title'] : null,
+            'campaign_title' => Arr::get($campaignWebsite, 'title'),
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #1096 with another two spots where a GraphQL query may return null (and thus trying to access one of the properties from the query response would [now explode](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.non-array-access)).

### How should this be reviewed?

👀

### Any background context you want to provide?

❗

### Relevant tickets

References [Pivotal #173629223](https://www.pivotaltracker.com/story/show/173629223).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
