### PR TITLE
Add User's Club Id to Signups and Posts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,4 @@ CUSTOMER_IO_PASSWORD=apiKey
 
 # Feature Flags:
 DS_ENABLE_BLINK=false
+DS_ENABLE_TRACK_CLUB_ID=false

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -26,7 +26,11 @@ class PostObserver
         }
 
         // If the post's signup has a club_id, save it on the post as well.
-        if (!$post->club_id && $post->signup->club_id) {
+        if (
+            config('features.track_club_id') &&
+            !$post->club_id &&
+            $post->signup->club_id
+        ) {
             $post->club_id = $post->signup->club_id;
         }
     }

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -24,6 +24,11 @@ class PostObserver
         if ($post->group_id && !$post->school_id && ($group = $post->group)) {
             $post->school_id = $group->school_id;
         }
+
+        // If the post's signup has a club_id, save it on the post as well.
+        if (!$post->club_id && $post->signup->club_id) {
+            $post->club_id = $post->signup->club_id;
+        }
     }
 
     /**

--- a/app/Observers/SignupObserver.php
+++ b/app/Observers/SignupObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rogue\Observers;
+
+use Rogue\Models\Signup;
+
+class SignupObserver
+{
+
+    /**
+     * Handle the Signup "creating" event.
+     *
+     * @param  \Rogue\Models\Signup  $signup
+     * @return void
+     */
+    public function creating(Signup $signup)
+    {
+    }
+}

--- a/app/Observers/SignupObserver.php
+++ b/app/Observers/SignupObserver.php
@@ -36,7 +36,7 @@ class SignupObserver
      */
     public function creating(Signup $signup)
     {
-        if (!$signup->club_id) {
+        if (config('features.track_club_id') && !$signup->club_id) {
             $data = $this->queryForUser($signup->northstar_id);
 
             if ($club_id = data_get($data, 'user.clubId')) {

--- a/app/Observers/SignupObserver.php
+++ b/app/Observers/SignupObserver.php
@@ -36,5 +36,12 @@ class SignupObserver
      */
     public function creating(Signup $signup)
     {
+        if (!$signup->club_id) {
+            $data = $this->queryForUser($signup->northstar_id);
+
+            if ($club_id = data_get($data, 'user.clubId')) {
+                $signup->club_id = $club_id;
+            }
+        }
     }
 }

--- a/app/Observers/SignupObserver.php
+++ b/app/Observers/SignupObserver.php
@@ -3,9 +3,30 @@
 namespace Rogue\Observers;
 
 use Rogue\Models\Signup;
+use Rogue\Services\GraphQL;
+
+const USER_CLUB_ID_QUERY = '
+    query UserClubIdQuery($userId: String!) {
+        user(id: $userId) {
+            clubId
+        }
+    }
+';
 
 class SignupObserver
 {
+    /**
+     * Query to get the user's club_id.
+     *
+     * @param string $userId
+     * @return array
+     */
+    public function queryForUser($userId)
+    {
+        return app(GraphQL::class)->query(USER_CLUB_ID_QUERY, [
+            'userId' => $userId,
+        ]);
+    }
 
     /**
      * Handle the Signup "creating" event.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,7 +13,9 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
 use Rogue\Models\Post;
+use Rogue\Models\Signup;
 use Rogue\Observers\PostObserver;
+use Rogue\Observers\SignupObserver;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -36,6 +38,7 @@ class AppServiceProvider extends ServiceProvider
     {
         // Attach model observer(s):
         Post::observe(PostObserver::class);
+        Signup::observe(SignupObserver::class);
 
         $this->app->singleton(Hashids::class, function ($app) {
             return new Hashids(config('app.key'), 10);

--- a/config/features.php
+++ b/config/features.php
@@ -12,4 +12,5 @@ return [
     */
 
     'blink' => env('DS_ENABLE_BLINK'),
+    'track_club_id' => env('DS_ENABLE_TRACK_CLUB_IDS', false),
 ];

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -1881,6 +1881,9 @@ class PostTest extends TestCase
      */
     public function testCreatingAPostForSignupWithClubId()
     {
+        // Turn on the feature flag for tracking club_ids.
+        config(['features.track_club_id' => 'true']);
+
         $clubId = factory(Club::class)->create()->id;
         $signup = factory(Signup::class)->create(['club_id' => $clubId]);
 

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -141,6 +141,9 @@ class SignupTest extends TestCase
      */
     public function testCreatingASignupForUserWithClubId()
     {
+        // Turn on the feature flag for tracking club_ids.
+        config(['features.track_club_id' => 'true']);
+
         $northstarId = $this->faker->northstar_id;
         $campaignId = $this->faker->randomNumber(4);
         $clubId = factory(Club::class)->create()->id;

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DoSomething\Gateway\Northstar;
 use DoSomething\Gateway\Resources\NorthstarUser;
 use Illuminate\Support\Facades\Storage;
+use Rogue\Observers\SignupObserver;
 use Rogue\Services\GraphQL;
 
 trait WithMocks
@@ -69,6 +70,14 @@ trait WithMocks
 
         $this->graphqlMock->shouldReceive('getUserById')->andReturn([
             'displayName' => 'Daisy D.',
+        ]);
+
+        // Signup Observer partial Mock. (To mock the GraphQL query method).
+        $this->signupObserverMock = $this->mock(
+            SignupObserver::class,
+        )->makePartial();
+        $this->signupObserverMock->shouldReceive('queryForUser')->andReturn([
+            'user' => ['clubId' => null],
         ]);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request appends the user's `club_id` to their signups and posts. (Branching off of #1120).

### How should this be reviewed?
commit-by-commit.

1. Is this implementation via a new `SignupObserver` sound?
2. Do you agree with the execution of the GraphQL query (colocated in the SignupObserver) and its mocks?
3. Is it safe to assume that we can simply grab the `club_id` from the post's signup instead of making the GraphQL query ourselves (e.g. what if the signup has no club_id erroneously, we then wouldn't attach a user's `club_id` to the signups posts! But I figured that edge case didn't warrant a separate GraphQL query).
4. Any concerns that making a GraphQL query while saving the signup will disrupt our traffic/bandwidth/devopswords?

### Any background context you want to provide?
So in our initial implementation of the GraphQL client, we discussed (https://github.com/DoSomething/rogue/pull/889#discussion_r297773531) colocating the queries in their respective class implementations. I was interested to see if this would work here, particularly because I wasn't positive how to go about resolving both the existing [`GraphQL::getUserById`](https://github.com/DoSomething/rogue/blob/c84cc8a7fde97c42f94044655552d54c80469813/app/Services/GraphQL.php#L95-L115) method and this new user query. 

I saw that we'd already done this in the [`PostTagged` class](https://github.com/DoSomething/rogue/blob/c84cc8a7fde97c42f94044655552d54c80469813/app/Notifications/PostTagged.php#L65-L74) so I followed by example. It seems like a nice bet! The only issue being the test mock which is more convenient for `GraphQL` methods. But I bumped into [Partial Mocking](http://docs.mockery.io/en/latest/reference/partial_mocks.html) with mockery which seemed to do the trick!

But if you disagree with this implementation LMK. One outstanding question is duplicate queries, which I don't think we have a solid answer for, but for now, I thought this seemed pretty neat!

### Relevant tickets

References [Pivotal #174338924](https://www.pivotaltracker.com/story/show/174338924).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
