### PR TITLE
Send signups directly to Customer.io & Gambit.

### DIFF
--- a/app/Jobs/Middleware/CustomerIoRateLimit.php
+++ b/app/Jobs/Middleware/CustomerIoRateLimit.php
@@ -15,7 +15,7 @@ class CustomerIoRateLimit
      */
     public function handle($job, $next)
     {
-        // Rate limit
+        // Rate limit to 10 requests/second.
         $throttler = Redis::throttle('customerio')
             ->allow(10)
             ->every(1);

--- a/app/Jobs/Middleware/GambitRateLimit.php
+++ b/app/Jobs/Middleware/GambitRateLimit.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rogue\Jobs\Middleware;
+
+use Illuminate\Support\Facades\Redis;
+
+class GambitRateLimit
+{
+    /**
+     * Process the queued job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        // Rate limit to 10 requests/second.
+        $throttler = Redis::throttle('gambit')
+            ->allow(10)
+            ->every(1);
+
+        $throttler->then(
+            function () use ($job, $next) {
+                // Lock obtained, run job...
+                $next($job);
+            },
+            function () use ($job) {
+                // If we  can't obtain a lock, release back to queue...
+                $job->release(10);
+            },
+        );
+    }
+}

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -11,7 +11,7 @@ class SendSignupToCustomerIo extends Job
     /**
      * The signup to send to Customer.io.
      *
-     * @var Post
+     * @var Signup
      */
     protected $signup;
 

--- a/app/Jobs/SendSignupToGambit.php
+++ b/app/Jobs/SendSignupToGambit.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rogue\Jobs;
+
+use Rogue\Jobs\Middleware\GambitRateLimit;
+use Rogue\Models\Signup;
+use Rogue\Services\Gambit;
+
+class SendSignupToGambit extends Job
+{
+    /**
+     * The signup to send to Customer.io.
+     *
+     * @var Signup
+     */
+    protected $signup;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Signup $signup)
+    {
+        $this->signup = $signup;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return [new GambitRateLimit()];
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(Gambit $gambit)
+    {
+        $gambit->relaySignup($this->signup);
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -73,7 +73,7 @@ class Group extends Model
      * @param Group $group
      * @return array
      */
-    public static function toBlinkPayload(?self $group)
+    public static function toCustomerIoPayload(?self $group)
     {
         return [
             'group_id' => $group ? $group->id : null,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -404,7 +404,7 @@ class Post extends Model
                 'updated_at' => $this->updated_at->timestamp,
                 'deleted_at' => optional($this->deleted_at)->timestamp,
             ],
-            Group::toBlinkPayload($this->group),
+            Group::toCustomerIoPayload($this->group),
         );
     }
 
@@ -712,7 +712,7 @@ class Post extends Model
                 'created_at' => $this->created_at->toIso8601String(),
                 'updated_at' => $this->updated_at->toIso8601String(),
             ],
-            Group::toBlinkPayload($this->group),
+            Group::toCustomerIoPayload($this->group),
         );
     }
 

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -191,7 +191,7 @@ class Signup extends Model
      *
      * @return array
      */
-    public function toBlinkPayload()
+    public function toCustomerIoPayload()
     {
         // Blink expects quantity to be a number.
         $quantity = $this->quantity === null ? 0 : $this->quantity;

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -225,7 +225,7 @@ class Signup extends Model
                 'created_at' => $this->created_at->toIso8601String(),
                 'updated_at' => $this->updated_at->toIso8601String(),
             ],
-            Group::toBlinkPayload($this->group),
+            Group::toCustomerIoPayload($this->group),
         );
     }
 

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -222,8 +222,8 @@ class Signup extends Model
                 'source' => $this->source,
                 'source_details' => $this->source_details,
                 'referrer_user_id' => $this->referrer_user_id,
-                'created_at' => $this->created_at->toIso8601String(),
-                'updated_at' => $this->updated_at->toIso8601String(),
+                'created_at' => optional($this->created_at)->timestamp,
+                'updated_at' => optional($this->updated_at)->timestamp,
             ],
             Group::toCustomerIoPayload($this->group),
         );

