### PR TITLE
Send posts directly to Customer.io.

### DIFF
--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -2,17 +2,25 @@
 
 namespace Rogue\Jobs;
 
-use DoSomething\Gateway\Blink;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Redis;
 use Rogue\Models\Post;
+use Rogue\Services\CustomerIo;
 
 class SendPostToCustomerIo implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Delete the job if its models no longer exist.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = true;
 
     /**
      * The post to send to Customer.io.
@@ -22,21 +30,13 @@ class SendPostToCustomerIo implements ShouldQueue
     protected $post;
 
     /**
-     * Whether or not to log that this Post was sent to Customer.io, via Blink.
-     *
-     * @var bool
-     */
-    protected $log;
-
-    /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct(Post $post, $log = true)
+    public function __construct(Post $post)
     {
         $this->post = $post;
-        $this->log = $log;
     }
 
     /**
@@ -44,18 +44,25 @@ class SendPostToCustomerIo implements ShouldQueue
      *
      * @return void
      */
-    public function handle(Blink $blink)
+    public function handle(CustomerIo $customerIo)
     {
-        // Check if the post still exists before sending (might have been deleted immediately if created in Runscope test).
-        if ($this->post && $this->post->signup) {
-            $payload = $this->post->toBlinkPayload();
-            $blink->userSignupPost($payload);
+        $throttler = Redis::throttle('customerio')
+            ->allow(10)
+            ->every(1);
 
-            if ($this->log) {
-                logger()->info(
-                    'Post ' . $payload['id'] . ' sent to Customer.io',
+        $throttler->then(
+            // Rate limit Customer.io API requests to 10/s:
+            function () use ($customerIo) {
+                $customerIo->trackEvent(
+                    $this->post->northstar_id,
+                    'campaign_signup_post',
+                    $this->post->toBlinkPayload(),
                 );
-            }
-        }
+            },
+            // If we  can't obtain a lock, release to queue:
+            function () {
+                return $this->release(10);
+            },
+        );
     }
 }

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -61,7 +61,7 @@ class PostManager
         );
 
         // Save the new post in Customer.io, via Blink.
-        if (config('features.blink') && $shouldSendToCustomerIo) {
+        if ($shouldSendToCustomerIo) {
             SendPostToCustomerIo::dispatch($post);
         }
 
@@ -102,8 +102,8 @@ class PostManager
             $data['dont_send_to_blink']
         );
 
-        if (config('features.blink') && $shouldSendToCustomerIo) {
-            SendPostToCustomerIo::dispatch($post, $log);
+        if ($shouldSendToCustomerIo) {
+            SendPostToCustomerIo::dispatch($post);
         }
 
         if ($post->referrer_user_id && $shouldSendToCustomerIo) {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -366,9 +366,9 @@ class Post extends Model
 
         return array_merge(
             [
-                'id' => $this->id,
+                'id' => (string) $this->id,
                 'signup_id' => $this->signup_id,
-                'quantity' => $quantity,
+                'quantity' => (int) $quantity,
                 'why_participated' => $this->signup->why_participated,
                 'campaign_id' => (string) $this->campaign_id,
                 'campaign_run_id' => (string) $this->signup->campaign_run_id,
@@ -399,11 +399,9 @@ class Post extends Model
                 'school_name' => isset($school)
                     ? Arr::get($school, 'name')
                     : null,
-                'created_at' => $this->created_at->toIso8601String(),
-                'updated_at' => $this->updated_at->toIso8601String(),
-                'deleted_at' => $this->deleted_at
-                    ? $this->deleted_at->toIso8601String()
-                    : null,
+                'created_at' => $this->created_at->timestamp,
+                'updated_at' => $this->updated_at->timestamp,
+                'deleted_at' => optional($this->deleted_at)->timestamp,
             ],
             Group::toBlinkPayload($this->group),
         );

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -73,14 +73,13 @@ class PostTest extends TestCase
         ]);
 
         // Mock the Blink API calls.
-        $this->mock(Blink::class)
-            ->shouldReceive('userSignup')
-            ->shouldReceive('userSignupPost');
+        $this->mock(Blink::class)->shouldReceive('userSignup');
 
         // Mock the GraphQL API calls.
         $this->mock(GraphQL::class)->shouldReceive(
             'getUserById',
             'getCampaignWebsiteByCampaignId',
+            'getSchoolById',
         );
 
         // Mock the Customer.io API calls.
@@ -157,9 +156,8 @@ class PostTest extends TestCase
         ]);
 
         // Mock the Blink API calls.
