### PR TITLE
Add 'gettext' extension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "ext-bcmath": "*",
     "ext-exif": "*",
     "ext-gd": "*",
+    "ext-gettext": "*",
     "ext-newrelic": "*",
     "algolia/algoliasearch-client-php": "^2.6",
     "aws/aws-sdk-php-laravel": "^3.1",


### PR DESCRIPTION
### What's this PR do?

This pull request adds the [gettext](https://www.php.net/manual/en/intro.gettext.php) PHP extension. This should address the [following errors](https://my.papertrailapp.com/groups/10447062/events?q=%28sender%3Adosomething-rogue+%28production.ERROR+OR+status%3D5%29%29++OR+%28sender%3Afastly+status%3D5+app%3Ddosomething-rogue%29) we're seeing on Rogue since the latest deploy:

```
[15-Jan-2021 16:26:25 UTC] [2021-01-15 16:26:25] production.ERROR: Call to undefined function bindtextdomain() {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to undefined function bindtextdomain() at /app/vendor/sokil/php-isocodes/src/TranslationDriver/GettextExtensionDriver.php:12) 
```

### How should this be reviewed?

See Heroku's [PHP Extension documentation](https://devcenter.heroku.com/articles/php-support#php-7-3) for details.

### Any background context you want to provide?

This extension is included by default in Homestead, but not on Heroku.

### Relevant tickets

References [Pivotal #176518566](https://www.pivotaltracker.com/story/show/176518566).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
