### PR TITLE
Volunteer Credits Access on Actions

### DIFF
--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -51,7 +51,12 @@
                         @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback'])
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action'])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry'])
-                        @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit'])
+                        <label class="option -checkbox">
+                            <input type="checkbox" name="volunteer_credit">
+                            <span class="option__indicator"></span>
+                            <span>Volunteer Credit <em>(read more about how Volunteer Credits work <a href="https://docs.google.com/document/d/1QG_jC6bKtzp4wSVuQAKPlinM62ALlyl1XQKZyKdB06g/edit#" target="_blank">here</a>)</em></span>
+                        </label>
+                        {{-- @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit (read more about how Volunteer Credits work here)']) --}}
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous'])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action'])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action'])

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -51,9 +51,7 @@
                         @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback'])
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action'])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry'])
-                        @if ($isAdminUser)
-                            @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit'])
-                        @endif
+                        @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit'])
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous'])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action'])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action'])

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -52,7 +52,7 @@
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action'])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry'])
                         <label class="option -checkbox">
-                            <input type="checkbox" name="volunteer_credit">
+                            <input type="checkbox" name="volunteer_credit" {{ old("volunteer_credit") ? 'checked' : '' }}>
                             <span class="option__indicator"></span>
                             <span>Volunteer Credit <em>(read more about how Volunteer Credits work <a href="https://docs.google.com/document/d/1QG_jC6bKtzp4wSVuQAKPlinM62ALlyl1XQKZyKdB06g/edit#" target="_blank">here</a>)</em></span>
                         </label>

--- a/resources/views/actions/create.blade.php
+++ b/resources/views/actions/create.blade.php
@@ -56,7 +56,6 @@
                             <span class="option__indicator"></span>
                             <span>Volunteer Credit <em>(read more about how Volunteer Credits work <a href="https://docs.google.com/document/d/1QG_jC6bKtzp4wSVuQAKPlinM62ALlyl1XQKZyKdB06g/edit#" target="_blank">here</a>)</em></span>
                         </label>
-                        {{-- @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit (read more about how Volunteer Credits work here)']) --}}
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous'])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action'])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action'])

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -55,9 +55,7 @@
                         @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback', 'value' => $action->reportback])
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action', 'value' => $action->civic_action])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry', 'value' => $action->scholarship_entry])
-                        @if ($isAdminUser)
-                            @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit', 'value' => $action->volunteer_credit])
-                        @endif
+                        @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit', 'value' => $action->volunteer_credit])
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous', 'value' => $action->anonymous])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action', 'value' => $action->online])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action', 'value' => $action->quiz])

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -56,7 +56,7 @@
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action', 'value' => $action->civic_action])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry', 'value' => $action->scholarship_entry])
                         <label class="option -checkbox">
-                            <input type="checkbox" name="volunteer_credit">
+                            <input type="checkbox" name="volunteer_credit" {{ old("volunteer_credit", ! empty($action->volunteer_credit)) ? 'checked' : '' }}>
                             <span class="option__indicator"></span>
                             <span>Volunteer Credit <em>(read more about how Volunteer Credits work <a href="https://docs.google.com/document/d/1QG_jC6bKtzp4wSVuQAKPlinM62ALlyl1XQKZyKdB06g/edit#" target="_blank">here</a>)</em></span>
                         </label>

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -55,7 +55,12 @@
                         @include('forms.option', ['name' => 'reportback', 'label' => 'Reportback', 'value' => $action->reportback])
                         @include('forms.option', ['name' => 'civic_action', 'label' => 'Civic Action', 'value' => $action->civic_action])
                         @include('forms.option', ['name' => 'scholarship_entry', 'label' => 'Scholarship Entry', 'value' => $action->scholarship_entry])
-                        @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit', 'value' => $action->volunteer_credit])
+                        <label class="option -checkbox">
+                            <input type="checkbox" name="volunteer_credit">
+                            <span class="option__indicator"></span>
+                            <span>Volunteer Credit <em>(read more about how Volunteer Credits work <a href="https://docs.google.com/document/d/1QG_jC6bKtzp4wSVuQAKPlinM62ALlyl1XQKZyKdB06g/edit#" target="_blank">here</a>)</em></span>
+                        </label>
+                        {{-- @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit (read more about how Volunteer Credits work here)', 'value' => $action->volunteer_credit]) --}}
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous', 'value' => $action->anonymous])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action', 'value' => $action->online])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action', 'value' => $action->quiz])

--- a/resources/views/actions/edit.blade.php
+++ b/resources/views/actions/edit.blade.php
@@ -60,7 +60,6 @@
                             <span class="option__indicator"></span>
                             <span>Volunteer Credit <em>(read more about how Volunteer Credits work <a href="https://docs.google.com/document/d/1QG_jC6bKtzp4wSVuQAKPlinM62ALlyl1XQKZyKdB06g/edit#" target="_blank">here</a>)</em></span>
                         </label>
-                        {{-- @include('forms.option', ['name' => 'volunteer_credit', 'label' => 'Volunteer Credit (read more about how Volunteer Credits work here)', 'value' => $action->volunteer_credit]) --}}
                         @include('forms.option', ['name' => 'anonymous', 'label' => 'Anonymous', 'value' => $action->anonymous])
                         @include('forms.option', ['name' => 'online', 'label' => 'Online Action', 'value' => $action->online])
                         @include('forms.option', ['name' => 'quiz', 'label' => 'Quiz Action', 'value' => $action->quiz])


### PR DESCRIPTION
### What's this PR do?

This pull request removes the restriction from the volunteer credits option on an action for non-admin users! We also add a link to documentation that explains when the volunteer credit should be checked.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Now that we're doing a full launch of the volunteer credit program, we want to allow access to anyone who needs to create the appropriate labels for new actions and campaigns.

### Relevant tickets

References [Pivotal #173898146](https://www.pivotaltracker.com/story/show/173898146).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
