### PR TITLE
Render Club Leader ID Safely

### DIFF
--- a/resources/assets/components/ClubsTable.js
+++ b/resources/assets/components/ClubsTable.js
@@ -18,6 +18,7 @@ const CLUBS_QUERY = gql`
           name
           city
           location
+          leaderId
           leader {
             id
             firstName
@@ -84,11 +85,15 @@ const ClubsTable = ({ filter }) => {
             </td>
             <td>{node.city ? `${node.city}, ${node.location}` : null}</td>
             <td>
-              <EntityLabel
-                id={node.leader.id}
-                name={node.leader.firstName}
-                path="users"
-              />
+              {node.leader ? (
+                <EntityLabel
+                  id={node.leader.id}
+                  name={node.leader.firstName}
+                  path="users"
+                />
+              ) : (
+                node.leaderId
+              )}
             </td>
             <td>
               {node.schoolId ? (


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the Club index table to render the Club's `leaderId` instead of the nested leader resource, if the resource is unavailable.

### How should this be reviewed?
👀 

### Any background context you want to provide?
The leaderId is a required field and must be a valid Northstar ID. However 
1. We don't validate this against NS, it really only needs to be a valid Mongodb ID
2. The user can be deleted and we don't remove the leader id from the club

I noticed that the table was breaking on production since presumably we're being met by one of these scenarios.

I think this is edge-casey enough, for now, to simply safely render the leader ID instead. But perhaps we should think about adding clearing the Leader ID from the club if the user is deleted? And/or properly validate the Leader ID against Northstar?

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
