### PR TITLE
Clubs Create & Edit Web Forms 

### DIFF
--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -4,6 +4,7 @@ namespace Rogue\Http\Controllers\Web;
 
 use Rogue\Models\Club;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Rogue\Http\Controllers\Controller;
 
 class ClubsController extends Controller
@@ -18,7 +19,6 @@ class ClubsController extends Controller
 
         $this->rules = [
             'name' => 'required|string|max:255',
-            'leader_id' => 'required|objectid|unique:clubs',
             'city' => 'nullable|string',
             'location' => 'nullable|iso3166',
             'school_id' => 'nullable|string|max:255',
@@ -40,7 +40,9 @@ class ClubsController extends Controller
      */
     public function store(Request $request)
     {
-        $this->validate($request, $this->rules);
+        $this->validate($request, array_merge_recursive($this->rules, [
+            'leader_id' => 'required|objectid|unique:clubs',
+        ]));
 
         $club = Club::create($request->all());
 
@@ -70,7 +72,9 @@ class ClubsController extends Controller
      */
     public function update(Club $club, Request $request)
     {
-        $this->validate($request, $this->rules);
+        $this->validate($request, array_merge_recursive($this->rules, [
+            'leader_id' => [ 'required', 'objectid', Rule::unique('clubs')->ignore($club) ],
+        ]));
 
         $club->update($request->all());
 

--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -45,7 +45,7 @@ class ClubsController extends Controller
         $club = Club::create($request->all());
 
         // Log that a club was created.
-        info('club', ['id' => $club->id]);
+        info('club_created', ['id' => $club->id]);
 
         return redirect('clubs/'. $club->id .'/edit')->with('status', 'Club successfully created!');
     }

--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -4,7 +4,6 @@ namespace Rogue\Http\Controllers\Web;
 
 use Rogue\Models\Club;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Rogue\Http\Controllers\Controller;
 
 class ClubsController extends Controller

--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -18,7 +18,7 @@ class ClubsController extends Controller
 
         $this->rules = [
             'name' => 'required|string|max:255',
-            'leader_id' => 'required|objectid',
+            'leader_id' => 'required|objectid|unique:clubs',
             'city' => 'nullable|string',
             'location' => 'nullable|iso3166',
             'school_id' => 'nullable|string|max:255',

--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Rogue\Http\Controllers\Web;
+
+use Rogue\Models\Club;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Rogue\Http\Controllers\Controller;
+
+class ClubsController extends Controller
+{
+    /**
+     * Create a controller instance.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('role:admin,staff');
+
+        $this->rules = [
+            'name' => 'required|string|max:255',
+            'leader_id' => 'required|objectid',
+            'city' => 'nullable|string',
+            'location' => 'nullable|iso3166',
+            'school_id' => 'nullable|string|max:255',
+        ];
+    }
+
+    /**
+     * Create a new club.
+     */
+    public function create()
+    {
+        return view('clubs.create');
+    }
+
+    /**
+     * Store a newly created club in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function store(Request $request)
+    {
+        $this->validate($request, $this->rules);
+
+        $club = Club::create($request->all());
+
+        // Log that a club was created.
+        info('club', ['id' => $club->id]);
+
+        return redirect('clubs/'. $club->id .'/edit')->with('status', 'Club successfully created!');
+    }
+
+    /**
+     * Edit an existing club.
+     *
+     * @param  \Rogue\Models\Club  $club
+     */
+    public function edit(Club $club)
+    {
+        return view('clubs.edit')->with([
+            'club' => $club,
+        ]);
+    }
+
+    /**
+     * Update the specified club in storage.
+     *
+     * @param  \Rogue\Models\Club  $club
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function update(Club $club, Request $request)
+    {
+        $this->validate($request, $this->rules);
+
+        $club->update($request->all());
+
+        // Log that a club was updated.
+        info('club_updated', ['id' => $club->id]);
+
+        return redirect()->back()->with('status', 'Club successfully updated!');
+    }
+}

--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -2,10 +2,10 @@
 
 namespace Rogue\Http\Controllers\Web;
 
-use Rogue\Models\Club;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Rogue\Http\Controllers\Controller;
+use Rogue\Models\Club;
 
 class ClubsController extends Controller
 {
@@ -40,16 +40,22 @@ class ClubsController extends Controller
      */
     public function store(Request $request)
     {
-        $this->validate($request, array_merge_recursive($this->rules, [
-            'leader_id' => 'required|objectid|unique:clubs',
-        ]));
+        $this->validate(
+            $request,
+            array_merge_recursive($this->rules, [
+                'leader_id' => 'required|objectid|unique:clubs',
+            ]),
+        );
 
         $club = Club::create($request->all());
 
         // Log that a club was created.
         info('club_created', ['id' => $club->id]);
 
-        return redirect('clubs/'. $club->id .'/edit')->with('status', 'Club successfully created!');
+        return redirect('clubs/' . $club->id . '/edit')->with(
+            'status',
+            'Club successfully created!',
+        );
     }
 
     /**
@@ -72,15 +78,24 @@ class ClubsController extends Controller
      */
     public function update(Club $club, Request $request)
     {
-        $this->validate($request, array_merge_recursive($this->rules, [
-            'leader_id' => [ 'required', 'objectid', Rule::unique('clubs')->ignore($club) ],
-        ]));
+        $this->validate(
+            $request,
+            array_merge_recursive($this->rules, [
+                'leader_id' => [
+                    'required',
+                    'objectid',
+                    Rule::unique('clubs')->ignore($club),
+                ],
+            ]),
+        );
 
         $club->update($request->all());
 
         // Log that a club was updated.
         info('club_updated', ['id' => $club->id]);
 
-        return redirect()->back()->with('status', 'Club successfully updated!');
+        return redirect()
+            ->back()
+            ->with('status', 'Club successfully updated!');
     }
 }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -6,6 +6,7 @@ use Faker\Generator;
 use Illuminate\Support\Str;
 use Rogue\Models\Action;
 use Rogue\Models\Campaign;
+use Rogue\Models\Club;
 use Rogue\Models\Group;
 use Rogue\Models\GroupType;
 use Rogue\Models\Post;
@@ -249,5 +250,16 @@ $factory->state(Group::class, 'school', function (Generator $faker) {
         'city' => $school->city,
         'location' => $school->location,
         'school_id' => $school->school_id,
+    ];
+});
+
+// Club Factory
+$factory->define(Club::class, function (Generator $faker) {
+    return [
+        'leader_id' => $this->faker->unique()->northstar_id,
+        'name' => Str::title($faker->company),
+        'city' => $faker->city,
+        'location' => 'US-' . $faker->stateAbbr,
+        'school_id' => $faker->school->school_id,
     ];
 });

--- a/resources/views/clubs/create.blade.php
+++ b/resources/views/clubs/create.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header', ['header' => 'New Club'])
+
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <form method="POST" action="{{ route('clubs.store') }}">
+                    {{ csrf_field()}}
+
+                    <div class="form-item">
+                        <label class="field-label">Name</label>
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Club name, e.g. DS Staffers DoSomething Club'])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Leader ID</label>
+                        @include('forms.text', ['name' => 'leader_id', 'placeholder' => 'The Club Leader\'s Northstar ID'])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">City</label>
+                        @include('forms.text', ['name' => 'city', 'placeholder' => ' e.g. San Antonio'])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Location</label>
+                        @include('forms.text', ['name' => 'location', 'placeholder' => ' e.g. US-TX'])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">School ID</label>
+                        @include('forms.text', ['name' => 'school_id', 'placeholder' => 'The school universal ID associated with this club'])
+                    </div>
+
+                    <ul class="form-actions -inline -padded">
+                        <li><input type="submit" class="button" value="Create Club"></li>
+                    </ul>
+                </form>
+            </div>
+        </div>
+    </div>
+
+@stop

--- a/resources/views/clubs/edit.blade.php
+++ b/resources/views/clubs/edit.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.master')
+
+@section('main_content')
+
+    @include('layouts.header', ['header' => 'Edit Club'])
+
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <form method="POST" action="{{ route('clubs.update', $club->id) }}">
+                    {{ csrf_field()}}
+                    {{ method_field('PATCH') }}
+
+                    <div class="form-item">
+                        <label class="field-label">Name</label>
+                        @include('forms.text', ['name' => 'name', 'placeholder' => 'Club name, e.g. DS Staffers DoSomething Club', 'value' => $club->name])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Leader ID</label>
+                        @include('forms.text', ['name' => 'leader_id', 'placeholder' => 'The Club Leader\'s Northstar ID', 'value' => $club->leader_id])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">City</label>
+                        @include('forms.text', ['name' => 'city', 'placeholder' => ' e.g. San Antonio', 'value' => $club->city])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">Location</label>
+                        @include('forms.text', ['name' => 'location', 'placeholder' => ' e.g. US-TX', 'value' => $club->location])
+                    </div>
+
+                    <div class="form-item">
+                        <label class="field-label">School ID</label>
+                        @include('forms.text', ['name' => 'school_id', 'placeholder' => 'The school universal ID associated with this club', 'value' => $club->school_id])
+                    </div>
+
+
+                    <ul class="form-actions -inline -padded">
+                        <li><input type="submit" class="button" value="Update Club"></li>
+                    </ul>
+                </form>
+            </div>
+        </div>
+    </div>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::get('group-types/{id}/groups/create', 'GroupsController@create');
 Route::resource('groups', 'GroupsController', [
     'except' => ['create', 'index', 'show'],
 ]);
+Route::resource('clubs', 'ClubsController', ['except' => ['index', 'show', 'destroy']]);
 
 // Client-side routes:
 Route::middleware(['auth', 'role:staff,admin'])->group(function () {

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -70,6 +70,21 @@ class ClubTest extends TestCase
     }
 
     /**
+     * test validation for creating a club with a duplicate leader_id.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testCreatingAClubWithDuplicateLeaderId()
+    {
+        $club = factory(Club::class)->create();
+
+        $this->actingAsAdmin()
+            ->postJson('clubs', ['name' => $this->faker->company, 'leader_id' => $club->leaderId])
+            ->assertJsonValidationErrors(['leader_id']);
+    }
+
+    /**
      * Test for updating a club successfully.
      *
      * PATCH /clubs/:id

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -119,6 +119,39 @@ class ClubTest extends TestCase
     }
 
     /**
+     * Test for updating a club without changing the leader_id successfully.
+     *
+     * PATCH /clubs/:id
+     * @return void
+     */
+    public function testUpdatingAClubWithoutChangingTheLeaderId()
+    {
+        $club = factory(Club::class)->create();
+
+        $name = $this->faker->company;
+        $location = 'US-' . $this->faker->stateAbbr;
+        $city = $this->faker->city;
+        $schooolId = $this->faker->school->school_id;
+
+        $response = $this->actingAsAdmin()->patchJson('clubs/' . $club->id, [
+            'name' => $name,
+            'leader_id' => $club->leader_id,
+            'location' => $location,
+            'city' => $city,
+            'school_id' => $schooolId,
+        ]);
+
+        $response->assertStatus(302);
+
+        // Make sure that the clubt's updated attributes are persisted in the database.
+        $this->assertEquals($club->fresh()->name, $name);
+        $this->assertEquals($club->fresh()->leader_id, $leaderId);
+        $this->assertEquals($club->fresh()->location, $location);
+        $this->assertEquals($club->fresh()->city, $city);
+        $this->assertEquals($club->fresh()->school_id, $schooolId);
+    }
+
+    /**
      * test validation for updating a club.
      *
      * PATCH /clubs/:id

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http\Web;
 
-use Tests\TestCase;
 use Rogue\Models\Club;
+use Tests\TestCase;
 
 class ClubTest extends TestCase
 {
@@ -68,7 +68,14 @@ class ClubTest extends TestCase
                 'location' => 'wakanda', // This should be an iso3166 string.
                 'city' => 789, // This should be a string.
                 'school_id' => 101112, // This should be a string.
-            ])->assertJsonValidationErrors(['name', 'leader_id', 'location', 'city', 'school_id']);
+            ])
+            ->assertJsonValidationErrors([
+                'name',
+                'leader_id',
+                'location',
+                'city',
+                'school_id',
+            ]);
     }
 
     /**
@@ -82,7 +89,10 @@ class ClubTest extends TestCase
         $club = factory(Club::class)->create();
 
         $this->actingAsAdmin()
-            ->postJson('clubs', ['name' => $this->faker->company, 'leader_id' => $club->leaderId])
+            ->postJson('clubs', [
+                'name' => $this->faker->company,
+                'leader_id' => $club->leaderId,
+            ])
             ->assertJsonValidationErrors(['leader_id']);
     }
 
@@ -161,6 +171,13 @@ class ClubTest extends TestCase
                 'location' => 'wakanda', // This should be an iso3166 string.
                 'city' => 789, // This should be a string.
                 'school_id' => 101112, // This should be a string.
-            ])->assertJsonValidationErrors(['name', 'leader_id', 'location', 'city', 'school_id']);
+            ])
+            ->assertJsonValidationErrors([
+                'name',
+                'leader_id',
+                'location',
+                'city',
+                'school_id',
+            ]);
     }
 }

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -23,6 +23,7 @@ class ClubTest extends TestCase
             ->postJson('clubs', ['name' => $name, 'leader_id' => $leaderId])
             ->assertStatus(302);
 
+        // Make sure the club is persisted in the database.
         $this->assertDatabaseHas('clubs', [
             'name' => $name,
             'leader_id' => $leaderId,
@@ -45,6 +46,7 @@ class ClubTest extends TestCase
             ->postJson('clubs', ['name' => $name, 'leader_id' => $leaderId])
             ->assertStatus(302);
 
+        // Make sure the club is persisted in the database.
         $this->assertDatabaseHas('clubs', [
             'name' => $name,
             'leader_id' => $leaderId,
@@ -110,7 +112,7 @@ class ClubTest extends TestCase
 
         $response->assertStatus(302);
 
-        // Make sure that the clubt's updated attributes are persisted in the database.
+        // Make sure that the club's updated attributes are persisted in the database.
         $this->assertEquals($club->fresh()->name, $name);
         $this->assertEquals($club->fresh()->leader_id, $leaderId);
         $this->assertEquals($club->fresh()->location, $location);
@@ -137,7 +139,7 @@ class ClubTest extends TestCase
 
         $response->assertStatus(302);
 
-        // Make sure that the clubt's updated attributes are persisted in the database.
+        // Make sure that the club's updated attributes are persisted in the database.
         $this->assertEquals($club->fresh()->name, $name);
         $this->assertEquals($club->fresh()->leader_id, $club->leader_id);
     }

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -8,7 +8,7 @@ use Rogue\Models\Club;
 class ClubTest extends TestCase
 {
     /**
-     * test that admin can create a new club.
+     * Test that admin can create a new club.
      *
      * POST /clubs
      * @return void
@@ -30,7 +30,7 @@ class ClubTest extends TestCase
     }
 
     /**
-     * test that staff can create a new club.
+     * Test that staff can create a new club.
      *
      * POST /clubs
      * @return void
@@ -52,7 +52,7 @@ class ClubTest extends TestCase
     }
 
     /**
-     * test validation for creating a club.
+     * Test validation for creating a club.
      *
      * POST /clubs
      * @return void

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -69,7 +69,6 @@ class ClubTest extends TestCase
             ])->assertJsonValidationErrors(['name', 'leader_id', 'location', 'city', 'school_id']);
     }
 
-
     /**
      * Test for updating a club successfully.
      *

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Http\Web;
+
+use Tests\TestCase;
+use Rogue\Models\Club;
+
+class ClubTest extends TestCase
+{
+    /**
+     * test that admin can create a new club.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testAdminCanCreateClub()
+    {
+        $name = $this->faker->sentence;
+        $leaderId = $this->faker->unique()->northstar_id;
+
+        // Verify redirected to new resource.
+        $this->actingAsAdmin()
+            ->postJson('clubs', ['name' => $name, 'leader_id' => $leaderId])
+            ->assertStatus(302);
+
+        $this->assertDatabaseHas('clubs', [
+            'name' => $name,
+            'leader_id' => $leaderId,
+        ]);
+    }
+
+    /**
+     * test that staff can create a new club.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testStaffCanCreateClub()
+    {
+        $name = $this->faker->sentence;
+        $leaderId = $this->faker->unique()->northstar_id;
+
+        // Verify redirected to new resource.
+        $this->actingAsStaff()
+            ->postJson('clubs', ['name' => $name, 'leader_id' => $leaderId])
+            ->assertStatus(302);
+
+        $this->assertDatabaseHas('clubs', [
+            'name' => $name,
+            'leader_id' => $leaderId,
+        ]);
+    }
+
+    /**
+     * test validation for creating a club.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testCreatingAClubWithValidationErrors()
+    {
+        $this->actingAsAdmin()
+            ->postJson('clubs', [
+                'name' => 123, // This should be a string.
+                'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.
+                'location' => 'wakanda', // This should be an iso3166 string.
+                'city' => 789, // This should be a string.
+                'school_id' => 101112, // This should be a string.
+            ])->assertJsonValidationErrors(['name', 'leader_id', 'location', 'city', 'school_id']);
+    }
+
+
+    /**
+     * Test for updating a club successfully.
+     *
+     * PATCH /clubs/:id
+     * @return void
+     */
+    public function testUpdatingAClub()
+    {
+        $club = factory(Club::class)->create();
+
+        $name = $this->faker->company;
+        $leaderId = $this->faker->unique()->northstar_id;
+        $location = 'US-' . $this->faker->stateAbbr;
+        $city = $this->faker->city;
+        $schooolId = $this->faker->school->school_id;
+
+        $response = $this->actingAsAdmin()->patchJson('clubs/' . $club->id, [
+            'name' => $name,
+            'leader_id' => $leaderId,
+            'location' => $location,
+            'city' => $city,
+            'school_id' => $schooolId,
+        ]);
+
+        $response->assertStatus(302);
+
+        // Make sure that the clubt's updated attributes are persisted in the database.
+        $this->assertEquals($club->fresh()->name, $name);
+        $this->assertEquals($club->fresh()->leader_id, $leaderId);
+        $this->assertEquals($club->fresh()->location, $location);
+        $this->assertEquals($club->fresh()->city, $city);
+        $this->assertEquals($club->fresh()->school_id, $schooolId);
+    }
+
+    /**
+     * test validation for updating a club.
+     *
+     * PATCH /clubs/:id
+     * @return void
+     */
+    public function testUpdatingAClubWithValidationErrors()
+    {
+        $club = factory(Club::class)->create();
+
+        $this->actingAsAdmin()
+            ->patchJson('clubs/' . $club->id, [
+                'name' => 123, // This should be a string.
+                'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.
+                'location' => 'wakanda', // This should be an iso3166 string.
+                'city' => 789, // This should be a string.
+                'school_id' => 101112, // This should be a string.
+            ])->assertJsonValidationErrors(['name', 'leader_id', 'location', 'city', 'school_id']);
+    }
+}

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -129,26 +129,17 @@ class ClubTest extends TestCase
         $club = factory(Club::class)->create();
 
         $name = $this->faker->company;
-        $location = 'US-' . $this->faker->stateAbbr;
-        $city = $this->faker->city;
-        $schooolId = $this->faker->school->school_id;
 
         $response = $this->actingAsAdmin()->patchJson('clubs/' . $club->id, [
             'name' => $name,
             'leader_id' => $club->leader_id,
-            'location' => $location,
-            'city' => $city,
-            'school_id' => $schooolId,
         ]);
 
         $response->assertStatus(302);
 
         // Make sure that the clubt's updated attributes are persisted in the database.
         $this->assertEquals($club->fresh()->name, $name);
-        $this->assertEquals($club->fresh()->leader_id, $leaderId);
-        $this->assertEquals($club->fresh()->location, $location);
-        $this->assertEquals($club->fresh()->city, $city);
-        $this->assertEquals($club->fresh()->school_id, $schooolId);
+        $this->assertEquals($club->fresh()->leader_id, $club->leader_id);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds create/edit forms for clubs for admins and staff.

### How should this be reviewed?
commit-by-commit if helpful. I tried to follow by example from existing work, but 👀  if I missed anything!

### Any background context you want to provide?
We still don't have the show/index pages ([#174301487](https://www.pivotaltracker.com/story/show/174301487)) since we postponed that work to post-launch. So we simply redirect to the edit page with a flash message upon successful form submission.

We don't seem to have a consistent standard for testing these so I tried to copy from the tests in [`GroupTest`](https://github.com/DoSomething/rogue/blob/0974d680e5c89e44cd805a61d22b8a01514e0060/tests/Http/Web/GroupTest.php#L1) & [`PostTest`](https://github.com/DoSomething/rogue/blob/0974d680e5c89e44cd805a61d22b8a01514e0060/tests/Http/PostTest.php#L1) for a relatively comprehensive suite.

I had to do the ole override per https://github.com/DoSomething/rogue/pull/1030#discussion_r434628475 for the uniqueness clause on the `leader_id` in https://github.com/DoSomething/rogue/commit/02c3c2be6b5a9e16f8d067a89414ab4d81aa2511

### Relevant tickets

References [Pivotal #174307528](https://www.pivotaltracker.com/story/show/174307528).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/90908380-4d575e80-e3a2-11ea-807d-f58e733b3765.png)

![image](https://user-images.githubusercontent.com/12417657/90908404-53e5d600-e3a2-11ea-87cf-91819b38cded.png)
