### PR TITLE
Campaign 'Searchable' payload - Add has_website computed attribute for filtering

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -326,6 +326,9 @@ class Campaign extends Model
             $array[$date] = optional($this->{$date})->timestamp;
         }
 
+        // Add boolean attribute for filtering website campaigns.
+        $array['has_website'] = !is_null($this->contentful_campaign_id);
+
         // Only send data we want to search against.
         return Arr::only($array, [
             'accepted_count',
@@ -333,6 +336,7 @@ class Campaign extends Model
             'contentful_campaign_id',
             'cause',
             'end_date',
+            'has_website',
             'id',
             'internal_title',
             'pending_count',

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -327,7 +327,7 @@ class Campaign extends Model
         }
 
         // Add boolean attribute for filtering website campaigns.
-        $array['has_website'] = !is_null($this->contentful_campaign_id);
+        $array['has_website'] = isset($this->contentful_campaign_id);
 
         // Only send data we want to search against.
         return Arr::only($array, [

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -37,5 +37,19 @@ class CampaignTest extends TestCase
             $searchableArray['end_date'],
             $campaign->end_date->timestamp,
         );
+
+        // There should be a computed boolean determining if the campaign is a Website Campaign.
+        // With a non-populated contentful_campaign_id:
+        $this->assertEquals($searchableArray['has_website'], false);
+
+        // With a populated contentful_campaign_id:
+        $websiteCampaign = factory(Campaign::class)->create([
+            'contentful_campaign_id' => '123',
+        ]);
+
+        $this->assertEquals(
+            $websiteCampaign->toSearchableArray()['has_website'],
+            true,
+        );
     }
 }

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Rogue\Models\Action;
+use Rogue\Models\Campaign;
+use Tests\TestCase;
+
+class CampaignTest extends TestCase
+{
+    /**
+     * Test expected payload for Laravel Scout / Algolia.
+     *
+     * @return void
+     */
+    public function testToSearchableArray()
+    {
+        $campaign = factory(Campaign::class)->create();
+        $action = factory(Action::class)->create([
+            'campaign_id' => $campaign->id,
+        ]);
+
+        $searchableArray = $campaign->toSearchableArray();
+
+        // The Campaign's Actions should be in the payload.
+        $this->assertEquals(
+            $searchableArray['actions'][0]['name'],
+            $action->name,
+        );
+
+        // The date fields should be transformed to a UNIX timestamp.
+        $this->assertEquals(
+            $searchableArray['start_date'],
+            $campaign->start_date->timestamp,
+        );
+        $this->assertEquals(
+            $searchableArray['end_date'],
+            $campaign->end_date->timestamp,
+        );
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a computed `has_website` attribute to the payload generated by the `toSearchableArray` method on Campaigns (for Algolia / Laravel Scout) so that we can filter for website campaigns via Algolia.
  
### How should this be reviewed?
👀 

### Any background context you want to provide?
[Algolia specifies](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-by-null-or-missing-attributes/) two methods to filter by a missing/null attribute (which we're doing here -- a campaign with a null `campaign_contentful_id` is not a website campaign and vice versa).

The simpler of the two approaches seemed to be to simply add a computed attribute (the other method being to use a new `_tags` array for a built-in "faceted search"). And this is consistent with the existing `hasWebsite` filter [in GraphQL](https://github.com/DoSomething/graphql/blob/533018cbb108b279649e800dcd79e6fc1552a3a6/src/schema/rogue.js#L83-L84) / [Rogue Campaigns](https://github.com/DoSomething/rogue/blob/cff701d37ae979b55cb64a089aa19ea6e551d796/app/Models/Campaign.php#L132-L146).

Once this attribute is in Algolia, we can use a simple `has_website = 1` to filter for website campaigns.

This is all to continue equipping our [Algolia campaigns search](https://github.com/DoSomething/graphql/blob/master/src/dataSources/Algolia.js) on GraphQL with the functionality expected by the [Phoenix Paginated Campaigns gallery](https://github.com/DoSomething/phoenix-next/blob/6f77f7492c3ca15302a6a01a096a1b7a2b8ae23a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js).

### Relevant tickets

References [Pivotal #173817560](https://www.pivotaltracker.com/story/show/173817560).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
