### PR TITLE
Clubs Cursor Pagination

### DIFF
--- a/app/Http/Controllers/ClubsController.php
+++ b/app/Http/Controllers/ClubsController.php
@@ -3,6 +3,7 @@
 namespace Rogue\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Rogue\Http\Transformers\ClubTransformer;
 use Rogue\Models\Club;
 
@@ -35,6 +36,11 @@ class ClubsController extends ApiController
 
         if (isset($filters['name'])) {
             $query->where('name', 'LIKE', '%' . $filters['name'] . '%');
+        }
+
+        if ($cursor = Arr::get($request->query('cursor'), 'after')) {
+            $query->whereAfterCursor($cursor);
+            $this->useCursorPagination = true;
         }
 
         return $this->paginatedCollection($query, $request);

--- a/app/Http/Transformers/ClubTransformer.php
+++ b/app/Http/Transformers/ClubTransformer.php
@@ -24,6 +24,7 @@ class ClubTransformer extends TransformerAbstract
             'school_id' => $club->school_id,
             'created_at' => $club->created_at->toIso8601String(),
             'updated_at' => $club->updated_at->toIso8601String(),
+            'cursor' => $club->getCursor(),
         ];
     }
 }

--- a/app/Models/Club.php
+++ b/app/Models/Club.php
@@ -3,9 +3,12 @@
 namespace Rogue\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Rogue\Models\Traits\HasCursor;
 
 class Club extends Model
 {
+    use HasCursor;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/docs/endpoints/clubs.md
+++ b/docs/endpoints/clubs.md
@@ -16,6 +16,9 @@ GET /api/v3/clubs
 
   - Filter results by names that include the given filter, e.g. `filter[name]=Oakland`.
 
+- **cursor[after]** _(string)_
+  - Get results _after_ specified cursor (Base-64 encoded ID of Club).
+
 Example Response:
 
 ```

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -59,6 +59,26 @@ class ClubTest extends TestCase
     }
 
     /**
+     * Test that we can paginate clubs using 'after' cursor.
+     * GET /api/v3/campaigns.
+     * @return void
+     */
+    public function testClubIndexAfterCursor()
+    {
+        $clubOne = factory(Club::class)->create();
+        $clubTwo = factory(Club::class)->create();
+
+        $response = $this->getJson(
+            'api/v3/clubs?cursor[after]=' . $clubOne->getCursor(),
+        );
+        $decodedResponse = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $decodedResponse['meta']['cursor']['count']);
+        $this->assertEquals($clubTwo->id, $decodedResponse['data'][0]['id']);
+    }
+
+    /**
      * Test that a GET request to /api/v3/clubs/:id returns the intended club.
      *
      * @return void


### PR DESCRIPTION
### What's this PR do?

This pull request adds cursor ('after') pagination to the Clubs API index endpoint.
Follows #1049 by example.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will allow us to implement a web index page for clubs using cursor pagination via GraphQL as we've done for e.g. Groups in #1052 

### Relevant tickets

References [Pivotal #174301487](https://www.pivotaltracker.com/story/show/174301487).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
