### PR TITLE
Drop deprecated state and filter_by_state fields

### DIFF
--- a/app/Http/Controllers/Web/GroupTypesController.php
+++ b/app/Http/Controllers/Web/GroupTypesController.php
@@ -44,7 +44,7 @@ class GroupTypesController extends Controller
             ]),
         );
         // @see ActionsController->fillInOmittedCheckboxes
-        $values['filter_by_state'] = $request->has('filter_by_state');
+        $values['filter_by_location'] = $request->has('filter_by_location');
 
         $groupType = GroupType::create($values);
 
@@ -81,7 +81,7 @@ class GroupTypesController extends Controller
             ]),
         );
         // @see ActionsController->fillInOmittedCheckboxes
-        $values['filter_by_state'] = $request->has('filter_by_state');
+        $values['filter_by_location'] = $request->has('filter_by_location');
 
         $groupType->update($values);
 

--- a/app/Http/Transformers/GroupTransformer.php
+++ b/app/Http/Transformers/GroupTransformer.php
@@ -20,7 +20,6 @@ class GroupTransformer extends TransformerAbstract
             'group_type_id' => $group->group_type_id,
             'name' => $group->name,
             'city' => $group->city,
-            'state' => $group->state,
             'location' => $group->location,
             'school_id' => $group->school_id,
             'goal' => $group->goal,

--- a/app/Http/Transformers/GroupTypeTransformer.php
+++ b/app/Http/Transformers/GroupTypeTransformer.php
@@ -19,7 +19,6 @@ class GroupTypeTransformer extends TransformerAbstract
             'id' => $groupType->id,
             'name' => $groupType->name,
             'filter_by_location' => $groupType->filter_by_location,
-            'filter_by_state' => $groupType->filter_by_state,
             'created_at' => $groupType->created_at->toIso8601String(),
             'updated_at' => $groupType->updated_at->toIso8601String(),
         ];

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -21,7 +21,6 @@ class Group extends Model
         'location',
         'name',
         'school_id',
-        'state',
     ];
 
     /**
@@ -32,13 +31,7 @@ class Group extends Model
      *
      * @var array
      */
-    public static $indexes = [
-        'group_type_id',
-        'id',
-        'location',
-        'school_id',
-        'state',
-    ];
+    public static $indexes = ['group_type_id', 'id', 'location', 'school_id'];
 
     /**
      * Attributes that we can sort by with the '?orderBy' query parameter.

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -14,8 +14,6 @@ class GroupType extends Model
      */
     protected $casts = [
         'filter_by_location' => 'boolean',
-        // This field will eventually be deprecated by filter_by_location.
-        'filter_by_state' => 'boolean',
     ];
 
     /**
@@ -23,12 +21,7 @@ class GroupType extends Model
      *
      * @var array
      */
-    protected $fillable = [
-        'filter_by_location',
-        // This field will eventually be deprecated by filter_by_location.
-        'filter_by_state',
-        'name',
-    ];
+    protected $fillable = ['filter_by_location', 'name'];
 
     protected static function boot()
     {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -225,7 +225,7 @@ $factory->define(GroupType::class, function (Generator $faker) {
         'name' =>
             'National ' . Str::title($faker->unique()->jobTitle) . ' Society',
         'filter_by_location' => true,
-        'filter_by_state' => true,
+        'filter_by_location' => true,
     ];
 });
 

--- a/database/migrations/2020_08_25_000000_drop_state_from_groups_table.php
+++ b/database/migrations/2020_08_25_000000_drop_state_from_groups_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropStateFromGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('state');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table
+                ->string('state', 10)
+                ->nullable()
+                ->after('city');
+        });
+    }
+}

--- a/database/migrations/2020_08_25_000100_drop_filter_by_state_from_group_types_table.php
+++ b/database/migrations/2020_08_25_000100_drop_filter_by_state_from_group_types_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropFilterByStateFromGroupTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('group_types', function (Blueprint $table) {
+            $table->dropColumn('filter_by_state');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('filter_by_state', function (Blueprint $table) {
+            $table
+                ->boolean('filter_by_state')
+                ->default(false)
+                ->after('name')
+                ->comment(
+                    'Whether or not group finders for this group type should filter by state.',
+                );
+        });
+    }
+}

--- a/docs/endpoints/group-types.md
+++ b/docs/endpoints/group-types.md
@@ -6,8 +6,6 @@
 GET /api/v3/group-types
 ```
 
-Note: The `filter_by_state` field will soon be removed, deprecated by `filter_by_location`.
-
 Example Response:
 
 ```
