### PR TITLE
Remove unused 'dont_send_to_blink' parameters.

### DIFF
--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -54,17 +54,10 @@ class PostManager
             $authenticatedUserRole,
         );
 
-        // Send to Customer.io unless 'dont_send_to_blink' is TRUE
-        $shouldSendToCustomerIo = !(
-            array_key_exists('dont_send_to_blink', $data) &&
-            $data['dont_send_to_blink']
-        );
+        // Send post event(s) to Customer.io for messaging:
+        SendPostToCustomerIo::dispatch($post);
 
-        if ($shouldSendToCustomerIo) {
-            SendPostToCustomerIo::dispatch($post);
-        }
-
-        if ($post->referrer_user_id && $shouldSendToCustomerIo) {
+        if ($post->referrer_user_id) {
             CreateCustomerIoEvent::dispatch(
                 $post->referrer_user_id,
                 'referral_post_created',
@@ -94,18 +87,10 @@ class PostManager
     {
         $post = $this->repository->update($post, $data);
 
-        // Save the new post in Customer.io, via Blink,
-        // unless 'dont_send_to_blink' is TRUE.
-        $shouldSendToCustomerIo = !(
-            array_key_exists('dont_send_to_blink', $data) &&
-            $data['dont_send_to_blink']
-        );
+        // Send post event(s) to Customer.io for messaging:
+        SendPostToCustomerIo::dispatch($post);
 
-        if ($shouldSendToCustomerIo) {
-            SendPostToCustomerIo::dispatch($post);
-        }
-
-        if ($post->referrer_user_id && $shouldSendToCustomerIo) {
+        if ($post->referrer_user_id) {
             CreateCustomerIoEvent::dispatch(
                 $post->referrer_user_id,
                 'referral_post_updated',

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -38,23 +38,15 @@ class SignupManager
     {
         $signup = $this->signup->create($data, $northstarId, $campaignId);
 
-        // Send to Customer.io unless 'dont_send_to_blink' is TRUE
-        $shouldSendToCustomerIo = !(
-            array_key_exists('dont_send_to_blink', $data) &&
-            $data['dont_send_to_blink']
-        );
-
-        // Send the new signup to Customer.io:
-        if ($shouldSendToCustomerIo) {
-            SendSignupToCustomerIo::dispatch($signup);
-        }
+        // Send signup event(s) to Customer.io for messaging:
+        SendSignupToCustomerIo::dispatch($signup);
 
         // If this wasn't triggered via SMS, send to Gambit:
         if (!preg_match('/(sms|gambit)/', $signup->source)) {
             SendSignupToGambit::dispatch($signup);
         }
 
-        if ($signup->referrer_user_id && $shouldSendToCustomerIo) {
+        if ($signup->referrer_user_id) {
             CreateCustomerIoEvent::dispatch(
                 $signup->referrer_user_id,
                 'referral_signup_created',

--- a/docs/endpoints/posts.md
+++ b/docs/endpoints/posts.md
@@ -264,8 +264,6 @@ Optional params:
   The referring User ID that this post should be associated with.
 - **group_id** (int).
   The Group ID that this post should be associated with.
-- **dont_send_to_blink** (boolean).
-  If included and true, the data for this Post will not be sent to Customer.io.
 - **created_at** (timestamp).
   If admin and included, the timestamp to set the `created_at` date to. This would be used in a case when we're importing data from the importer app (e.g. `voter-reg` posts, historical FB share posts, etc.).
 

--- a/docs/endpoints/signups.md
+++ b/docs/endpoints/signups.md
@@ -24,8 +24,6 @@ POST /api/v3/signups
   The referring User ID that this signup should be associated with.
 - **group_id**: (int) optional.
   The Group ID that this signup should be associated with.
-- **dont_send_to_blink** (boolean) optional.
-  If included and true, the data for this Signup will not be sent to Customer.io.
 - **created_at**: (string) optional.
   `Y-m-d H:i:s` format. When the signup was created.
 - **updated_at**: (string) optional.


### PR DESCRIPTION
### What's this PR do?

This pull request removes the unused `dont_send_to_blink` parameters from signup & post endpoints. These are no longer accurate (it should really be `dont_send_to_customer_io`), and [no longer used anywhere](https://github.com/search?q=org%3ADoSomething+dont_send_to_blink&type=code) (aside from a very old Ashes script).

If we need to exclude a set of posts from messaging in the future, we can do so with Customer.io trigger rules.

### How should this be reviewed?

👀

### Any background context you want to provide?

Thanks @aaronschachter for flagging this in https://github.com/DoSomething/rogue/pull/1143#discussion_r510333090!

### Relevant tickets

N/A

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