-        $this->mock(Blink::class)
-            ->shouldReceive('userSignup')
-            ->shouldReceive('userSignupPost');
+        $this->mock(Blink::class)->shouldReceive('userSignup');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($northstarId)->json(
@@ -217,8 +215,7 @@ class PostTest extends TestCase
             'campaign_id' => $signup->campaign_id,
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -277,8 +274,7 @@ class PostTest extends TestCase
             'post_type' => 'text',
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -397,8 +393,7 @@ class PostTest extends TestCase
             'post_type' => 'share-social',
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -447,8 +442,7 @@ class PostTest extends TestCase
             'post_type' => 'share-social',
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
@@ -494,8 +488,7 @@ class PostTest extends TestCase
             'post_type' => 'share-social',
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
@@ -538,8 +531,7 @@ class PostTest extends TestCase
         $text = $this->faker->sentence;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post with an invalid type (not in text, photo, voter-reg, share-social).
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -573,8 +565,7 @@ class PostTest extends TestCase
         $quantity = $this->faker->numberBetween(10, 1000);
         $text = $this->faker->sentence;
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Make sure you also need the activity scope.
         $response = $this->postJson('api/v3/posts', [
@@ -610,8 +601,7 @@ class PostTest extends TestCase
             'campaign_id' => $signup->campaign_id,
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -704,8 +694,7 @@ class PostTest extends TestCase
             'campaign_id' => $signup->campaign_id,
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken(
@@ -752,8 +741,7 @@ class PostTest extends TestCase
             'campaign_id' => $signup->campaign_id,
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -796,8 +784,7 @@ class PostTest extends TestCase
         $quantity = $this->faker->numberBetween(10, 1000);
         $text = $this->faker->sentence;
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->postJson('api/v3/posts', [
@@ -829,8 +816,7 @@ class PostTest extends TestCase
             'name' => 'test-action',
         ]);
 
-        // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post without sending an action_id!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -1507,7 +1493,7 @@ class PostTest extends TestCase
         $post = factory(Post::class)->create();
         $signup = $post->signup;
 
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         $response = $this->withAdminAccessToken()->patchJson(
             'api/v3/posts/' . $post->id,
@@ -1570,7 +1556,7 @@ class PostTest extends TestCase
     {
         $post = factory(Post::class)->create();
 
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         $response = $this->withAdminAccessToken()->patchJson(
             'api/v3/posts/' . $post->id,
@@ -1594,7 +1580,7 @@ class PostTest extends TestCase
     {
         $post = factory(Post::class)->create();
 
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         $response = $this->withAdminAccessToken()->patchJson(
             'api/v3/posts/' . $post->id,
@@ -1617,7 +1603,7 @@ class PostTest extends TestCase
         $post = factory(Post::class)->create();
         $signup = $post->signup;
 
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         $response = $this->patchJson('api/v3/posts/' . $post->id, [
             'text' => 'new caption',
@@ -1794,7 +1780,7 @@ class PostTest extends TestCase
         ];
 
         // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAdminAccessToken()->postJson('api/v3/posts', [
@@ -1841,7 +1827,7 @@ class PostTest extends TestCase
         ]);
 
         // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -1895,7 +1881,7 @@ class PostTest extends TestCase
         ]);
 
         // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($signup->northstar_id)->postJson(
@@ -1947,7 +1933,7 @@ class PostTest extends TestCase
         $northstar_id = $this->faker->northstar_id;
 
         // Mock the Blink API call.
-        $this->mock(Blink::class)->shouldReceive('userSignupPost');
+        $this->mock(CustomerIo::class)->shouldReceive('trackEvent');
 
         // Create the post!
         $response = $this->withAccessToken($northstar_id)->postJson(


### PR DESCRIPTION
### What's this PR do?

This pull request updates Rogue to send `campaign_signup_post` events directly to [Customer.io](https://customer.io).

### How should this be reviewed?

🎯 I updated the `SendPostToCustomerIo` job to talk directly to Customer.io, via the `trackEvent` method in b1147d0.

🚜 I updated the `toCustomerIoPayload` method to include transformations [previously handled by Blink](https://github.com/DoSomething/blink/blob/dfe6d5ef138bd2fb3d66a105d626f4ab6f62d6c5/src/messages/CampaignSignupPostMessage.js#L52-L55) in fb4aa7c.

🚥 I updated tests to mock this method, rather than Blink's `userSignupPost` method in 9d9c491.

### Any background context you want to provide?

This reduces complexity and will allow us to reduce some Heroku costs in the future.

### Relevant tickets

References [Pivotal #174827032](https://www.pivotaltracker.com/story/show/174827032).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