@@ -17,7 +15,6 @@ Example Response:
       "id": 1,
       "name": "March For Our Lives",
       "filter_by_location": false,
-      "filter_by_state": false,
       "created_at": "2019-12-04T21:28:26+00:00",
       "updated_at": "2019-12-04T22:33:03+00:00"
     },
@@ -25,7 +22,6 @@ Example Response:
       "id": 2,
       "name": "College Board",
       "filter_by_location": true,
-      "filter_by_state": true,
       "created_at": "2019-12-04T22:05:29+00:00",
       "updated_at": "2019-12-04T22:05:29+00:00"
     }
@@ -58,7 +54,6 @@ Example Response:
     "id": 1,
     "name": "March For Our Lives",
     "filter_by_location": false,
-    "filter_by_state": false,
     "created_at": "2019-12-04T21:28:26+00:00",
     "updated_at": "2019-12-04T22:33:03+00:00"
   };

--- a/docs/endpoints/groups.md
+++ b/docs/endpoints/groups.md
@@ -28,10 +28,6 @@ GET /api/v3/groups
 
   - Filter results by given school_id, e.g. `filter[external_id]=13000419`.
 
-- **filter[state]** _(string)_ -- Deprecated
-
-  - Filter results by given state, e.g. `filter[state]=SC`.
-
 Example Response:
 
 ```
@@ -42,7 +38,6 @@ Example Response:
       "group_type_id": 1,
       "name": "A C Flora High School",
       "city": "Charleston",
-      "state": "SC",
       "location": "US-SC",
       "school_id": "3600737",
       "goal": 150,
@@ -54,7 +49,6 @@ Example Response:
       "group_type_id": 1,
       "name": "Afton Central School",
       "city": "Afton",
-      "state": "NY",
       "location": "US-NY",
       "school_id": null,
       "goal": null,
@@ -91,7 +85,6 @@ Example Response:
     "group_type_id": 1,
     "name": "A C Flora High School",
     "city": "Charleston",
-    "state": "SC",
     "location": "US-SC",
     "school_id": "3600737",
     "goal": 150,

--- a/resources/views/group-types/create.blade.php
+++ b/resources/views/group-types/create.blade.php
@@ -17,7 +17,7 @@
 
                     <div class="form-item">
                         <label class="field-label">Group Finder</label>
-                        @include('forms.option', ['name' => 'filter_by_state', 'label' => 'Filter by state'])
+                        @include('forms.option', ['name' => 'filter_by_location', 'label' => 'Filter by location'])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/resources/views/group-types/edit.blade.php
+++ b/resources/views/group-types/edit.blade.php
@@ -21,7 +21,7 @@
 
                     <div class="form-item">
                         <label class="field-label">Group Finder</label>
-                        @include('forms.option', ['name' => 'filter_by_state', 'label' => 'Filter by state', 'value' => $groupType->filter_by_state])
+                        @include('forms.option', ['name' => 'filter_by_location', 'label' => 'Filter by location', 'value' => $groupType->filter_by_location])
                     </div>
 
                     <ul class="form-actions -inline -padded">

--- a/tests/Http/Web/GroupTypeTest.php
+++ b/tests/Http/Web/GroupTypeTest.php
@@ -16,13 +16,13 @@ class GroupTypeTest extends TestCase
         $this->actingAsAdmin()
             ->postJson('group-types', [
                 'name' => $name,
-                'filter_by_state' => true,
+                'filter_by_location' => true,
             ])
             ->assertStatus(302);
 
         $this->assertDatabaseHas('group_types', [
             'name' => $name,
-            'filter_by_state' => 1,
+            'filter_by_location' => 1,
         ]);
 
         // Verify cannot duplicate resource name.
@@ -50,7 +50,7 @@ class GroupTypeTest extends TestCase
     public function testUnsettingFilterByState()
     {
         $groupType = factory(GroupType::class)->create([
-            'filter_by_state' => true,
+            'filter_by_location' => true,
         ]);
 
         // Verify redirected upon success.
@@ -60,7 +60,7 @@ class GroupTypeTest extends TestCase
 
         $this->assertDatabaseHas('group_types', [
             'id' => $groupType->id,
-            'filter_by_state' => 0,
+            'filter_by_location' => 0,
         ]);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request drops the respective fields from the `groups` and `group_types` tables, now that they've been deprecated by `location` and `filter_by_location` (refs https://github.com/DoSomething/graphql/pull/270)

### How should this be reviewed?

👀 

### Any background context you want to provide?

🔥 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
