### PR TITLE
Change Group page/form to view/edit location instead of state

### DIFF
--- a/resources/assets/pages/ShowGroup.js
+++ b/resources/assets/pages/ShowGroup.js
@@ -24,7 +24,7 @@ const SHOW_GROUP_QUERY = gql`
       }
       name
       schoolId
-      state
+      location
     }
     voterRegistrationsCountByGroupId(groupId: $id)
   }
@@ -52,7 +52,7 @@ const ShowGroup = ({ selectedTab }) => {
 
   if (!data.group) return <NotFound title={title} type="group" />;
 
-  const { city, goal, groupType, name, schoolId, state } = data.group;
+  const { city, goal, groupType, name, schoolId, location } = data.group;
 
   return (
     <Shell title={title} subtitle={`${name} (${groupType.name})`}>
@@ -64,7 +64,7 @@ const ShowGroup = ({ selectedTab }) => {
               'Voter Registrations Completed':
                 data.voterRegistrationsCountByGroupId,
               City: city || '--',
-              State: state || '--',
+              Location: location || '--',
               School: schoolId ? (
                 <Link to={`/schools/${schoolId}`}>{schoolId}</Link>
               ) : (

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -29,8 +29,8 @@
                     </div>
 
                     <div class="form-item">
-                        <label class="field-label">State</label>
-                        @include('forms.text', ['name' => 'state', 'placeholder' => ' e.g. TX'])
+                        <label class="field-label">State</Location>
+                        @include('forms.text', ['name' => 'location', 'placeholder' => ' e.g. US-TX'])
                     </div>
 
                     <div class="form-item">

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -29,7 +29,7 @@
                     </div>
 
                     <div class="form-item">
-                        <label class="field-label">State</Location>
+                        <label class="field-label">Location</label>
                         @include('forms.text', ['name' => 'location', 'placeholder' => ' e.g. US-TX'])
                     </div>
 

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -30,8 +30,8 @@
                     </div>
 
                     <div class="form-item">
-                        <label class="field-label">State</label>
-                        @include('forms.text', ['name' => 'state', 'placeholder' => ' e.g. TX', 'value' => $group->state])
+                        <label class="field-label">Location</label>
+                        @include('forms.text', ['name' => 'location', 'placeholder' => ' e.g. US-TX', 'value' => $group->location])
                     </div>
 
                     <div class="form-item">


### PR DESCRIPTION
### What's this PR do?

This pull request makes the `location` field editable instead of `state` on the Group create/edit form, since our Group Finder now queries by `location` instead of `state` as of https://github.com/DoSomething/phoenix-next/pull/2324.

I didn't realize admins are adding new groups, but they do. And as of  https://github.com/DoSomething/phoenix-next/pull/2324., those new groups won't show up in the group finder because we need `location` populated instead of `state` (which is so close to being deprecated/dropped)

### How should this be reviewed?

👀 

### Any background context you want to provide?

📬 

### Relevant tickets

References [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1597349671361400), [#174327055](https://www.pivotaltracker.com/n/projects/2417735/stories/174327055)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
