### PR TITLE
Add Post hours_spent Field to Custommer.io Payload

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -363,6 +363,7 @@ class Post extends Model
                 'id' => (string) $this->id,
                 'signup_id' => $this->signup_id,
                 'quantity' => (int) $this->quantity,
+                'hours_spent' => (float) $this->hours_spent,
                 'why_participated' => strip_tags($signup->why_participated),
                 'campaign_id' => (string) $this->campaign_id,
                 'campaign_title' => Arr::get($campaignWebsite, 'title'),


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `hours_spent` field to the Post's customer.io payload.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I cast it as a `float` copying the `quantity` [where we cast it](https://github.com/DoSomething/rogue/blob/5d6aa4e862d4d31c828fbb30bd08f8bc1ef2d976/app/Models/Post.php#L365) as an `int`.

### Relevant tickets

References [Pivotal #176369835](https://www.pivotaltracker.com/story/show/176369835).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
