### PR TITLE
Add name filter to Clubs index

### DIFF
--- a/app/Http/Controllers/ClubsController.php
+++ b/app/Http/Controllers/ClubsController.php
@@ -33,6 +33,10 @@ class ClubsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, Club::$indexes);
 
+        if (isset($filters['name'])) {
+            $query->where('name', 'LIKE', '%' . $filters['name'] . '%');
+        }
+
         return $this->paginatedCollection($query, $request);
     }
 

--- a/docs/endpoints/clubs.md
+++ b/docs/endpoints/clubs.md
@@ -12,6 +12,10 @@ GET /api/v3/clubs
 
   - Filter results by Club ID or ID's.
 
+- **filter[name]** _(string)_
+
+  - Filter results by names that include the given filter, e.g. `filter[name]=Oakland`.
+
 Example Response:
 
 ```

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -116,6 +116,12 @@ class CampaignTest extends Testcase
         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
     }
 
+    /**
+     * Test that we can filter campaigns by cause.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
     public function testCauseFilteredCampaignIndex()
     {
         $causes = Cause::all();

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -25,7 +25,7 @@ class ClubTest extends TestCase
 
     /**
      * Test that we can filter clubs by name.
-     * GET /api/v3/campaigns
+     * GET /api/v3/campaigns.
      * @return void
      */
     public function testClubIndexNameFilter()

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -24,6 +24,41 @@ class ClubTest extends TestCase
     }
 
     /**
+     * Test that we can filter clubs by name.
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testClubIndexNameFilter()
+    {
+        $clubNames = [
+            'Batman Begins',
+            'Bipartisan',
+            'Brave New World',
+            'If I Never Knew You',
+            'San Dimas High School',
+            'Santa Claus',
+        ];
+
+        foreach ($clubNames as $clubName) {
+            factory(Club::class)->create([
+                'name' => $clubName,
+            ]);
+        }
+
+        $response = $this->getJson('api/v3/clubs?filter[name]=new');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(2, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson('api/v3/clubs?filter[name]=san');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+    }
+
+    /**
      * Test that a GET request to /api/v3/clubs/:id returns the intended club.
      *
      * @return void


### PR DESCRIPTION
### What's this PR do?

This pull request allows us to filter Clubs by the `name` field via the `/clubs` index API endpoint. 

### How should this be reviewed?
👀 

### Any background context you want to provide?
This follows https://github.com/DoSomething/rogue/pull/1048 by example since we're imitating this filter. 

I did deviate though in using the [SQL `'LIKE'` operator](https://www.w3schools.com/sql/sql_like.asp). The reason we didn't use `LIKE` for Groups was because of case-sensitivity (see https://github.com/DoSomething/rogue/pull/1048#discussion_r443850722), but I discovered that [we use](https://github.com/DoSomething/rogue/blob/45dbce64312e55f09b87e5395d34860d1291c687/config/database.php#L54) `utf8_unicode_ci` collation for our SQL database in Rogue which means we're automatically getting case insensitive querying! ([TIL](https://www.webucator.com/how-to/how-check-case-sensitivity-sql-server.cfm) that the `ci` stands for case insensitive) (I tested some queries against Rogue QA to confirm, and it seems to indeed be the case! (....case 😩)).

### Relevant tickets

References [Pivotal #174300560](https://www.pivotaltracker.com/story/show/174300560).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
