### PR TITLE
Handle undeliverable 'bad requests'.

### DIFF
--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -63,6 +63,10 @@ class Gambit
                 // We expect to get 422s from this endpoint for any users who sign up for
                 // a campaign but don't have a mobile on their profile or are unsubscribed
                 // from text messages. These should not be counted as failures!
+            } elseif ($response->getStatusCode() === 400) {
+                // We expect to get 400s from this endpoint for any users who sign up for
+                // a campaign & have a mobile, but the mobile number is undeliverable. Since
+                // this likely won't change, this shouldn't be counted as a failure!
             } else {
                 throw $exception;
             }


### PR DESCRIPTION
### What's this PR do?

This pull request handles `400 Bad Request` errors from Gambit, which we've been seeing pile up in our "failed jobs" table and continually get retried every morning. Since these are all due to "not currently reachable" errors for users who can't receive SMS messages, there's no reason to mark these as failed jobs.

### How should this be reviewed?

👀

### Any background context you want to provide?

See [recent Rogue errors](https://my.papertrailapp.com/groups/10447062/events?focus=1255803625465982976&q=%28sender%3Adosomething-rogue%20%28production.ERROR%20OR%20status%3D5%29%29%20%20OR%20%28sender%3Afastly%20status%3D5%20app%3Ddosomething-rogue%29) and [this Slack thread](https://dosomething.slack.com/archives/CUQMTP0RM/p1602598318001900).

### Relevant tickets

References [Pivotal #175287738](https://www.pivotaltracker.com/story/show/175287738).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
