### PR TITLE
Update Post Hours Spent Customer.io Value

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -363,7 +363,9 @@ class Post extends Model
                 'id' => (string) $this->id,
                 'signup_id' => $this->signup_id,
                 'quantity' => (int) $this->quantity,
-                'hours_spent' => (float) $this->hours_spent,
+                'hours_spent' => $this->hours_spent
+                    ? (float) $this->hours_spent
+                    : null,
                 'why_participated' => strip_tags($signup->why_participated),
                 'campaign_id' => (string) $this->campaign_id,
                 'campaign_title' => Arr::get($campaignWebsite, 'title'),


### PR DESCRIPTION
So we don't send over 0.0 for null values

### What's this PR do?

This pull request updates the `hours_spent` field in the customer.io payload on Posts to only cast itself as a `float` _if_ the value exists. 

### How should this be reviewed?
👀 

### Any background context you want to provide?
A quick addendum to #1156 so we don't send over `0.0` for `null` values.

### Relevant tickets

References [Pivotal #176369835](https://www.pivotaltracker.com/story/show/176369835).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
