### PR TITLE
Add Unrealistic Hours Tag for Posts

### DIFF
--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -26,6 +26,7 @@ export const TAGS = {
   irrelevant: 'Irrelevant',
   inappropriate: 'Inappropriate',
   'unrealistic-quantity': 'Unrealistic Quantity',
+  'unrealistic-hours': 'Unrealistic Hours',
   test: 'Test',
   'incomplete-action': 'Incomplete Action',
   bulk: 'Bulk',


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `unrealistic-hours` tag for posts.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We've added the new Hours Spent field on Posts #1154, #1155. We've seen some unrealistic values being reported by members. This gives admins the opportunity to tag posts rejected for this reason. (And ultimately will allow us to inform the user with the context for the rejection via sending these tags to customer.io)

### Relevant tickets

References [Pivotal #176421331](https://www.pivotaltracker.com/story/show/176421331).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/105223572-f2c95680-5b29-11eb-9060-40ae8e8f1099.png)
