### PR TITLE
Display Post Hours Spent Field for Admins

### DIFF
--- a/resources/assets/components/ReviewablePost.js
+++ b/resources/assets/components/ReviewablePost.js
@@ -30,6 +30,7 @@ export const ReviewablePostFragment = gql`
     ...TagButton
     ...QuantityForm
     quantity
+    hoursSpent
     text
     type
     url
@@ -198,8 +199,9 @@ const ReviewablePost = ({ post }) => {
               ),
               Type: post.type,
               Source: post.source,
-              Location: post.location,
+              Location: post.location || '-',
               Submitted: formatDateTime(post.createdAt),
+              'Hours Spent': post.hoursSpent || '-',
               Referrer: post.referrerUserId ? (
                 <Link to={`/users/${post.referrerUserId}`}>
                   {post.referrerUserId}
@@ -210,7 +212,7 @@ const ReviewablePost = ({ post }) => {
               Club: post.clubId ? (
                 <Link to={`/clubs/${post.clubId}`}>{post.clubId}</Link>
               ) : (
-                '--'
+                '-'
               ),
               Group: post.groupId ? (
                 <Link to={`/groups/${post.groupId}`}>{post.groupId}</Link>


### PR DESCRIPTION
### What's this PR do?

This pull request displays the new Post **Hours Spent** field for admins trhough the `ReviewablePost` component.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Staff will be able to see and evaluate this field when reviewing posts.

### Relevant tickets

References [Pivotal #176369788](https://www.pivotaltracker.com/story/show/176369788).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
