### PR TITLE
Adds group_type_id filter to action-stats index, and general exclude_by_field filter

### DIFF
--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -34,6 +34,10 @@ class ActionStatsController extends ApiController
         $filters = $request->query('filter');
         $query = $this->filter($query, $filters, ActionStat::$indexes);
 
+        if (Arr::has($filters, 'group_type_id')) {
+            $query = $query->inGroupTypeId($filters['group_type_id']);
+        }
+
         // Allow ordering results:
         $orderBy = $request->query('orderBy');
         $query = $this->orderBy($query, $orderBy, ActionStat::$sortable);

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -88,6 +88,10 @@ trait FiltersRequests
      */
     public function orderBy($query, $orderBy, $indexes)
     {
+        // We specify the table name of our 'id' in case the query is joining on tables.
+        $tableName = $query->getModel()->getTable();
+        $idField = $tableName . '.id';
+
         if ($orderBy) {
             [$column, $direction] = explode(',', $orderBy, 2);
 
@@ -97,20 +101,14 @@ trait FiltersRequests
                 // If we have multiple items with the same '$column' value,
                 // use ID as a secondary sort column to ensure stable sort.
                 if ($column != 'id') {
-                    $query->orderBy('id', 'asc');
+                    $query->orderBy($idField, 'asc');
                 }
             }
         } else {
-            /**
-             * If we don't specify an ordering in the query, we should default
-             * to order by ID. (Fun fact: MySQL makes no guarantees of ordering
-             * if we don't include this in the query!)
-             *
-             * We specify the table name of our 'id' in case the query is joining on tables.
-             */
-            $tableName = $query->getModel()->getTable();
-
-            $query->orderBy($tableName . '.id', 'asc');
+            // If we don't specify an ordering in the query, we should default
+            // to order by ID. (Fun fact: MySQL makes no guarantees of ordering
+            // if we don't include this in the query!)
+            $query->orderBy($idField, 'asc');
         }
 
         return $query;

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -38,7 +38,7 @@ trait FiltersRequests
             /**
              * If there is an exclude_by_field filter, remove from $filters and save the value,
              * Else default to exclude by an 'id' field.
-             * Example: filter[exclude]=1200537,3618101&filter[exclude_field]=school_id
+             * Example: filter[exclude]=1200537,3618101&filter[exclude_field]=school_id.
              */
             if (array_key_exists('exclude_by_field', $filters)) {
                 $excludeByField = $filters['exclude_by_field'];

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -101,9 +101,13 @@ trait FiltersRequests
                 }
             }
         } else {
-            // If we don't specify an ordering in the query, we should default
-            // to order by ID. (Fun fact: MySQL makes no guarantees of ordering
-            // if we don't include this in the query!)
+            /**
+             * If we don't specify an ordering in the query, we should default
+             * to order by ID. (Fun fact: MySQL makes no guarantees of ordering
+             * if we don't include this in the query!)
+             *
+             * We specify the table name of our 'id' in case the query is joining on tables.
+             */
             $tableName = $query->getModel()->getTable();
 
             $query->orderBy($tableName . '.id', 'asc');

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -104,7 +104,9 @@ trait FiltersRequests
             // If we don't specify an ordering in the query, we should default
             // to order by ID. (Fun fact: MySQL makes no guarantees of ordering
             // if we don't include this in the query!)
-            $query->orderBy('id', 'asc');
+            $tableName = $query->getModel()->getTable();
+
+            $query->orderBy($tableName . '.id', 'asc');
         }
 
         return $query;

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -35,12 +35,14 @@ trait FiltersRequests
             $excludedValues = $filters['exclude'];
             unset($filters['exclude']);
 
