### PR TITLE
Display Club in Signup & Post Views & Tables

### DIFF
--- a/resources/assets/components/PostsTable.js
+++ b/resources/assets/components/PostsTable.js
@@ -36,6 +36,10 @@ const POSTS_INDEX_QUERY = gql`
             id
             internalTitle
           }
+          club {
+            id
+            name
+          }
           groupId
           group {
             id
@@ -106,6 +110,8 @@ const PostsTable = ({ campaignId, groupId, referrerUserId, userId }) => {
             <td>Status</td>
 
             {groupId ? null : <td>Group</td>}
+
+            <td>Club</td>
           </tr>
         </thead>
         <tbody>
@@ -148,6 +154,16 @@ const PostsTable = ({ campaignId, groupId, referrerUserId, userId }) => {
                   ) : null}
                 </td>
               )}
+
+              <td>
+                {node.club ? (
+                  <EntityLabel
+                    id={node.club.id}
+                    name={node.club.name}
+                    path="clubs"
+                  />
+                ) : null}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -36,6 +36,7 @@ export const ReviewablePostFragment = gql`
     createdAt
     source
     details
+    clubId
     groupId
     referrerUserId
     schoolId
@@ -205,6 +206,11 @@ const ReviewablePost = ({ post }) => {
                 </Link>
               ) : (
                 '-'
+              ),
+              Club: post.clubId ? (
+                <Link to={`/clubs/${post.clubId}`}>{post.clubId}</Link>
+              ) : (
+                '--'
               ),
               Group: post.groupId ? (
                 <Link to={`/groups/${post.groupId}`}>{post.groupId}</Link>

--- a/resources/assets/components/SignupsTable.js
+++ b/resources/assets/components/SignupsTable.js
@@ -25,6 +25,10 @@ const SIGNUPS_TABLE_QUERY = gql`
             id
             internalTitle
           }
+          club {
+            id
+            name
+          }
           groupId
           group {
             id
@@ -98,6 +102,8 @@ const SignupsTable = ({ campaignId, groupId }) => {
             {campaignId ? null : <td>Campaign</td>}
 
             {groupId ? null : <td>Group</td>}
+
+            <td>Club</td>
           </tr>
         </thead>
         <tbody>
@@ -134,6 +140,18 @@ const SignupsTable = ({ campaignId, groupId }) => {
                   ) : null}
                 </td>
               )}
+
+              <td>
+                {node.club ? (
+                  <EntityLabel
+                    id={node.club.id}
+                    name={node.club.name}
+                    path="clubs"
+                  />
+                ) : (
+                  '--'
+                )}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/resources/assets/pages/ShowSignup.js
+++ b/resources/assets/pages/ShowSignup.js
@@ -18,6 +18,7 @@ const SHOW_SIGNUP_QUERY = gql`
   query ShowCampaignQuery($id: Int!) {
     signup(id: $id) {
       id
+      clubId
       groupId
       whyParticipated
       source
@@ -103,6 +104,13 @@ const ShowCampaign = () => {
                     Group: signup.groupId ? (
                       <Link to={`/groups/${signup.groupId}`}>
                         {signup.groupId}
+                      </Link>
+                    ) : (
+                      '-'
+                    ),
+                    Club: signup.clubId ? (
+                      <Link to={`/clubs/${signup.clubId}`}>
+                        {signup.clubId}
                       </Link>
                     ) : (
                       '-'


### PR DESCRIPTION
### What's this PR do?

This pull request surfaces the Club ID on Signup & Post index tables and individual views. Per https://github.com/DoSomething/graphql/pull/285 & https://github.com/DoSomething/graphql/pull/284

### How should this be reviewed?
👀 

These tables are getting a lil crowded?

### Any background context you want to provide?
Admin convenience!


### Relevant tickets

References [Pivotal #174934297](https://www.pivotaltracker.com/story/show/174934297).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

📸 
- [Signup Table](https://user-images.githubusercontent.com/12417657/96305474-ecc45680-0fcb-11eb-97b3-cb109ca50ecc.png)
- [Signup view](https://user-images.githubusercontent.com/12417657/96305494-f352ce00-0fcb-11eb-8d9f-1611ab08eb50.png)
- [Post view](https://user-images.githubusercontent.com/12417657/96305546-10879c80-0fcc-11eb-9fa4-98780bc35d8b.png)
- [Post table](https://user-images.githubusercontent.com/12417657/96305565-17aeaa80-0fcc-11eb-8393-4b5d998f06ad.png)
