### PR TITLE
Campaign Algolia/Scout Payload - Limit the amount of Actions indexed

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -331,8 +331,12 @@ class Campaign extends Model
     {
         $array = $this->toArray();
 
+        // Only index the first 20 actions to prevent exceeding the permitted Algolia entry size (10kb).
+        // (A select few campaigns contain an overwhelming amount of actions. https://bit.ly/38WOlgq).
+        $actions = $this->actions->slice(0, 20);
+
         // Append data from Action model relationship.
-        $array['actions'] = $this->actions->map(function ($data) {
+        $array['actions'] = $actions->map(function ($data) {
             return Arr::only($data->toArray(), [
                 'action_type',
                 'anonymous',

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -61,5 +61,17 @@ class CampaignTest extends TestCase
             $evergreenWebsiteCampaign->toSearchableArray()['is_evergreen'],
             true,
         );
+
+        // We should only index the first 20 actions of the campaign.
+        $multiActionCampaign = factory(Campaign::class)->create();
+
+        factory(Action::class, 30)->create([
+            'campaign_id' => $multiActionCampaign->id,
+        ]);
+
+        $this->assertEquals(
+            $multiActionCampaign->toSearchableArray()['actions']->count(),
+            20,
+        );
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request limits the amount of actions sent to the Algolia/Scout payload for indexing to 20. This addresses an edge case, where some of our campaigns exceed the permitted entry size limit in Algolia due to an overwhelming amount of associated actions.

### How should this be reviewed?
Does this solution sound good for now? I opted to apply a global rule instead of addressing the two faulty campaigns specifically since it felt a bit cleaner and technically, could prevent this bug in the future.

### Any background context you want to provide?
The full context is in the thread of the attached Pivotal Story.

TL;DR:
We noticed the Laravel Scout import of our Campaigns into Algolia would fail after the first batch ("chunk") of 500 campaigns. Turns out the second batch would fail due to an entry size exceeding the size limit permitted for our Algolia plan -- [10kb](https://www.algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records/#:~:text=If%20you%20signed%20up%20for,record%20size%20across%20all%20records) per our "Legacy" plan on the free track.

Turns out that two campaigns on Rogue [8109 & 8017](https://www.pivotaltracker.com/story/show/175782135/comments/219865473) contain an epic amount of associated Actions. (our average is 2 or 3. These ones have >100 and >50 respectively).

[In the future](https://www.pivotaltracker.com/story/show/175782135/comments/219865965) we might go about cleaning up these campaigns. For now, we're limiting the number of actions indexed, which will solve our importing issue. (these campaigns are closed now in any case).

### Relevant tickets

References [Pivotal #175782135](https://www.pivotaltracker.com/story/show/175782135).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
