### PR TITLE
Silence 422 exceptions returned from this endpoint.

### DIFF
--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -60,7 +60,7 @@ class Gambit
             // We expect to get 422s for any users who sign up for a campaign but don't
             // have a mobile on their profile. These should not count as failures.
             if ($response->getStatusCode() !== 422) {
-                throw $e;
+                throw $exception;
             }
         }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds some error handling for the 422 errors we're getting on this endpoint:

```
Oct 08 11:39:12 dosomething-rogue app/queue.1: [2020-10-08 15:39:12] production.ERROR: Client error: `POST https://gambit-conversations-prod.herokuapp.com/api/v2/messages?origin=signup` resulted in a `422 Unprocessable Entity` response: 
```

These are thrown whenever a user signs up for a campaign, but _doesn't_ have a mobile on their profile. Since this is not a "real" error that should fail the job & be retried, we'll catch it here and only throw if it's another 4xx status.

### How should this be reviewed?

👀

### Any background context you want to provide?

We'll probably get a quick spike of errors tomorrow AM unless I sneak in a deploy before then, but no harm done if so!

### Relevant tickets

References [Pivotal #](https://www.pivotaltracker.com/story/show/174827024).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