-            // If there is an exclude_by_field filter, remove from $filters and save the value.
-            // Example: filter[exclude]=1200537,3618101&filter[exclude_field]=school_id
+            /**
+             * If there is an exclude_by_field filter, remove from $filters and save the value,
+             * Else default to exclude by an 'id' field.
+             * Example: filter[exclude]=1200537,3618101&filter[exclude_field]=school_id
+             */
             if (array_key_exists('exclude_by_field', $filters)) {
                 $excludeByField = $filters['exclude_by_field'];
                 unset($filters['exclude_by_field']);
-                // Else default to exclude by an 'id' field.
             } else {
                 $excludeByField = 'id';
             }

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -34,6 +34,16 @@ trait FiltersRequests
         if (array_key_exists('exclude', $filters)) {
             $excludedValues = $filters['exclude'];
             unset($filters['exclude']);
+
+            // If there is an exclude_by_field filter, remove from $filters and save the value.
+            // Example: filter[exclude]=1200537,3618101&filter[exclude_field]=school_id
+            if (array_key_exists('exclude_by_field', $filters)) {
+                $excludeByField = $filters['exclude_by_field'];
+                unset($filters['exclude_by_field']);
+                // Else default to exclude by an 'id' field.
+            } else {
+                $excludeByField = 'id';
+            }
         } else {
             $excludedValues = false;
         }
@@ -60,8 +70,7 @@ trait FiltersRequests
         }
 
         if ($excludedValues) {
-            // @TODO - Only excludes `id` fields, we could update this to be more flexible.
-            $query->whereNotIn('id', explode(',', $excludedValues));
+            $query->whereNotIn($excludeByField, explode(',', $excludedValues));
         }
 
         return $query;

--- a/app/Models/ActionStat.php
+++ b/app/Models/ActionStat.php
@@ -35,4 +35,18 @@ class ActionStat extends Model
      * @var array
      */
     public static $sortable = ['id', 'impact'];
+
+    /**
+     * Scope a query to only include schools that have groups in given group type ID.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  int  $groupTypeId
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeInGroupTypeId($query, $groupTypeId)
+    {
+        return $query
+            ->join('groups', 'action_stats.school_id', '=', 'groups.school_id')
+            ->where('groups.group_type_id', '=', $groupTypeId);
+    }
 }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -264,9 +264,9 @@ $factory->define(Club::class, function (Generator $faker) {
     ];
 });
 
-// Action Stat Factory
+// ActionStat Factory
 $factory->define(ActionStat::class, function (Generator $faker) {
-    $school = $faker->school;
+    $school = $faker->unique()->school;
 
     return [
         'school_id' => $school->school_id,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -5,6 +5,7 @@
 use Faker\Generator;
 use Illuminate\Support\Str;
 use Rogue\Models\Action;
+use Rogue\Models\ActionStat;
 use Rogue\Models\Campaign;
 use Rogue\Models\Club;
 use Rogue\Models\Group;
@@ -225,7 +226,6 @@ $factory->define(GroupType::class, function (Generator $faker) {
         'name' =>
             'National ' . Str::title($faker->unique()->jobTitle) . ' Society',
         'filter_by_location' => true,
-        'filter_by_location' => true,
     ];
 });
 
@@ -261,5 +261,19 @@ $factory->define(Club::class, function (Generator $faker) {
         'city' => $faker->city,
         'location' => 'US-' . $faker->stateAbbr,
         'school_id' => $faker->school->school_id,
+    ];
+});
+
+// Action Stat Factory
+$factory->define(ActionStat::class, function (Generator $faker) {
+    $school = $faker->school;
+
+    return [
+        'school_id' => $school->school_id,
+        'location' => $school->location,
+        'action_id' => function () {
+            return factory(Action::class)->create()->id;
+        },
+        'impact' => $faker->randomNumber(2),
     ];
 });

--- a/docs/endpoints/action-stats.md
+++ b/docs/endpoints/action-stats.md
@@ -10,10 +10,35 @@ GET /api/v3/action-stats
 
 ### Optional Query Parameters
 
-- **filter[column]** _(string)_
+- **filter[action_id]** _(integer)_
 
-  - Filter results by column. Supported columns: `action_id`, `location`, `school_id`
-  - Use commas to filter by multiple values in a column, e.g. `/action-stats?filter[action_id]=121,122`
+  - The action id to filter by.
+  - e.g. `/action-stats?filter[action_id]=954`
+
+- **filter[exclude]** _(integer|string)_
+
+  - The id(s) to exclude in response. If `exclude_by_field` filter is not set, this defaults to filter by the action stat id.
+  - e.g. `/action-stats?filter[exclude]=2,3,4`
+
+- **filter[exclude_by_field]** _(string)_
+
+  - The field to exclude by, if an `exclude` filter is also set.
+  - e.g. `/acion-stats?filter[exclude]=US-AL,US-HI&filter[exclude_by_field]=location`
+
+- **filter[group_type_id]** _(int)_
+
+  - The group type id to filter the response by, joining on [`groups`](../groups.md) by `school_id`.
+  - e.g. `/action-stats?filter[location]=US-NY`
+
+- **filter[location]** _(string)_
+
+  - The location to filter the response by.
+  - e.g. `/action-stats?filter[location]=US-NY`
+
+- **filter[school_id]** _(string)_
+
+  - The school id to filter the response by.
+  - e.g. `/action-stats?filter[school_id]=4809500`
 
 - **orderBy** _(string)_
   - Order results by column. Supported columns: `id`, `impact`

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -55,9 +55,12 @@ Posts are returned in reverse chronological order.
 - **filter[created_at]** _(timestamp)_
   - The created_at date to filter the response by.
   - e.g. `/posts?filter[created_at]=2017-04-28 01:46:45`
-- **filter[exclude]** _(integer)_
-  - The post id(s) to exclude in response.
+- **filter[exclude]** _(integer|string)_
+  - The id(s) to exclude in response. If `exclude_by_field` filter is not set, this defaults to filter by the post id.
   - e.g. `/posts?filter[exclude]=2,3,4`
+- **filter[exclude_by_field]** _(string)_
+  - The field to exclude by, if an `exclude` filter is also set.
+  - e.g. `/posts?filter[exclude]=US-AL,US-HI&filter[exclude_by_field]=location`
 - **filter[tag]** _(string)_
   - The tag(s) to filter the response by.
   - Tag is passed in as tag_slug.

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Http;
+
+use Rogue\Models\ActionStat;
+use Rogue\Models\Group;
+use Rogue\Models\GroupType;
+use Tests\TestCase;
+
+class ActionStatsTest extends TestCase
+{
+    /**
+     * Test that a GET request to /api/v3/action-stats returns an index of all action stats.
+     *
+     * GET /api/v3/actions
+     * @return void
+     */
+    public function testActionStatsIndex()
+    {
+        // Create five action stats.
+        factory(ActionStat::class, 5)->create();
+
+        $response = $this->getJson('api/v3/action-stats');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+    }
+}

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -12,7 +12,6 @@ class ActionStatsTest extends TestCase
     /**
      * Test that a GET request to /api/v3/action-stats returns an index of all action stats.
      *
-     * GET /api/v3/actions
      * @return void
      */
     public function testActionStatsIndex()
