### PR TITLE
Fixes bug when filtering Action Stats by location

### DIFF
--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -30,12 +30,29 @@ class ActionStatsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(ActionStat::class);
+        $tableName = $query->getModel()->getTable();
 
         $filters = $request->query('filter');
-        $query = $this->filter($query, $filters, ActionStat::$indexes);
+
+        /**
+         * Because we may be joining on groups, which also have location and school_id columns, we
+         * specify our table name to avoid integrity constraint violations for ambiguous clauses.
+         */
+
+        if (Arr::has($filters, 'action_id')) {
+            $query->where('action_id', $filters['action_id']);
+        }
+
+        if (Arr::has($filters, 'location')) {
+            $query->where($tableName . '.location', $filters['location']);
+        }
 
         if (Arr::has($filters, 'group_type_id')) {
             $query = $query->inGroupTypeId($filters['group_type_id']);
+        }
+
+        if (Arr::has($filters, 'school_id')) {
+            $query->where($tableName . '.school_id', $filters['school_id']);
         }
 
         // Allow ordering results:

--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -30,7 +30,6 @@ class ActionStatsController extends ApiController
     public function index(Request $request)
     {
         $query = $this->newQuery(ActionStat::class);
-        $tableName = $query->getModel()->getTable();
 
         $filters = $request->query('filter');
 
@@ -38,6 +37,7 @@ class ActionStatsController extends ApiController
          * Because we may be joining on groups, which also have location and school_id columns, we
          * specify our table name to avoid integrity constraint violations for ambiguous clauses.
          */
+        $tableName = $query->getModel()->getTable();
 
         if (Arr::has($filters, 'action_id')) {
             $query->where('action_id', $filters['action_id']);

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -83,4 +83,62 @@ class ActionStatsTest extends TestCase
         $response->assertStatus(200);
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
     }
+
+    /**
+     * Test expected results for location filter.
+     *
+     * @return void
+     */
+    public function testLocationFilter()
+    {
+        // Create action stats with different locations.
+        $firstActionStat = factory(ActionStat::class)->create([
+            'location' => 'US-CA',
+        ]);
+        $firstSchoolId = $firstActionStat->school_id;
+        $secondActionStat = factory(ActionStat::class)->create([
+            'location' => 'US-NJ',
+        ]);
+        $secondSchoolId = $secondActionStat->school_id;
+        $firstGroupType = factory(GroupType::class)->create();
+        $firstGroupTypeId = $firstGroupType->id;
+        $secondGroupType = factory(GroupType::class)->create();
+        $secondGroupTypeId = $secondGroupType->id;
+
+        // Create two groups for our first group type, each with different schools.
+        factory(Group::class)->create([
+            'group_type_id' => $firstGroupTypeId,
+            'school_id' => $firstSchoolId,
+        ]);
+        factory(Group::class)->create([
+            'group_type_id' => $firstGroupTypeId,
+            'school_id' => $secondSchoolId,
+        ]);
+        // Create one group for our 2nd group type.
+        factory(Group::class)->create([
+            'group_type_id' => $secondGroupTypeId,
+            'school_id' => $firstSchoolId,
+        ]);
+
+        $response = $this->getJson(
+            'api/v3/action-stats?filter[location]=' .
+                $firstActionStat->location,
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+
+        // Verify no errors are thrown when additionally filtering by group_type_id.
+        $response = $this->getJson(
+            'api/v3/action-stats?orderBy=impact,desc&filter[group_type_id]=' .
+                $firstGroupTypeId .
+                '&filter[location]=' .
+                $firstActionStat->location,
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+    }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug introduced in #1123: when additionally filtering by `location` as well as `group_type_id` (which can be done in the leaderboard by selecting a location), an error is thrown: ` Integrity constraint violation: 1052 Column 'location' in where clause is ambiguous`

#1123 joins the `action_stats` table on the `groups` table -- both tables have a `location` column. This PR manually constructs the filters in a `GET /action-stats` index query to specify the table name of any potentially ambigious columns we may be filtering by.


### How should this be reviewed?

👀 

### Any background context you want to provide?

What I'm puzzled about is a related separate ambiguous error we're seeing in Slack:
```
production.ERROR: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous (SQL: select * from `action_stats` inner join `groups` on `action_stats`.`school_id` = `groups`.`school_id` where `action_id` = 954 and `groups`.`group_type_id` = 5 and (`impact` < 6 or (`impact` = 6 and `id` > 11955)) order by `impact` desc, `action_stats`.`id` asc limit 11 offset 0)
```
Off the top of my head - I have no idea which app is making this query. Will dig in a bit, but figured I'd open this PR to fix the `location` integrity constraint violation, and also see if we still see this `id`  integrity constraint violation upon deploy.

### Relevant tickets

References [Pivotal #175096130](https://www.pivotaltracker.com/n/projects/2417735/stories/175096130).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
