### PR TITLE
Fix cursor pagination errors for Action Stats index endpoint

### DIFF
--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -32,27 +32,10 @@ class ActionStatsController extends ApiController
         $query = $this->newQuery(ActionStat::class);
 
         $filters = $request->query('filter');
-
-        /**
-         * Because we may be joining on groups, which also have location and school_id columns, we
-         * specify our table name to avoid integrity constraint violations for ambiguous clauses.
-         */
-        $tableName = $query->getModel()->getTable();
-
-        if (Arr::has($filters, 'action_id')) {
-            $query->where('action_id', $filters['action_id']);
-        }
-
-        if (Arr::has($filters, 'location')) {
-            $query->where($tableName . '.location', $filters['location']);
-        }
+        $query = $this->filter($query, $filters, ActionStat::$indexes);
 
         if (Arr::has($filters, 'group_type_id')) {
             $query = $query->inGroupTypeId($filters['group_type_id']);
-        }
-
-        if (Arr::has($filters, 'school_id')) {
-            $query->where($tableName . '.school_id', $filters['school_id']);
         }
 
         // Allow ordering results:

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -42,6 +42,12 @@ trait HasCursor
 
         $orderBy = request()->query('orderBy');
 
+        /**
+         * Because we may be joining tables, specify the base query table name
+         * to avoid integrity constraint violations for ambiguous clauses.
+         */
+        $idField = $query->getModel()->getTable() . '.id';
+
         // If we're sorting by anything other than ID, things get a lil' tricky. First,
         // we'll extract the sorted column & direction from the `?orderBy` query string:
         if ($orderBy && $orderBy !== 'id,asc' && !is_null($sortCursor)) {
@@ -57,14 +63,14 @@ trait HasCursor
                 $query->where($column, $operator, $sortCursor);
                 $query->orWhere([
                     [$column, '=', $sortCursor],
-                    ['id', '>', $id],
+                    [$idField, '>', $id],
                 ]);
 
                 // @TODO: This gets a lot more complicated if the sorted column can have nulls...
             }
         } else {
             // Otherwise, treat as a plain ID cursor... easy!
-            $query->where('id', '>', $id);
+            $query->where($idField, '>', $id);
         }
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,6 +52,12 @@ function multipleValueQuery($query, $queryString, $filter)
 {
     $values = explode(',', $queryString);
 
+    /**
+     * Because we may be joining tables, specify the base query table name
+     * to avoid integrity constraint violations for ambiguous clauses.
+     */
+    $filter = $query->getModel()->getTable() . '.' . $filter;
+
     if (count($values) > 1) {
         // For the first `where` query, we want to limit results... from then on,
         // we want to append (e.g. `SELECT * (WHERE _ OR WHERE _ OR WHERE _)` and (WHERE _ OR WHERE _))

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -21,7 +21,7 @@ class ActionStatsTest extends TestCase
         // Create five action stats.
         factory(ActionStat::class, 5)->create();
 
-        $response = $this->getJson('api/v3/action-stats');
+        $response = $this->getJson($this->url);
         $decodedResponse = $response->decodeResponseJson();
 
         $response->assertStatus(200);
@@ -68,7 +68,7 @@ class ActionStatsTest extends TestCase
         $this->assertEquals(2, $decodedResponse['meta']['pagination']['count']);
 
         $response = $this->getJson(
-            'api/v3/action-stats?filter[group_type_id]=' . $secondGroupTypeId,
+            $this->url . '?filter[group_type_id]=' . $secondGroupTypeId,
         );
         $decodedResponse = $response->decodeResponseJson();
 
@@ -77,7 +77,8 @@ class ActionStatsTest extends TestCase
 
         // Verify no errors are thrown when using a groupBy query.
         $response = $this->getJson(
-            'api/v3/action-stats?orderBy=impact,desc&filter[group_type_id]=' .
+            $this->url .
+                '?orderBy=impact,desc&filter[group_type_id]=' .
                 $secondGroupTypeId,
         );
         $decodedResponse = $response->decodeResponseJson();
@@ -123,8 +124,7 @@ class ActionStatsTest extends TestCase
         ]);
 
         $response = $this->getJson(
-            'api/v3/action-stats?filter[location]=' .
-                $firstActionStat->location,
+            $this->url . '?filter[location]=' . $firstActionStat->location,
         );
         $decodedResponse = $response->decodeResponseJson();
 
@@ -133,7 +133,8 @@ class ActionStatsTest extends TestCase
 
         // Verify no errors are thrown when additionally filtering by group_type_id.
         $response = $this->getJson(
-            'api/v3/action-stats?orderBy=impact,desc&filter[group_type_id]=' .
+            $this->url .
+                '?orderBy=impact,desc&filter[group_type_id]=' .
                 $firstGroupTypeId .
                 '&filter[location]=' .
                 $firstActionStat->location,


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the ` Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous ` error that occurs if querying the `GET /action-stats` index endpoint with `filter[group_type_id]` and `cursor[after]` query parameters set, by specifying the table name of our base model in the `HasCursor` trait, per @DFurnes's helpful comment in https://github.com/DoSomething/rogue/pull/1125#issuecomment-702849789.

It also cleans up the `ActionStatsController` per https://github.com/DoSomething/rogue/pull/1125#discussion_r498941457, so any other endpoints that may end up joining on other tables won't suffer from the same ambiguous column errors.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Question for @DFurnes -- in https://github.com/DoSomething/rogue/pull/1125#issuecomment-702850642 you mention adding a simple test to demonstrate the bug. I can't think of a way to do this, beyond adding a new query parameter that would avoid specifying the table name in `HasCursor` and `multipleValueQuery`... but this seems like it complicates the code even more for the sake of a test. Did you have a different approach in mind?

### Relevant tickets

References [Pivotal #175272211](https://www.pivotaltracker.com/story/show/175272211).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
