### PR TITLE
Send 'campaign_review' events directly to Customer.io & clean up jobs.

### DIFF
--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -3,8 +3,12 @@
 namespace Rogue\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-abstract class Job
+abstract class Job implements ShouldQueue
 {
     /*
     |--------------------------------------------------------------------------
@@ -12,10 +16,20 @@ abstract class Job
     |--------------------------------------------------------------------------
     |
     | This job base class provides a central location to place any logic that
-    | is shared across all of your jobs. The trait included with the class
-    | provides access to the "onQueue" and "delay" queue helper methods.
+    | is shared across all of your jobs. The traits included here provide behavior
+    | that we use across the board (like the "dispatch" and "onQueue" methods, or
+    | Eloquent model serialization).
     |
     */
 
-    use Queueable;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Delete jobs if their model(s) no longer exist. This prevents things that
+     * have been deleted (either as part of automated testing or account deletions)
+     * from cluttering up our failed jobs table with false negatives.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = true;
 }

--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -3,10 +3,10 @@
 namespace Rogue\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 abstract class Job implements ShouldQueue
 {

--- a/app/Jobs/Middleware/CustomerIoRateLimit.php
+++ b/app/Jobs/Middleware/CustomerIoRateLimit.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rogue\Jobs\Middleware;
+
+use Illuminate\Support\Facades\Redis;
+
+class RateLimited
+{
+    /**
+     * Process the queued job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        // Rate limit
+        $throttler = Redis::throttle('customerio')
+            ->allow(10)
+            ->every(1);
+
+        $throttler->then(
+            function () use ($job, $next) {
+                // Lock obtained, run job...
+                $next($job);
+            },
+            function () use ($job) {
+                // If we  can't obtain a lock, release back to queue...
+                $job->release(10);
+            },
+        );
+    }
+}

--- a/app/Jobs/Middleware/CustomerIoRateLimit.php
+++ b/app/Jobs/Middleware/CustomerIoRateLimit.php
@@ -4,7 +4,7 @@ namespace Rogue\Jobs\Middleware;
 
 use Illuminate\Support\Facades\Redis;
 
-class RateLimited
+class CustomerIoRateLimit
 {
     /**
      * Process the queued job.

--- a/app/Jobs/RejectPost.php
+++ b/app/Jobs/RejectPost.php
@@ -2,17 +2,10 @@
 
 namespace Rogue\Jobs;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Rogue\Models\Post;
 
-class RejectPost implements ShouldQueue
+class RejectPost extends Job
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
      * The post to reject.
      *
@@ -40,7 +33,6 @@ class RejectPost implements ShouldQueue
         $this->post->status = 'rejected';
         $this->post->save();
 
-        // Log
         info('Automatically rejected post ' . $this->post->id);
     }
 }

--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -2,26 +2,12 @@
 
 namespace Rogue\Jobs;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Redis;
+use Rogue\Jobs\Middleware\CustomerIoRateLimit;
 use Rogue\Models\Post;
 use Rogue\Services\CustomerIo;
 
-class SendPostToCustomerIo implements ShouldQueue
+class SendPostToCustomerIo extends Job
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
-    /**
-     * Delete the job if its models no longer exist.
-     *
-     * @var bool
-     */
-    public $deleteWhenMissingModels = true;
-
     /**
      * The post to send to Customer.io.
      *
@@ -40,29 +26,25 @@ class SendPostToCustomerIo implements ShouldQueue
     }
 
     /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return [new CustomerIoRateLimit()];
+    }
+
+    /**
      * Execute the job.
      *
      * @return void
      */
     public function handle(CustomerIo $customerIo)
     {
-        $throttler = Redis::throttle('customerio')
-            ->allow(10)
-            ->every(1);
+        $userId = $this->post->northstar_id;
+        $payload = $this->post->toCustomerIoPayload();
 
-        $throttler->then(
-            // Rate limit Customer.io API requests to 10/s:
-            function () use ($customerIo) {
-                $customerIo->trackEvent(
-                    $this->post->northstar_id,
-                    'campaign_signup_post',
-                    $this->post->toCustomerIoPayload(),
-                );
-            },
-            // If we  can't obtain a lock, release to queue:
-            function () {
-                return $this->release(10);
-            },
-        );
+        $customerIo->trackEvent($userId, 'campaign_signup_post', $payload);
     }
 }

--- a/app/Jobs/SendReviewedPostToCustomerIo.php
+++ b/app/Jobs/SendReviewedPostToCustomerIo.php
@@ -15,6 +15,13 @@ class SendReviewedPostToCustomerIo implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
+     * Delete the job if its models no longer exist.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = true;
+
+    /**
      * The post to send to Customer.io.
      *
      * @var Post


### PR DESCRIPTION
### What's this PR do?

This pull request updates Rogue to send `campaign_review` events directly to Customer.io (rather than routing them through Blink). I've created a [job middleware](https://laravel.com/docs/6.x/queues#job-middleware) to handle configuring this rate limiter since it's a little verbose & we do it for every Customer.io job. I've also cleaned up our job classes to extend the abstract `Job` class (where we add traits & defaults) so we don't have to do the same setup for every single job.

### How should this be reviewed?

It may be easiest to review this commit-by-commit!

### Any background context you want to provide?

One more job after this & then I'm done! I'll also make similar cleanups in Northstar.

### Relevant tickets

References [Pivotal #174827028](https://www.pivotaltracker.com/story/show/174827028).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
