### PR TITLE
Campaign Algolia/Scout payload - add is_evergreen attribute

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -329,6 +329,9 @@ class Campaign extends Model
         // Add boolean attribute for filtering website campaigns.
         $array['has_website'] = isset($this->contentful_campaign_id);
 
+        // Adds boolean attribute for filtering open/closed campaigns.
+        $array['is_evergreen'] = is_null($this->end_date);
+
         // Only send data we want to search against.
         return Arr::only($array, [
             'accepted_count',
@@ -339,6 +342,7 @@ class Campaign extends Model
             'has_website',
             'id',
             'internal_title',
+            'is_evergreen',
             'pending_count',
             'secondary_causes',
             'start_date',

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -38,17 +38,27 @@ class CampaignTest extends TestCase
             $campaign->end_date->timestamp,
         );
 
-        // There should be a computed boolean determining if the campaign is a Website Campaign.
+        // There should be computed boolean attributes determining:
+        // - if the campaign is a Website Campaign
+        // - if the campaign is evergreen (has no end date)
+        //
         // With a non-populated contentful_campaign_id:
         $this->assertEquals($searchableArray['has_website'], false);
+        // With a populated end_date:
+        $this->assertEquals($searchableArray['is_evergreen'], false);
 
-        // With a populated contentful_campaign_id:
-        $websiteCampaign = factory(Campaign::class)->create([
+        // With a populated contentful_campaign_id and no end_date.
+        $evergreenWebsiteCampaign = factory(Campaign::class)->create([
             'contentful_campaign_id' => '123',
+            'end_date' => null,
         ]);
 
         $this->assertEquals(
-            $websiteCampaign->toSearchableArray()['has_website'],
+            $evergreenWebsiteCampaign->toSearchableArray()['has_website'],
+            true,
+        );
+        $this->assertEquals(
+            $evergreenWebsiteCampaign->toSearchableArray()['is_evergreen'],
             true,
         );
     }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `is_evergreen` computed boolean attribute to the Campaign `toSearchableArray` payload for Algolia/Scout determining if the campaign is evergreen i.e. has an end date.

### How should this be reviewed?
Is this descriptive naming helpful or should this simply be called `has_end_date`?

### Any background context you want to provide?
I noticed a bug with the way we filter for open/closed campaigns [in GraphQL](https://github.com/DoSomething/graphql/blob/d57d4e6f08996b4614387fe2fff0438f408b678c/src/dataSources/Algolia.js#L49-L65) via Algolia.

Since the `end_date` [could be a `null` value](https://github.com/DoSomething/rogue/blob/5129bf34de477124a593c9a2e8fa561b3956e09b/app/Http/Controllers/Web/CampaignsController.php#L29), we're running a filter on a nullable field which will cause the filtering to fail.

Algolia [doesn't support](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-by-null-or-missing-attributes/) filtering by `null` values, but instead recommends either creating [a tag](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-by-null-or-missing-attributes/#creating-a-boolean-attribute), or [a boolean attribute](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/how-to/filter-by-null-or-missing-attributes/#creating-a-boolean-attribute) - which as in #1146, seems like the simpler choice.

We can then refine our filtering to be e.g. `start_date < ${now} AND (end_date > ${now} OR is_evergreen = 1)`

### Relevant tickets

References [Pivotal #173817560](https://www.pivotaltracker.com/story/show/173817560).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