@@ -28,16 +27,16 @@ class ActionStatsTest extends TestCase
     }
 
     /**
-     * Test that a GET request to /api/v3/action-stats returns an index of all action stats.
+     * Test expected results for group_type_id filter.
      *
-     * GET /api/v3/actions
      * @return void
      */
-    public function testFilterByGroupTypeId()
+    public function testGroupTypeIdFilter()
     {
         // Create five action stats.
         $actionStats = factory(ActionStat::class, 5)->create();
-
+        $firstSchoolId = $actionStats[0]->school_id;
+        $secondSchoolId = $actionStats[1]->school_id;
         $firstGroupType = factory(GroupType::class)->create();
         $firstGroupTypeId = $firstGroupType->id;
         $secondGroupType = factory(GroupType::class)->create();
@@ -46,16 +45,16 @@ class ActionStatsTest extends TestCase
         // Create two groups for our first group type, each with different schools.
         factory(Group::class)->create([
             'group_type_id' => $firstGroupTypeId,
-            'school_id' => $actionStats[0]->school_id,
+            'school_id' => $firstSchoolId,
         ]);
         factory(Group::class)->create([
             'group_type_id' => $firstGroupTypeId,
-            'school_id' => $actionStats[1]->school_id,
+            'school_id' => $secondSchoolId,
         ]);
         // Create one group for our 2nd group type.
         factory(Group::class)->create([
             'group_type_id' => $secondGroupTypeId,
-            'school_id' => $actionStats[0]->school_id,
+            'school_id' => $firstSchoolId,
         ]);
 
         $response = $this->getJson(
@@ -83,5 +82,61 @@ class ActionStatsTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+    }
+
+    /**
+     * Test expected results for exclude filter without exclude_by_field.
+     *
+     * @return void
+     */
+    public function testExcludeFilter()
+    {
+        $actionStats = factory(ActionStat::class, 5)->create();
+
+        // Test expected results using exclude and exclude_by_field filters.
+        $response = $this->getJson(
+            'api/v3/action-stats?filter[exclude]=' . $actionStats[3]->id,
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(4, $decodedResponse['meta']['pagination']['count']);
+        $response->assertJson([
+            'data' => [
+                ['id' => $actionStats[0]->id],
+                ['id' => $actionStats[1]->id],
+                ['id' => $actionStats[2]->id],
+                ['id' => $actionStats[4]->id],
+            ],
+        ]);
+    }
+
+    /**
+     * Test expected results for exclude_by_field filter.
+     *
+     * @return void
+     */
+    public function testExcludeByFieldFilter()
+    {
+        $actionStats = factory(ActionStat::class, 5)->create();
+
+        // Test expected results using exclude and exclude_by_field filters.
+        $response = $this->getJson(
+            'api/v3/action-stats?filter[exclude]=' .
+                $actionStats[0]->school_id .
+                '&filter[exclude_by_field]=school_id',
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(4, $decodedResponse['meta']['pagination']['count']);
+        $response->assertJson([
+            'data' => [
+                ['id' => $actionStats[1]->id],
+                ['id' => $actionStats[2]->id],
+                ['id' => $actionStats[3]->id],
+                ['id' => $actionStats[4]->id],
+            ],
+        ]);
     }
 }

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -73,5 +73,15 @@ class ActionStatsTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+
+        // Verify no errors are thrown when using a groupBy query.
+        $response = $this->getJson(
+            'api/v3/action-stats?orderBy=impact,desc&filter[group_type_id]=' .
+                $secondGroupTypeId,
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
     }
 }

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -26,4 +26,52 @@ class ActionStatsTest extends TestCase
         $response->assertStatus(200);
         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
     }
