### PR TITLE
Command to backfill hours_spent on posts

### DIFF
--- a/app/Console/Commands/BackfillHoursSpentOnPosts.php
+++ b/app/Console/Commands/BackfillHoursSpentOnPosts.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Rogue\Console\Commands;
+
+use Illuminate\Console\Command;
+use Rogue\Models\Post;
+
+class BackfillHoursSpentOnPosts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rogue:backfill-hours-spent-on-posts';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Backfills informally stored "hours" field in Post details to the new hours_spent column.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        info(
+            'rogue:backfill-hours-spent-on-posts: Backfilling posts with "hours" field in "details" to "hours_spent" field',
+        );
+
+        $posts = Post::where('details', 'like', '%hours%')->get();
+
+        info(
+            'rogue:backfill-hours-spent-on-posts: There are about ' .
+                $posts->count() .
+                ' posts to update.',
+        );
+
+        $numUpdated = 0;
+
+        foreach ($posts as $post) {
+            $details = json_decode($post->details);
+            $hours = data_get($details, 'hours');
+
+            if ($hours && !$post->hours_spent) {
+                $post->update(['hours_spent' => (float) $hours]);
+
+                $numUpdated++;
+
+                info(
+                    'rogue:backfill-hours-spent-on-posts: Backfilling post_id: ' .
+                        $post->id .
+                        ' with hours_spent: ' .
+                        $hours,
+                );
+            }
+        }
+
+        info(
+            'rogue:backfill-hours-spent-on-posts: Backfill completed! ' .
+                $numUpdated .
+                ' posts updated.',
+        );
+    }
+}

--- a/tests/Console/BackfillHoursSpentOnPostsTest.php
+++ b/tests/Console/BackfillHoursSpentOnPostsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Console;
+
+use Rogue\Models\Post;
+use Tests\TestCase;
+
+class BackfillHoursSpentOnPostsTest extends TestCase
+{
+    public function testBackfillingHoursSpentOnPosts()
+    {
+        $postWithHours = factory(Post::class)->create([
+            'details' => json_encode(['hours' => 1.5]),
+        ]);
+
+        $postWithTrickyHours = factory(Post::class)->create([
+            'details' => json_encode(['trick!' => 'hours']),
+        ]);
+
+        $postWithHoursSpentAndHours = factory(Post::class)->create([
+            'details' => json_encode(['hours' => 1.5]),
+            'hours_spent' => 3.0,
+        ]);
+
+        $this->artisan('rogue:backfill-hours-spent-on-posts');
+
+        $this->assertDatabaseHas('posts', [
+            'id' => $postWithHours->id,
+            'hours_spent' => 1.5,
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'id' => $postWithTrickyHours->id,
+            'hours_spent' => null,
+        ]);
+
+        $this->assertDatabaseHas('posts', [
+            'id' => $postWithHoursSpentAndHours->id,
+            'hours_spent' => 3.0,
+        ]);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a console command to backfill older posts with the informally stored `"hours"` field in the `details` over to the new formal `hours_spent` column.

### How should this be reviewed?
👀 

I figured the `LIKE %hours%` was an easy way to filter for this one. We use some logic to ensure we're updating correctly on the `hours` field despite the fuzziness of this filter. This worked well when I queried against the QA database. Some other results were returned (like some "email" field with "hours" in it), but these are filtered away in the command logic.

### Any background context you want to provide?
We first started informally storing the "Volunteer Hours" Photo RB field in the Post details to enable shipping this feature before the new year https://github.com/DoSomething/phoenix-next/pull/2471. We've started storing to our new `hours_spent` field #1154, and this command will backfill those older posts.

### Relevant tickets

References [Pivotal #176369878](https://www.pivotaltracker.com/story/show/176369878).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
