### PR TITLE
Properly catch the unexpected 422s here.

### DIFF
--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -61,8 +61,8 @@ class Gambit
 
             if ($response->getStatusCode() === 422) {
                 // We expect to get 422s from this endpoint for any users who sign up for
-                // a campaign but don't have a mobile on their profile. These should not
-                // be counted as failures!
+                // a campaign but don't have a mobile on their profile or are unsubscribed
+                // from text messages. These should not be counted as failures!
             } else {
                 throw $exception;
             }

--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -53,13 +53,17 @@ class Gambit
         }
 
         try {
-            $response = $this->client->post('/api/v2/messages?origin=signup', [
+            $this->client->post('/api/v2/messages?origin=signup', [
                 'json' => $payload,
             ]);
         } catch (ClientException $exception) {
-            // We expect to get 422s for any users who sign up for a campaign but don't
-            // have a mobile on their profile. These should not count as failures.
-            if ($response->getStatusCode() !== 422) {
+            $response = $exception->getResponse();
+
+            if ($response->getStatusCode() === 422) {
+                // We expect to get 422s from this endpoint for any users who sign up for
+                // a campaign but don't have a mobile on their profile. These should not
+                // be counted as failures!
+            } else {
                 throw $exception;
             }
         }


### PR DESCRIPTION
### What's this PR do?

This pull request properly catches the 422's being thrown by Gambit here when a user without a mobile number signs up for a campaign. The previous fix in #1131 didn't work because the `$response` variable was not defined yet when Guzzle throws the exception, so instead you have to grab it from the exception itself.

### How should this be reviewed?

For reference, here's [Guzzle's 'Exceptions' documentation](http://docs.guzzlephp.org/en/stable/quickstart.html#exceptions).

### Any background context you want to provide?

Third times the charm! I've hooked up my local to Gambit Staging & confirmed this fix actually works. 😅

### Relevant tickets

References [Pivotal #174827024](https://www.pivotaltracker.com/story/show/174827024).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