+
+    /**
+     * Test that a GET request to /api/v3/action-stats returns an index of all action stats.
+     *
+     * GET /api/v3/actions
+     * @return void
+     */
+    public function testFilterByGroupTypeId()
+    {
+        // Create five action stats.
+        $actionStats = factory(ActionStat::class, 5)->create();
+
+        $firstGroupType = factory(GroupType::class)->create();
+        $firstGroupTypeId = $firstGroupType->id;
+        $secondGroupType = factory(GroupType::class)->create();
+        $secondGroupTypeId = $secondGroupType->id;
+
+        // Create two groups for our first group type, each with different schools.
+        factory(Group::class)->create([
+            'group_type_id' => $firstGroupTypeId,
+            'school_id' => $actionStats[0]->school_id,
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $firstGroupTypeId,
+            'school_id' => $actionStats[1]->school_id,
+        ]);
+        // Create one group for our 2nd group type.
+        factory(Group::class)->create([
+            'group_type_id' => $secondGroupTypeId,
+            'school_id' => $actionStats[0]->school_id,
+        ]);
+
+        $response = $this->getJson(
+            'api/v3/action-stats?filter[group_type_id]=' . $firstGroupTypeId,
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(2, $decodedResponse['meta']['pagination']['count']);
+
+        $response = $this->getJson(
+            'api/v3/action-stats?filter[group_type_id]=' . $secondGroupTypeId,
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+    }
 }

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -63,7 +63,7 @@ class ActionTest extends TestCase
     }
 
     /**
-     * Test that a GET request to /api/v3/actions returns an index of all campaigns.
+     * Test that a GET request to /api/v3/actions returns an index of all actions.
      *
      * GET /api/v3/actions
      * @return void

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -71,7 +71,7 @@ class ActionTest extends TestCase
     public function testActionIndex()
     {
         // Create five actions.
-        $first = factory(Action::class, 5)->create();
+        factory(Action::class, 5)->create();
 
         $response = $this->getJson('api/v3/actions');
         $decodedResponse = $response->decodeResponseJson();


### PR DESCRIPTION
### What's this PR do?

This pull request adds support to filter a list of action stats by a given `group_type_id`, by joining on the `groups` table by `school_id`.

It also adds support for an `exclude_by_field` filter to controllers that use our `FiltersRequests` trait.

### How should this be reviewed?

...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
