### PR TITLE
Algolia Campaign is_group_campaign Computed Attribute

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -20,7 +20,7 @@ class Campaign extends Model
      *
      * @var array
      */
-    protected $appends = ['has_website', 'is_evergreen'];
+    protected $appends = ['has_website', 'is_evergreen', 'is_group_campaign'];
 
     /**
      * The attributes that should be mutated to dates.
@@ -287,6 +287,16 @@ class Campaign extends Model
     {
         // If we don't have an assigned end date, this campaign is evergreen.
         return is_null($this->attributes['end_date']);
+    }
+
+    /**
+     * Accessor for determining if this campaign is associated with a specific Group Type.
+     *
+     * @return bool
+     */
+    public function getIsGroupCampaignAttribute()
+    {
+        return isset($this->attributes['group_type_id']);
     }
 
     /**

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -380,6 +380,7 @@ class Campaign extends Model
             'id',
             'internal_title',
             'is_evergreen',
+            'is_group_campaign',
             'pending_count',
             'secondary_causes',
             'start_date',

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Models;
 
 use Rogue\Models\Action;
 use Rogue\Models\Campaign;
+use Rogue\Models\GroupType;
 use Tests\TestCase;
 
 class CampaignTest extends TestCase
@@ -41,16 +42,20 @@ class CampaignTest extends TestCase
         // There should be computed boolean attributes determining:
         // - if the campaign is a Website Campaign
         // - if the campaign is evergreen (has no end date)
+        // - if the campaign is a group campain
         //
         // With a non-populated contentful_campaign_id:
         $this->assertEquals($searchableArray['has_website'], false);
         // With a populated end_date:
         $this->assertEquals($searchableArray['is_evergreen'], false);
+        // Without a group_type_id:
+        $this->assertEquals($searchableArray['is_group_campaign'], false);
 
         // With a populated contentful_campaign_id and no end_date.
         $evergreenWebsiteCampaign = factory(Campaign::class)->create([
             'contentful_campaign_id' => '123',
             'end_date' => null,
+            'group_type_id' => factory(GroupType::class)->create()->id,
         ]);
 
         $this->assertEquals(
@@ -59,6 +64,10 @@ class CampaignTest extends TestCase
         );
         $this->assertEquals(
             $evergreenWebsiteCampaign->toSearchableArray()['is_evergreen'],
+            true,
+        );
+        $this->assertEquals(
+            $evergreenWebsiteCampaign->toSearchableArray()['is_group_campaign'],
             true,
         );
 

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -45,11 +45,11 @@ class CampaignTest extends TestCase
         // - if the campaign is a group campaign
         //
         // With a non-populated contentful_campaign_id:
-        $this->assertEquals($searchableArray['has_website'], false);
+        $this->assertFalse($searchableArray['has_website']);
         // With a populated end_date:
-        $this->assertEquals($searchableArray['is_evergreen'], false);
+        $this->assertFalse($searchableArray['is_evergreen']);
         // Without a group_type_id:
-        $this->assertEquals($searchableArray['is_group_campaign'], false);
+        $this->assertFalse($searchableArray['is_group_campaign']);
 
         // With a populated contentful_campaign_id and no end_date.
         $evergreenWebsiteCampaign = factory(Campaign::class)->create([
@@ -58,17 +58,14 @@ class CampaignTest extends TestCase
             'group_type_id' => factory(GroupType::class)->create()->id,
         ]);
 
-        $this->assertEquals(
+        $this->assertTrue(
             $evergreenWebsiteCampaign->toSearchableArray()['has_website'],
-            true,
         );
-        $this->assertEquals(
+        $this->assertTrue(
             $evergreenWebsiteCampaign->toSearchableArray()['is_evergreen'],
-            true,
         );
-        $this->assertEquals(
+        $this->assertTrue(
             $evergreenWebsiteCampaign->toSearchableArray()['is_group_campaign'],
-            true,
         );
 
         // We should only index the first 20 actions of the campaign.

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -42,7 +42,7 @@ class CampaignTest extends TestCase
         // There should be computed boolean attributes determining:
         // - if the campaign is a Website Campaign
         // - if the campaign is evergreen (has no end date)
-        // - if the campaign is a group campain
+        // - if the campaign is a group campaign
         //
         // With a non-populated contentful_campaign_id:
         $this->assertEquals($searchableArray['has_website'], false);


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new computed `is_group_campaign` attribute to the Campaign model and sends this attribute along to Algolia.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will allow us to filter for group / non-group campaigns via GraphQL / the Algolia API

### Relevant tickets

References [Pivotal #175358477](https://www.pivotaltracker.com/story/show/175358477).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
