### PR TITLE
Add Navigation Link to Clubs Page

### DIFF
--- a/resources/views/layouts/nav.blade.php
+++ b/resources/views/layouts/nav.blade.php
@@ -16,6 +16,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="/clubs">
+                        <strong class="navigation__title">Clubs</strong>
+                        <span class="navigation__subtitle">Review & edit</span>
+                    </a>
+                </li>
+                <li>
                     <a href="/faq">
                         <strong class="navigation__title">FAQ</strong>
                         <span class="navigation__subtitle">How do I...</span>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a link in the navigation bar to the new clubs page added in #1136 

### How should this be reviewed?
👀 

### Any background context you want to provide?
https://www.pivotaltracker.com/story/show/174301487/comments/218827256

I suppose at some point it could be worth adding a dropdown or index page linking to the various resources available on Rogue that have no direct links as of now.

### Relevant tickets

References [Pivotal #174301487](https://www.pivotaltracker.com/story/show/174301487).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/96048536-c1632f80-0e44-11eb-91b6-9664fe3fb8a3.png)
