### PR TITLE
Adds formatting check to Group Import console command

### DIFF
--- a/app/Console/Commands/ImportGroupsCommand.php
+++ b/app/Console/Commands/ImportGroupsCommand.php
@@ -130,6 +130,7 @@ class ImportGroupsCommand extends Command
                     'city' => isset($groupCity)
                         ? ucwords(strtolower($groupCity))
                         : null,
+                    // Convert US State abbreviation to ISO 3166 format.
                     'location' => isset($record['state'])
                         ? 'US-' . trim($record['state'])
                         : null,

--- a/app/Console/Commands/ImportGroupsCommand.php
+++ b/app/Console/Commands/ImportGroupsCommand.php
@@ -110,6 +110,7 @@ class ImportGroupsCommand extends Command
         foreach ($csv->getRecords() as $record) {
             $groupName = $this->sanitizeValue($record, 'name');
             $groupSchoolId = $this->sanitizeValue($record, 'universal_id');
+            $groupCity = $this->sanitizeValue($record, 'city');
 
             if (!$groupName) {
                 $numSkipped++;
@@ -125,7 +126,10 @@ class ImportGroupsCommand extends Command
                 $group = Group::firstOrCreate([
                     'group_type_id' => $this->groupTypeId,
                     'name' => $groupName,
-                    'city' => $this->sanitizeValue($record, 'city'),
+                    // Convert any uppercase city names to Title Case.
+                    'city' => isset($groupCity)
+                        ? ucwords(strtolower($groupCity))
+                        : null,
                     'location' => isset($record['state'])
                         ? 'US-' . trim($record['state'])
                         : null,

--- a/tests/Console/ImportGroupsCommandTest.php
+++ b/tests/Console/ImportGroupsCommandTest.php
@@ -47,5 +47,12 @@ class ImportGroupsCommandTest extends TestCase
         $this->assertDatabaseMissing('groups', [
             'school_id' => '4400188',
         ]);
+        // Check that uppercase city name is converted to Title Case.
+        $this->assertDatabaseHas('groups', [
+            'name' => 'Woods Cross High School',
+            'group_type_id' => $groupTypeId,
+            'city' => 'Woods Cross',
+            'location' => 'US-UT',
+        ]);
     }
 }

--- a/tests/Console/example-groups.csv
+++ b/tests/Console/example-groups.csv
@@ -8,3 +8,4 @@ Portsmouth High School,Portsmouth,RI,4400189
 Prudence Island School,Prudence Island,RI,4400191
 Charlotte Woods Elementary School,Providence,RI,4400203
 Frank D. Spaziano Annex Elementary School,Providence,RI,4400198
+Woods Cross High School,WOODS CROSS,UT,


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `ImportGroupsCommand` to convert any uppercase city names to Title Case, e.g. ("San Francisco" instead of "SAN FRANCISCO")

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

Our source file for a new group type randomly contains uppercase city values, and it seemed easy enough to handle the cleaning up the data within the command.

### Relevant tickets

References [Pivotal #174829345](https://www.pivotaltracker.com/story/show/174829345).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
