### PR TITLE
Add Clubs Index & Show Pages

### DIFF
--- a/docs/features/clubs.md
+++ b/docs/features/clubs.md
@@ -20,7 +20,7 @@ Clubs can be edited by visiting the edit page using the Club ID e.g. https://act
 
 ## Viewing a club
 
-Currently, clubs can only be viewed through the API using the Club ID e.g. https://activity.dosomething.org/api/v3/clubs/1
+The full list of clubs can be viewed at https://activity.dosomething.org/clubs. Individual clubs via appending the ID, e.g. https://activity.dosomething.org/clubs/1.
 
 ## Updating a user's club
 

--- a/docs/features/clubs.md
+++ b/docs/features/clubs.md
@@ -26,6 +26,10 @@ The full list of clubs can be viewed at https://activity.dosomething.org/clubs. 
 
 You can view and update a user's `club_id` field via their profile page on our [admin site](https://admin.dosomething.org/users).
 
+## Joining a club
+
+Over on our website, users can join a club via an embedded [Current Club Block](https://dosomething.gitbook.io/phoenix-documentation/development/content-types/current-club-block).
+
 ## Tracking Impact
 
 Any Signups or Posts created for a user associated with a club will track the Clubs ID in the `club_id` field of the Signup/Post.

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -9,6 +9,7 @@ import ShowPost from './pages/ShowPost';
 import ShowUser from './pages/ShowUser';
 import PostIndex from './pages/PostIndex';
 import UserIndex from './pages/UserIndex';
+import ClubIndex from './pages/ClubIndex';
 import ShowGroup from './pages/ShowGroup';
 import ShowAction from './pages/ShowAction';
 import ShowSignup from './pages/ShowSignup';
@@ -45,6 +46,9 @@ const Application = () => {
           <Redirect from="/campaigns/:id/inbox" to="/campaigns/:id/pending" />
           <Route path="/campaigns/:id/:status">
             <ShowCampaign />
+          </Route>
+          <Route path="/clubs" exact>
+            <ClubIndex />
           </Route>
           <Route path="/clubs/:id">
             <ShowClub />

--- a/resources/assets/Application.js
+++ b/resources/assets/Application.js
@@ -4,6 +4,7 @@ import { ApolloProvider } from '@apollo/react-hooks';
 
 import { env } from './helpers';
 import graphql from './graphql';
+import ShowClub from './pages/ShowClub';
 import ShowPost from './pages/ShowPost';
 import ShowUser from './pages/ShowUser';
 import PostIndex from './pages/PostIndex';
@@ -44,6 +45,9 @@ const Application = () => {
           <Redirect from="/campaigns/:id/inbox" to="/campaigns/:id/pending" />
           <Route path="/campaigns/:id/:status">
             <ShowCampaign />
+          </Route>
+          <Route path="/clubs/:id">
+            <ShowClub />
           </Route>
           <Route path="/groups" exact>
             <GroupTypeIndex />

--- a/resources/assets/components/CampaignsTable.js
+++ b/resources/assets/components/CampaignsTable.js
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react';
 
 import Empty from './Empty';
 import { updateQuery } from '../helpers';
+import ErrorBlock from './utilities/ErrorBlock';
 import EntityLabel from './utilities/EntityLabel';
 import SortableHeading from './utilities/SortableHeading';
 
@@ -106,12 +107,7 @@ const CampaignsTable = ({ isOpen, filter }) => {
   }, [filter, endCursor]);
 
   if (error) {
-    return (
-      <div className="text-center">
-        <p>There was an error. :(</p>
-        <code>{JSON.stringify(error)}</code>
-      </div>
-    );
+    return <ErrorBlock error={error} />;
   }
 
   if (noFilteredResults && !hasNextPage) {

--- a/resources/assets/components/ClubsTable.js
+++ b/resources/assets/components/ClubsTable.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+
+import Empty from './Empty';
+import EntityLabel from './utilities/EntityLabel';
+import { updateQuery } from '../helpers';
+
+const CLUBS_QUERY = gql`
+  query ClubsIndexQuery($filter: String, $cursor: String) {
+    clubs: paginatedClubs(after: $cursor, first: 50, name: $filter) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          city
+          location
+          leader {
+            id
+            firstName
+          }
+          schoolId
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+/**
+ * This component handles fetching & paginating a list of clubs matching the given filter.
+ *
+ * @param {String} filter
+ */
+const ClubsTable = ({ filter }) => {
+  const { error, loading, data, fetchMore } = useQuery(CLUBS_QUERY, {
+    variables: { filter },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const clubs = get(data, 'clubs.edges', []);
+  const noResults = !clubs.length && !loading;
+  const { endCursor, hasNextPage } = get(data, 'clubs.pageInfo', {});
+
+  const handleViewMore = () =>
+    fetchMore({ variables: { cursor: endCursor }, updateQuery });
+
+  if (error) {
+    return (
+      <div className="text-center">
+        <p>There was an error. :(</p>
+
+        <code>{JSON.stringify(error)}</code>
+      </div>
+    );
+  }
+
+  if (noResults && !hasNextPage) {
+    return (
+      <Empty
+        copy={`Could not find any clubs${
+          filter ? ` containing "${filter}"` : ''
+        }.`}
+      />
+    );
+  }
+
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          <td>Club ID</td>
+          <td>Location</td>
+          <td>Leader</td>
+          <td>School ID</td>
+        </tr>
+      </thead>
+
+      <tbody>
+        {clubs.map(({ node, cursor }) => (
+          <tr key={cursor}>
+            <td>
+              <EntityLabel id={node.id} name={node.name} path="clubs" />
+            </td>
+            <td>{node.city ? `${node.city}, ${node.location}` : null}</td>
+            <td>
+              <EntityLabel
+                id={node.leader.id}
+                name={node.leader.firstName}
+                path="users"
+              />
+            </td>
+            <td>
+              {node.schoolId ? (
+                <EntityLabel
+                  id={node.schoolId}
+                  name={node.schoolId}
+                  path="schools"
+                />
+              ) : null}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+
+      <tfoot className="form-actions">
+        {loading ? (
+          <tr>
+            <td colSpan="4">
+              <div className="spinner margin-horizontal-auto margin-vertical" />
+            </td>
+          </tr>
+        ) : null}
+
+        {hasNextPage ? (
+          <tr>
+            <td colSpan="4">
+              <button
+                className="button -tertiary"
+                onClick={handleViewMore}
+                disabled={loading}
+              >
+                view more...
+              </button>
+            </td>
+          </tr>
+        ) : null}
+      </tfoot>
+    </table>
+  );
+};
+
+export default ClubsTable;

--- a/resources/assets/components/ClubsTable.js
+++ b/resources/assets/components/ClubsTable.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 
 import Empty from './Empty';
+import ErrorBlock from './utilities/ErrorBlock';
 import EntityLabel from './utilities/EntityLabel';
 import { updateQuery } from '../helpers';
 
@@ -51,13 +52,7 @@ const ClubsTable = ({ filter }) => {
     fetchMore({ variables: { cursor: endCursor }, updateQuery });
 
   if (error) {
-    return (
-      <div className="text-center">
-        <p>There was an error. :(</p>
-
-        <code>{JSON.stringify(error)}</code>
-      </div>
-    );
+    return <ErrorBlock error={error} />;
   }
 
   if (noResults && !hasNextPage) {

--- a/resources/assets/components/GroupsTable.js
+++ b/resources/assets/components/GroupsTable.js
@@ -4,6 +4,7 @@ import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
 import Empty from './Empty';
+import ErrorBlock from './utilities/ErrorBlock';
 import EntityLabel from './utilities/EntityLabel';
 import { updateQuery } from '../helpers';
 
@@ -70,12 +71,7 @@ const GroupsTable = ({ filter, groupLocation, groupTypeId }) => {
   };
 
   if (error) {
-    return (
-      <div className="text-center">
-        <p>There was an error. :(</p>
-        <code>{JSON.stringify(error)}</code>
-      </div>
-    );
+    return <ErrorBlock error={error} />;
   }
 
   if (noResults && !hasNextPage) {

--- a/resources/assets/components/utilities/ErrorBlock.js
+++ b/resources/assets/components/utilities/ErrorBlock.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ErrorBlock = error => (
+  <div className="text-center">
+    <p>There was an error. :(</p>
+
+    <code>{JSON.stringify(error)}</code>
+  </div>
+);
+
+export default ErrorBlock;

--- a/resources/assets/pages/ClubIndex.js
+++ b/resources/assets/pages/ClubIndex.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+import Shell from '../components/utilities/Shell';
+import ClubsTable from '../components/ClubsTable';
+
+const ClubIndex = () => {
+  const [filter, setFilter] = useState('');
+
+  const title = 'Clubs';
+  document.title = title;
+
+  return (
+    <Shell title={title}>
+      <div className="container__row">
+        <div className="container__block -half">
+          <input
+            type="text"
+            className="text-field -search"
+            placeholder="Filter by club name"
+            onChange={event => setFilter(event.target.value)}
+          />
+        </div>
+
+        <div className="container__block -half form-actions -inline text-right">
+          <a className="button -tertiary" href="/clubs/create">
+            New Club
+          </a>
+        </div>
+      </div>
+
+      <div className="container__row">
+        <div className="container__block">
+          <ClubsTable filter={filter} />
+        </div>
+      </div>
+    </Shell>
+  );
+};
+
+export default ClubIndex;

--- a/resources/assets/pages/ShowClub.js
+++ b/resources/assets/pages/ShowClub.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+import { Link, useParams } from 'react-router-dom';
+
+import NotFound from '../pages/NotFound';
+import Shell from '../components/utilities/Shell';
+import MetaInformation from '../components/utilities/MetaInformation';
+
+const SHOW_CLUB_QUERY = gql`
+  query ShowClubQuery($id: Int!) {
+    club(id: $id) {
+      id
+      name
+      city
+      location
+      leader {
+        id
+        displayName
+      }
+      schoolId
+    }
+  }
+`;
+
+const ShowClub = () => {
+  const { id } = useParams();
+  const title = `Club #${id}`;
+  document.title = title;
+
+  const { loading, error, data } = useQuery(SHOW_CLUB_QUERY, {
+    variables: { id: Number(id) },
+  });
+
+  if (error) {
+    return <Shell error={error} />;
+  }
+
+  if (loading) {
+    return <Shell title={title} loading />;
+  }
+
+  if (!data.club) {
+    return <NotFound title={title} type="club" />;
+  }
+
+  const { name, city, location, leader, schoolId } = data.club;
+
+  return (
+    <Shell title={title} subtitle={name}>
+      <div className="container__row">
+        <div className="container__block -half">
+          <MetaInformation
+            details={{
+              Name: name,
+              City: city || '--',
+              Location: location || '--',
+              Leader: (
+                <Link to={`/users/${leader.id}`}>{leader.displayName}</Link>
+              ),
+              School: schoolId ? (
+                <Link to={`/schools/${schoolId}`}>{schoolId}</Link>
+              ) : (
+                '--'
+              ),
+            }}
+          />
+        </div>
+
+        <div className="container__block -half form-actions -inline text-right">
+          <a className="button -tertiary" href={`/clubs/${id}/edit`}>
+            Edit Club #{id}
+          </a>
+        </div>
+
+        {/* @TODO: Display table of club members here. */}
+        {/* @TODO: Display table of clubs posts/signups. */}
+      </div>
+    </Shell>
+  );
+};
+
+export default ShowClub;

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,6 +53,10 @@ Route::middleware(['auth', 'role:staff,admin'])->group(function () {
     Route::view('campaigns/{id}', 'app');
     Route::view('campaigns/{id}/{status}', 'app');
 
+    // Clubs
+    Route::view('clubs', 'app');
+    Route::view('clubs/{id}', 'app');
+
     // Groups
     Route::view('groups', 'app');
     Route::view('groups/{id}', 'app');


### PR DESCRIPTION
### What's this PR do?

This pull request adds index `/clubs` and show `/clubs/:id` pages for the Clubs resource via React.
https://github.com/DoSomething/rogue/commit/9bc1df30fd230fdfd633f18801561b0e23fe8e0a extracts a repeated bit of logic for error blocks into a new utility component.

### How should this be reviewed?
I followed existing pages by example notably the [`CampaignsTable`](https://github.com/DoSomething/rogue/blob/863e71736c188c41c25cb2fbbc8c41b5e0747710/resources/assets/components/CampaignsTable.js), [`GroupsTable`](https://github.com/DoSomething/rogue/blob/863e71736c188c41c25cb2fbbc8c41b5e0747710/resources/assets/components/GroupsTable.js), [`GroupTypeIndex`](https://github.com/DoSomething/rogue/blob/863e71736c188c41c25cb2fbbc8c41b5e0747710/resources/assets/pages/GroupTypeIndex.js), and [`ShowGroup`](https://github.com/DoSomething/rogue/blob/863e71736c188c41c25cb2fbbc8c41b5e0747710/resources/assets/pages/ShowGroup.js).

More work to be done here to embed the list of club members, and a table of the clubs posts & signups.

### Any background context you want to provide?
We set the stage for paginating the index of clubs for the index page in #1135 & https://github.com/DoSomething/graphql/pull/282

### Relevant tickets

References [Pivotal #174301487](https://www.pivotaltracker.com/story/show/174301487).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

<img width="1552" alt="Screen Shot 2020-10-14 at 3 49 14 PM" src="https://user-images.githubusercontent.com/12417657/96039128-2fecc100-0e36-11eb-9d54-5eb571c2c2f3.png">
<img width="1552" alt="Screen Shot 2020-10-14 at 3 49 07 PM" src="https://user-images.githubusercontent.com/12417657/96039130-30855780-0e36-11eb-856e-3e055f440647.png">