--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rogue\Services;
+
+use Rogue\Models\Signup;
+use RuntimeException;
+
+class Gambit
+{
+    /**
+     * The HTTP client.
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Create a new Gambit API client.
+     */
+    public function __construct()
+    {
+        $config = config('services.gambit');
+
+        $this->client = new \GuzzleHttp\Client([
+            'base_uri' => $config['url'],
+            'auth' => [$config['user'], $config['password']],
+        ]);
+    }
+
+    /**
+     * Relay a signup event to Gambit so that we can switch
+     * the user's conversation topic.
+     *
+     * @see https://git.io/JUAiB
+     *
+     * @param Signup $signup
+     */
+    public function relaySignup(Signup $signup)
+    {
+        $payload = [
+            'userId' => $signup->northstar_id,
+            'campaignId' => $signup->campaign_id,
+        ];
+
+        if (!config('features.gambit')) {
+            info('Signup would have been sent to Gambit.', [
+                'id' => $signup->id,
+                'payload' => $payload,
+            ]);
+
+            return;
+        }
+
+        $this->client->post('/api/v2/messages?origin=signup', [
+            'json' => $payload,
+        ]);
+
+        info('Signup sent to Gambit.', ['id' => $signup->id]);
+    }
+}

--- a/config/features.php
+++ b/config/features.php
@@ -12,5 +12,6 @@ return [
     */
 
     'blink' => env('DS_ENABLE_BLINK'),
+    'gambit' => env('DS_ENABLE_GAMBIT_RELAY', false),
     'track_club_id' => env('DS_ENABLE_TRACK_CLUB_IDS', false),
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -83,6 +83,12 @@ return [
         'service_id' => env('FASTLY_SERVICE_ID'),
     ],
 
+    'gambit' => [
+        'url' => env('GAMBIT_URL'),
+        'user' => env('GAMBIT_USERNAME'),
+        'password' => env('GAMBIT_PASSWORD'),
+    ],
+
     'graphql' => [
         'url' => env('GRAPHQL_URL'),
     ],

--- a/tests/Unit/Models/SignupModelTest.php
+++ b/tests/Unit/Models/SignupModelTest.php
@@ -9,7 +9,7 @@ use Tests\TestCase;
 class SignupModelTest extends TestCase
 {
     /**
-     * Test expected payload for Blink.
+     * Test expected payload for Customer.io.
      *
      * @return void
      */
@@ -21,7 +21,7 @@ class SignupModelTest extends TestCase
             'referrer_user_id' => $this->faker->northstar_id,
         ]);
 
-        $result = $signup->toBlinkPayload();
+        $result = $signup->toCustomerIoPayload();
 
         $this->assertEquals($result['group_id'], $group->id);
         $this->assertEquals($result['group_name'], $group->name);
@@ -45,7 +45,7 @@ class SignupModelTest extends TestCase
     {
         $signup = factory(Signup::class)->create();
 
-        $result = $signup->toBlinkPayload();
+        $result = $signup->toCustomerIoPayload();
 
         $this->assertEquals($result['group_id'], null);
         $this->assertEquals($result['group_name'], null);

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -7,6 +7,7 @@ use DoSomething\Gateway\Northstar;
 use DoSomething\Gateway\Resources\NorthstarUser;
 use Illuminate\Support\Facades\Storage;
 use Rogue\Observers\SignupObserver;
+use Rogue\Services\Gambit;
 use Rogue\Services\GraphQL;
 
 trait WithMocks
@@ -53,6 +54,10 @@ trait WithMocks
                     'mobile' => $this->faker->phoneNumber,
                 ]);
             });
+
+        // Gambit Mock
+        $this->gambitMock = $this->mock(Gambit::class);
+        $this->gambitMock->shouldReceive('relaySignup');
 
         // GraphQL Mock
         $this->graphqlMock = $this->mock(GraphQL::class);


### PR DESCRIPTION
### What's this PR do?

This pull request updates Rogue to send signup events directly to Customer.io and Gambit, rather than routing this event through Blink. These API calls power email & SMS transactional messages when a user signs up for a campaign.

### How should this be reviewed?

I've broken this into individual commits for each portion of this task.

This is blocked from merge/deploy until I make some some configuration changes to add Gambit environment variables & feature flag to each environment. I'm preparing that change now and will update this note when it's ready.

### Any background context you want to provide?

This reduces complexity and will help us save on Heroku costs in the future. 💰 

### Relevant tickets

References [Pivotal #174827024](https://www.pivotaltracker.com/story/show/174827024).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
