### PR TITLE
Fixes School page

### DIFF
--- a/resources/assets/pages/ShowSchool.js
+++ b/resources/assets/pages/ShowSchool.js
@@ -16,7 +16,7 @@ const SHOW_SCHOOL_QUERY = gql`
       id
       name
       city
-      state
+      location
     }
     groups(schoolId: $id) {
       id
@@ -48,7 +48,7 @@ const ShowSchool = () => {
 
   if (!data.school) return <NotFound title={title} type="school" />;
 
-  const { city, name, state } = data.school;
+  const { city, name, location } = data.school;
 
   const groupList = data.groups.length ? (
     <ul>
@@ -74,7 +74,7 @@ const ShowSchool = () => {
             details={{
               ID: id,
               City: city,
-              State: state,
+              Location: location,
               Groups: groupList,
             }}
           />


### PR DESCRIPTION
### What's this PR do?

This pull request updates the GraphQL query for a school to use `location` instead of the deleted `state` field. 

### How should this be reviewed?

* 👀 
* Spot check a school page, e.g. http://rogue.test/schools/4809500

### Any background context you want to provide?

🙈 

### Relevant tickets

References https://github.com/DoSomething/graphql/pull/270.

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
