### PR TITLE
Fixing setup command.

### DIFF
--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -51,10 +51,13 @@ class SetupCommand extends Command
             $this->setEnvironmentVariable('NORTHSTAR_CLIENT_SECRET', 'Enter the OAuth Client Secret for machine requests');
         });
 
-        $this->runCommand('key:generate', 'Creating application key');
+        $this->line('Creating application key');
+        $this->call('key:generate');
 
-        $this->runCommand('gateway:key', 'Fetching public key from Northstar');
+        $this->line('Fetching public key from Northstar');
+        $this->call('gateway:key');
 
-        $this->runCommand('migrate', 'Running database migrations');
+        $this->line('Running database migrations');
+        $this->call('migrate');
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `SetupCommand()` to fix an issue I ran into when running `php artisan rogue:setup` after a complete reset of my Homestead.

<img width="972" alt="Console Error" src="https://user-images.githubusercontent.com/105849/90324737-7f029c80-df40-11ea-85c6-612964e64c24.png">

Seems like the signature of the `runCommand()` has changed and now requires passing a class that implements the `OutputInterface` as the third argument.

I figured the simplest way to resolve this would be to use the `call()` command before hand and precede it with calling the `line()` command to write the message to the console.

### How should this be reviewed?

👀 

### Any background context you want to provide?

It may be that we'll need to update the other projects that have their own Artisan `setup` command, since they likely also call the `runCommand()` as well.

### Relevant tickets

🌵 

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
