### PR TITLE
Fix issue with 'campaign_cause' transformer.

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -366,7 +366,7 @@ class Post extends Model
                 'campaign_id' => (string) $this->campaign_id,
                 'campaign_title' => Arr::get($campaignWebsite, 'title'),
                 'campaign_slug' => Arr::get($campaignWebsite, 'slug'),
-                'campaign_cause' => implode(',', $campaign->cause),
+                'campaign_cause' => implode(',', $campaign->cause ?: []),
                 'northstar_id' => $this->northstar_id,
                 'type' => $this->type,
                 'action' => $this->getActionName(),

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -154,6 +154,23 @@ class PostModelTest extends TestCase
     }
 
     /**
+     * Test expected payload for Customer.io, even if the
+     * post's signup has been deleted.
+     *
+     * @return void
+     */
+    public function testCustomerIoPayloadWithoutSignup()
+    {
+        $post = factory(Post::class)->create();
+        $post->signup->delete();
+
+        $payload = $post->fresh()->toCustomerIoPayload();
+
+        $this->assertArrayHasKey('id', $payload);
+        $this->assertEquals('', $payload['campaign_cause']);
+    }
+
+    /**
      * Test expected payload for a referral post event.
      *
      * @return void


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue where `$campaign` not existing causes `implode` to pout when it's passed `null`. As a quick fix, we'll use the `?:` operator to pass an empty array in this scenario.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is happening because we're relying on the `optional()` helper's fallback behavior, and not the "empty" array provided by this field's accessor. (I also considered using a `$campaign ? … : null` ternary, but that made this take up multiple lines.)

### Relevant tickets

References [Pivotal #175209573](https://www.pivotaltracker.com/story/show/175209573) and [this Slack thread](https://dosomething.slack.com/archives/CUQMTP0RM/p1602278321008400?thread_ts=1602278269.008300&cid=CUQMTP0RM).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
