### PR TITLE
Add authorization to GraphQL Client

### DIFF
--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -14,6 +14,7 @@ class GraphQL
         $this->client = ClientBuilder::build(config('services.graphql.url'), [
             'headers' => [
                 'apollographql-client-name' => 'rogue',
+                'authorization' => 'Bearer ' . token()->jwt(),
             ],
         ]);
     }

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -11,11 +11,21 @@ class GraphQL
      */
     public function __construct()
     {
-        $this->client = ClientBuilder::build(config('services.graphql.url'), [
-            'headers' => [
-                'apollographql-client-name' => 'rogue',
+        $headers = [
+            // Identify this client for Apollo GraphQL metrics (https://bit.ly/35Vf3F1).
+            'apollographql-client-name' => 'rogue',
+        ];
+
+        // If we have an authorization token (machine clients), assign the authorization header for
+        // our GraphQL client so that we can request gated fields.
+        if (token()->exists()) {
+            $headers = array_merge($headers, [
                 'authorization' => 'Bearer ' . token()->jwt(),
-            ],
+            ]);
+        }
+
+        $this->client = ClientBuilder::build(config('services.graphql.url'), [
+            'headers' => $headers,
         ]);
     }
 

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -11,7 +11,11 @@ class GraphQL
      */
     public function __construct()
     {
-        $this->client = ClientBuilder::build(config('services.graphql.url'));
+        $this->client = ClientBuilder::build(config('services.graphql.url'), [
+            'headers' => [
+                'apollographql-client-name' => 'rogue',
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds `apollographql-client-name` (per [Pivotal #174634307](https://www.pivotaltracker.com/story/show/174634307)) and `authorization` headers to our GraphQL client.

### How should this be reviewed?
See below.

### Any background context you want to provide?
Per [Pivotal #174338924](https://www.pivotaltracker.com/story/show/174338924), we'll need to append a user's Club ID to their signups and posts if applicable. We'll need to check Northstar for this information. The `club_id` field is [gated](https://github.com/DoSomething/northstar/blob/e8032fdd7aa68a8504f54974a5801fa6a7a39534/app/Http/Transformers/UserTransformer.php#L68-L76) and thus wouldn't be accessible via the anonymous GraphQL queries we generally make from this application.

My first thought was to use our [`Registrar`](https://github.com/DoSomething/rogue/blob/d0ba62091d319e03670ea62cf5e9f0e3b3552544/app/Services/Registrar.php) but I feel like we'd prefer to avoid this in favor of GraphQL. 

So I figured it could be simple enough, following the logic we used to append an Apollo client name in Northstar (https://github.com/DoSomething/northstar/pull/1050#discussion_r482333421) to also append an `authorization` header using the local token. (https://github.com/DoSomething/rogue/commit/5302ca78d31d14d0a3bacedb6a18b29499999dd4).

This does assume that GraphQL queries are running via authorized machine requests (I think that's how this `token` works right?), but I think that's our only use case?

We could also _optionally_ append the token to the headers _if_ available so that by default anonymous requests would work (avoiding [this issue](https://www.pivotaltracker.com/story/show/172629326)).


I should note, that I tried to hook up the [OAuth2 version](https://github.com/softonic/oauth2-provider) of this GraphQL client, but it seems to be specific to their own [OAuth2 Provider](https://github.com/softonic/oauth2-provider) and I could _not_ get this to work.

### Relevant tickets

References [Pivotal #174338924](https://www.pivotaltracker.com/story/show/174338924).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
