### PR TITLE
Fixes Groups search by name

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -35,7 +35,7 @@ class GroupsController extends ApiController
         $query = $this->filter($query, $filters, Group::$indexes);
 
         if (isset($filters['name'])) {
-            $query->where('name', 'REGEXP', $filters['name']);
+            $query->where('name', 'LIKE', '%' . $filters['name'] . '%');
         }
 
         // This endpoint always returns groups in alphabetical order by name. We'll

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -49,6 +49,13 @@ class GroupTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+
+        // Test special characters:
+        $response = $this->getJson('api/v3/groups?filter[name]=g\\');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
     }
 
     /**

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -50,8 +50,8 @@ class GroupTest extends TestCase
         $response->assertStatus(200);
         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
 
-        // Test special characters:
-        $response = $this->getJson('api/v3/groups?filter[name]=g\\');
+        // Test for encoded special characters.
+        $response = $this->getJson('api/v3/groups?filter[name]=g%5C');
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the syntax errors that are thrown when a special character is included in the `name` filter of a Groups index query, with a big thanks to @mendelB for the insights in #1114  

### How should this be reviewed?

👀 

### Any background context you want to provide?

🌵 

### Relevant tickets

References [Pivotal #174472802](https://www.pivotaltracker.com/story/show/174472802).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
