### PR TITLE
Rename 'Rogue\' to 'App\'.

### DIFF
--- a/app/Console/Commands/BackfillHoursSpentOnPosts.php
+++ b/app/Console/Commands/BackfillHoursSpentOnPosts.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Post;
 use Illuminate\Console\Command;
-use Rogue\Models\Post;
 
 class BackfillHoursSpentOnPosts extends Command
 {

--- a/app/Console/Commands/BulkReviewPosts.php
+++ b/app/Console/Commands/BulkReviewPosts.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Managers\PostManager;
+use App\Models\Post;
 use Illuminate\Console\Command;
-use Rogue\Managers\PostManager;
-use Rogue\Models\Post;
 
 class BulkReviewPosts extends Command
 {
@@ -32,7 +32,7 @@ class BulkReviewPosts extends Command
     /**
      * The Post Manager instance.
      *
-     * @var Rogue\Managers\PostManager
+     * @var App\Managers\PostManager
      */
     protected $posts;
 

--- a/app/Console/Commands/DeletePosts.php
+++ b/app/Console/Commands/DeletePosts.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Managers\PostManager;
+use App\Models\Post;
 use Illuminate\Console\Command;
-use Rogue\Managers\PostManager;
-use Rogue\Models\Post;
 
 class DeletePosts extends Command
 {

--- a/app/Console/Commands/ForceDeletePosts.php
+++ b/app/Console/Commands/ForceDeletePosts.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Managers\PostManager;
+use App\Models\Post;
 use Illuminate\Console\Command;
-use Rogue\Managers\PostManager;
-use Rogue\Models\Post;
 
 class ForceDeletePosts extends Command
 {

--- a/app/Console/Commands/ForceDeleteTestRecords.php
+++ b/app/Console/Commands/ForceDeleteTestRecords.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Post;
+use App\Models\Signup;
 use Illuminate\Console\Command;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
 
 class ForceDeleteTestRecords extends Command
 {

--- a/app/Console/Commands/ImportGroupsCommand.php
+++ b/app/Console/Commands/ImportGroupsCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Group;
+use App\Models\GroupType;
 use Exception;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
 
 class ImportGroupsCommand extends Command
 {

--- a/app/Console/Commands/ImportMfolGroupsCommand.php
+++ b/app/Console/Commands/ImportMfolGroupsCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Group;
+use App\Models\GroupType;
 use Exception;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
 
 class ImportMfolGroupsCommand extends Command
 {

--- a/app/Console/Commands/ImportNasspGroupsCommand.php
+++ b/app/Console/Commands/ImportNasspGroupsCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Group;
+use App\Models\GroupType;
 use Exception;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
 
 class ImportNasspGroupsCommand extends Command
 {

--- a/app/Console/Commands/ImportPrePostMetaDataActions.php
+++ b/app/Console/Commands/ImportPrePostMetaDataActions.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Action;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Rogue\Models\Action;
 
 class ImportPrePostMetaDataActions extends Command
 {

--- a/app/Console/Commands/ImportSignupsCommand.php
+++ b/app/Console/Commands/ImportSignupsCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Jobs\SendSignupToCustomerIo;
+use App\Models\Signup;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Rogue\Jobs\SendSignupToCustomerIo;
-use Rogue\Models\Signup;
 
 class ImportSignupsCommand extends Command
 {

--- a/app/Console/Commands/MakeDefaultURLsNull.php
+++ b/app/Console/Commands/MakeDefaultURLsNull.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Post;
 use Illuminate\Console\Command;
-use Rogue\Models\Post;
 
 class MakeDefaultURLsNull extends Command
 {

--- a/app/Console/Commands/PostCleanup.php
+++ b/app/Console/Commands/PostCleanup.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Post;
 use DB;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
-use Rogue\Models\Post;
 
 class PostCleanup extends Command
 {

--- a/app/Console/Commands/RecountPostsCommand.php
+++ b/app/Console/Commands/RecountPostsCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Campaign;
+use App\Models\Post;
 use Illuminate\Console\Command;
-use Rogue\Models\Campaign;
-use Rogue\Models\Post;
 
 class RecountPostsCommand extends Command
 {

--- a/app/Console/Commands/ReviewSignup.php
+++ b/app/Console/Commands/ReviewSignup.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Managers\PostManager;
+use App\Models\Signup;
 use Illuminate\Console\Command;
-use Rogue\Managers\PostManager;
-use Rogue\Models\Signup;
 
 class ReviewSignup extends Command
 {
@@ -25,7 +25,7 @@ class ReviewSignup extends Command
     /**
      * The Post manager instance.
      *
-     * @var Rogue\Managers\PostManager
+     * @var App\Managers\PostManager
      */
     protected $posts;
 

--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
 use DFurnes\Environmentalist\ConfiguresApplication;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/StandardizeCauses.php
+++ b/app/Console/Commands/StandardizeCauses.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Campaign;
 use Illuminate\Console\Command;
-use Rogue\Models\Campaign;
 
 class StandardizeCauses extends Command
 {

--- a/app/Console/Commands/TagPosts.php
+++ b/app/Console/Commands/TagPosts.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Post;
+use App\Models\Tag;
 use Illuminate\Console\Command;
-use Rogue\Models\Post;
-use Rogue\Models\Tag;
 
 class TagPosts extends Command
 {

--- a/app/Console/Commands/UpdatePostsWithActionIds.php
+++ b/app/Console/Commands/UpdatePostsWithActionIds.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Action;
 use DB;
 use Illuminate\Console\Command;
-use Rogue\Models\Action;
 
 class UpdatePostsWithActionIds extends Command
 {

--- a/app/Console/Commands/UpdateSignup.php
+++ b/app/Console/Commands/UpdateSignup.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Managers\SignupManager;
+use App\Models\Signup;
 use Illuminate\Console\Command;
-use Rogue\Managers\SignupManager;
-use Rogue\Models\Signup;
 
 class UpdateSignup extends Command
 {
@@ -25,7 +25,7 @@ class UpdateSignup extends Command
     /**
      * The signup manager instance.
      *
-     * @var Rogue\Managers\SignupManager
+     * @var App\Managers\SignupManager
      */
     protected $signups;
 

--- a/app/Console/Commands/UpdateSignupAndOrPostField.php
+++ b/app/Console/Commands/UpdateSignupAndOrPostField.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Managers\PostManager;
+use App\Managers\SignupManager;
+use App\Models\Post;
+use App\Models\Signup;
 use Illuminate\Console\Command;
-use Rogue\Managers\PostManager;
-use Rogue\Managers\SignupManager;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
 
 class UpdateSignupAndOrPostField extends Command
 {
@@ -27,14 +27,14 @@ class UpdateSignupAndOrPostField extends Command
     /**
      * The Signup Manager instance.
      *
-     * @var Rogue\Managers\SignupManager
+     * @var App\Managers\SignupManager
      */
     protected $signups;
 
     /**
      * The Post Manager instance.
      *
-     * @var Rogue\Managers\PostManager
+     * @var App\Managers\PostManager
      */
     protected $posts;
 

--- a/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
+++ b/app/Console/Commands/UpdateSignupAndPostCampaignIds.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\Campaign;
+use App\Models\Post;
+use App\Models\Signup;
 use DB;
 use Illuminate\Console\Command;
-use Rogue\Models\Campaign;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
 
 class UpdateSignupAndPostCampaignIds extends Command
 {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Console;
+namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;

--- a/app/Events/Event.php
+++ b/app/Events/Event.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Events;
+namespace App\Events;
 
 abstract class Event
 {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Exceptions;
+namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;

--- a/app/Http/Controllers/ActionStatsController.php
+++ b/app/Http/Controllers/ActionStatsController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\ActionStatTransformer;
+use App\Models\ActionStat;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Rogue\Http\Transformers\ActionStatTransformer;
-use Rogue\Models\ActionStat;
 
 class ActionStatsController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\ActionTransformer;
+     * @var App\Http\Transformers\ActionTransformer;
      */
     protected $transformer;
 

--- a/app/Http/Controllers/ActionsController.php
+++ b/app/Http/Controllers/ActionsController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\ActionTransformer;
+use App\Models\Action;
 use Illuminate\Http\Request;
-use Rogue\Http\Transformers\ActionTransformer;
-use Rogue\Models\Action;
 
 class ActionsController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\ActionTransformer;
+     * @var App\Http\Transformers\ActionTransformer;
      */
     protected $transformer;
 
@@ -39,7 +39,7 @@ class ActionsController extends ApiController
     /**
      * Display the specified resource.
      *
-     * @param  \Rogue\Models\Action  $action
+     * @param  \App\Models\Action  $action
      * @return \Illuminate\Http\Response
      */
     public function show(Action $action)

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Rogue\Http\Controllers\Controller as BaseController;
-use Rogue\Http\Controllers\Traits\FiltersRequests;
+use App\Http\Controllers\Controller as BaseController;
+use App\Http\Controllers\Traits\FiltersRequests;
 
 class ApiController extends BaseController
 {

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\CampaignTransformer;
+use App\Models\Campaign;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Rogue\Http\Transformers\CampaignTransformer;
-use Rogue\Models\Campaign;
 
 class CampaignsController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\CampaignTransformer;
+     * @var App\Http\Transformers\CampaignTransformer;
      */
     protected $transformer;
 
@@ -83,7 +83,7 @@ class CampaignsController extends ApiController
     /**
      * Display the specified resource.
      *
-     * @param  \Rogue\Models\Campaign  $campaign
+     * @param  \App\Models\Campaign  $campaign
      * @return \Illuminate\Http\Response
      */
     public function show(Campaign $campaign, Request $request)
@@ -96,7 +96,7 @@ class CampaignsController extends ApiController
      * PATCH /api/campaigns/:id.
      *
      * @param Request $request
-     * @param  \Rogue\Models\Campaign  $campaign
+     * @param  \App\Models\Campaign  $campaign
      * @return \Illuminate\Http\JsonResponse
      */
     public function update(Request $request, Campaign $campaign)

--- a/app/Http/Controllers/ClubsController.php
+++ b/app/Http/Controllers/ClubsController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\ClubTransformer;
+use App\Models\Club;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Rogue\Http\Transformers\ClubTransformer;
-use Rogue\Models\Club;
 
 class ClubsController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\ClubTransformer;
+     * @var App\Http\Transformers\ClubTransformer;
      */
     protected $transformer;
 
@@ -49,7 +49,7 @@ class ClubsController extends ApiController
     /**
      * Display the specified resource.
      *
-     * @param  \Rogue\Models\Club  $club
+     * @param  \App\Models\Club  $club
      * @return \Illuminate\Http\Response
      */
     public function show(Club $club)

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Controllers\Traits\TransformsRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller as BaseController;
-use Rogue\Http\Controllers\Traits\TransformsRequests;
 
 class Controller extends BaseController
 {

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\EventTransformer;
+use App\Models\Event;
 use Illuminate\Http\Request;
-use Rogue\Http\Transformers\EventTransformer;
-use Rogue\Models\Event;
 
 class EventsController extends ApiController
 {

--- a/app/Http/Controllers/GroupTypesController.php
+++ b/app/Http/Controllers/GroupTypesController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\GroupTypeTransformer;
+use App\Models\GroupType;
 use Illuminate\Http\Request;
-use Rogue\Http\Transformers\GroupTypeTransformer;
-use Rogue\Models\GroupType;
 
 class GroupTypesController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\GroupTypeTransformer;
+     * @var App\Http\Transformers\GroupTypeTransformer;
      */
     protected $transformer;
 
@@ -36,7 +36,7 @@ class GroupTypesController extends ApiController
     /**
      * Display the specified resource.
      *
-     * @param  \Rogue\Models\GroupType  $groupType
+     * @param  \App\Models\GroupType  $groupType
      * @return \Illuminate\Http\Response
      */
     public function show(GroupType $groupType)

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\GroupTransformer;
+use App\Models\Group;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Rogue\Http\Transformers\GroupTransformer;
-use Rogue\Models\Group;
 
 class GroupsController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\GroupTransformer;
+     * @var App\Http\Transformers\GroupTransformer;
      */
     protected $transformer;
 
@@ -56,7 +56,7 @@ class GroupsController extends ApiController
     /**
      * Display the specified resource.
      *
-     * @param  \Rogue\Models\Group  $group
+     * @param  \App\Models\Group  $group
      * @return \Illuminate\Http\Response
      */
     public function show(Group $group)

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Controllers\Traits\FiltersRequests;
+use App\Http\Requests\PostRequest;
+use App\Http\Transformers\PostTransformer;
+use App\Managers\PostManager;
+use App\Managers\SignupManager;
+use App\Models\Campaign;
+use App\Models\Post;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
-use Rogue\Http\Controllers\Traits\FiltersRequests;
-use Rogue\Http\Requests\PostRequest;
-use Rogue\Http\Transformers\PostTransformer;
-use Rogue\Managers\PostManager;
-use Rogue\Managers\SignupManager;
-use Rogue\Models\Campaign;
-use Rogue\Models\Post;
 
 class PostsController extends ApiController
 {
@@ -20,19 +20,19 @@ class PostsController extends ApiController
     /**
      * The post manager instance.
      *
-     * @var \Rogue\Managers\PostManager
+     * @var \App\Managers\PostManager
      */
     protected $posts;
 
     /**
      * The SignupManager instance.
      *
-     * @var \Rogue\Managers\SignupManager
+     * @var \App\Managers\SignupManager
      */
     protected $signups;
 
     /**
-     * @var \Rogue\Http\Transformers\PostTransformer;
+     * @var \App\Http\Transformers\PostTransformer;
      */
     protected $transformer;
 
@@ -173,7 +173,7 @@ class PostsController extends ApiController
      * Returns a specific post.
      * GET /posts/:id.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \Illuminate\Http\JsonResponse
      */
     public function show(Post $post)
@@ -189,7 +189,7 @@ class PostsController extends ApiController
      * PATCH /posts/:id.
      *
      * @param PostRequest $request
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \Illuminate\Http\JsonResponse
      */
     public function update(PostRequest $request, Post $post)
@@ -213,7 +213,7 @@ class PostsController extends ApiController
      * Delete a post.
      * DELETE /posts/:id.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \Illuminate\Http\JsonResponse
      */
     public function destroy(Post $post)

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\ReactionTransformer;
+use App\Models\Post;
+use App\Models\Reaction;
 use Illuminate\Http\Request;
-use Rogue\Http\Transformers\ReactionTransformer;
-use Rogue\Models\Post;
-use Rogue\Models\Reaction;
 
 class ReactionController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\ReactionTransformer;
+     * @var App\Http\Transformers\ReactionTransformer;
      */
     protected $transformer;
 
@@ -37,7 +37,7 @@ class ReactionController extends ApiController
      * Store a newly created resource in storage.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \Illuminate\Http\Response
      */
     public function store(Request $request, Post $post)
@@ -79,7 +79,7 @@ class ReactionController extends ApiController
      * GET /post/:post_id/reactions.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return Illuminate\Http\Response
      */
     public function index(Request $request, Post $post)

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -1,23 +1,23 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\PostTransformer;
+use App\Managers\PostManager;
+use App\Models\Post;
 use Illuminate\Http\Request;
-use Rogue\Http\Transformers\PostTransformer;
-use Rogue\Managers\PostManager;
-use Rogue\Models\Post;
 
 class ReviewsController extends ApiController
 {
     /**
      * The post manager instance.
      *
-     * @var Rogue\Managers\PostManager
+     * @var App\Managers\PostManager
      */
     protected $post;
 
     /**
-     * @var \Rogue\Http\Transformers\PostTransformer
+     * @var \App\Http\Transformers\PostTransformer
      */
     protected $transformer;
 

--- a/app/Http/Controllers/RotationController.php
+++ b/app/Http/Controllers/RotationController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\PostTransformer;
+use App\Models\Post;
+use App\Services\Fastly;
+use App\Services\ImageStorage;
 use Illuminate\Http\Request;
-use Rogue\Http\Transformers\PostTransformer;
-use Rogue\Models\Post;
-use Rogue\Services\Fastly;
-use Rogue\Services\ImageStorage;
 use Storage;
 
 class RotationController extends Controller

--- a/app/Http/Controllers/SignupsController.php
+++ b/app/Http/Controllers/SignupsController.php
@@ -1,27 +1,27 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\SignupTransformer;
+use App\Managers\SignupManager;
+use App\Models\Campaign;
+use App\Models\Signup;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Rogue\Http\Transformers\SignupTransformer;
-use Rogue\Managers\SignupManager;
-use Rogue\Models\Campaign;
-use Rogue\Models\Signup;
 
 class SignupsController extends ApiController
 {
     /**
-     * @var Rogue\Http\Transformers\SignupTransformer;
+     * @var App\Http\Transformers\SignupTransformer;
      */
     protected $transformer;
 
     /**
      * The signup manager instance.
      *
-     * @var \Rogue\Manager\SignupManager
+     * @var \App\Manager\SignupManager
      */
     protected $signups;
 
@@ -134,7 +134,7 @@ class SignupsController extends ApiController
      * GET /signups/:id.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return \Illuminate\Http\JsonResponse
      */
     public function show(Request $request, Signup $signup)
@@ -170,7 +170,7 @@ class SignupsController extends ApiController
      * PATCH /signups/:id.
      *
      * @param \Illuminate\Http\Request $request
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, Signup $signup)
@@ -199,7 +199,7 @@ class SignupsController extends ApiController
      * Delete a signup.
      * DELETE /signups/:id.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return \Illuminate\Http\JsonResponse
      */
     public function destroy(Signup $signup)

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\PostTransformer;
+use App\Models\Post;
+use App\Repositories\PostRepository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use Rogue\Http\Transformers\PostTransformer;
-use Rogue\Models\Post;
-use Rogue\Repositories\PostRepository;
 
 class TagsController extends ApiController
 {
     /**
      * The post service instance.
      *
-     * @var Rogue\Repositories\PostRepository
+     * @var App\Repositories\PostRepository
      */
     protected $post;
 
     /**
-     * @var Rogue\Http\Transformers\PostTransformer;
+     * @var App\Http\Transformers\PostTransformer;
      */
     protected $transformer;
 

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Controllers\Traits;
+namespace App\Http\Controllers\Traits;
 
 trait FiltersRequests
 {

--- a/app/Http/Controllers/Traits/TransformsRequests.php
+++ b/app/Http/Controllers/Traits/TransformsRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Controllers\Traits;
+namespace App\Http\Controllers\Traits;
 
 use League\Fractal\Manager;
 use League\Fractal\Pagination\Cursor;

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
-use Rogue\Services\Fastly;
-use Rogue\Services\ImageStorage;
+use App\Models\Post;
+use App\Models\Signup;
+use App\Services\Fastly;
+use App\Services\ImageStorage;
 
 class UsersController extends Controller
 {

--- a/app/Http/Controllers/Web/ActionsController.php
+++ b/app/Http/Controllers/Web/ActionsController.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\Action;
+use App\Types\ActionType;
+use App\Types\PostType;
+use App\Types\TimeCommitment;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\Action;
-use Rogue\Types\ActionType;
-use Rogue\Types\PostType;
-use Rogue\Types\TimeCommitment;
 
 class ActionsController extends Controller
 {
@@ -95,7 +95,7 @@ class ActionsController extends Controller
     /**
      * Edit an existing action.
      *
-     * @param  \Rogue\Models\Action  $action
+     * @param  \App\Models\Action  $action
      * @param  $campaignId
      */
     public function edit(Action $action)
@@ -112,7 +112,7 @@ class ActionsController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Rogue\Models\Action  $action
+     * @param  \App\Models\Action  $action
      * @param  \Illuminate\Http\Request  $request
      */
     public function update(Action $action, Request $request)
@@ -139,7 +139,7 @@ class ActionsController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \Rogue\Models\Action  $action
+     * @param  \App\Models\Action  $action
      */
     public function destroy(Action $action)
     {

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Rogue\Http\Controllers\Controller;
 
 class AuthController extends Controller
 {

--- a/app/Http/Controllers/Web/CampaignsController.php
+++ b/app/Http/Controllers/Web/CampaignsController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\Campaign;
+use App\Models\GroupType;
+use App\Types\Cause;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\Campaign;
-use Rogue\Models\GroupType;
-use Rogue\Types\Cause;
 
 class CampaignsController extends Controller
 {
@@ -66,7 +66,7 @@ class CampaignsController extends Controller
     /**
      * Edit a specific campaign page.
      *
-     * @param  \Rogue\Models\Campaign  $campaign
+     * @param  \App\Models\Campaign  $campaign
      */
     public function edit(Campaign $campaign)
     {
@@ -81,7 +81,7 @@ class CampaignsController extends Controller
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Rogue\Models\Campaign  $campaign
+     * @param  \App\Models\Campaign  $campaign
      */
     public function update(Request $request, Campaign $campaign)
     {
@@ -105,7 +105,7 @@ class CampaignsController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \Rogue\Models\Campaign  $campaign
+     * @param  \App\Models\Campaign  $campaign
      */
     public function destroy(Campaign $campaign)
     {

--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\Club;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\Club;
 
 class ClubsController extends Controller
 {
@@ -61,7 +61,7 @@ class ClubsController extends Controller
     /**
      * Edit an existing club.
      *
-     * @param  \Rogue\Models\Club  $club
+     * @param  \App\Models\Club  $club
      */
     public function edit(Club $club)
     {
@@ -73,7 +73,7 @@ class ClubsController extends Controller
     /**
      * Update the specified club in storage.
      *
-     * @param  \Rogue\Models\Club  $club
+     * @param  \App\Models\Club  $club
      * @param  \Illuminate\Http\Request  $request
      */
     public function update(Club $club, Request $request)

--- a/app/Http/Controllers/Web/GroupTypesController.php
+++ b/app/Http/Controllers/Web/GroupTypesController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\GroupType;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\GroupType;
 
 class GroupTypesController extends Controller
 {
@@ -57,7 +57,7 @@ class GroupTypesController extends Controller
     /**
      * Edit an existing action.
      *
-     * @param  \Rogue\Models\GroupType  $groupType
+     * @param  \App\Models\GroupType  $groupType
      */
     public function edit(GroupType $groupType)
     {
@@ -69,7 +69,7 @@ class GroupTypesController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Rogue\Models\GroupType  $groupType
+     * @param  \App\Models\GroupType  $groupType
      * @param  \Illuminate\Http\Request  $request
      */
     public function update(GroupType $groupType, Request $request)

--- a/app/Http/Controllers/Web/GroupsController.php
+++ b/app/Http/Controllers/Web/GroupsController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\Group;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\Group;
 
 class GroupsController extends Controller
 {
@@ -63,7 +63,7 @@ class GroupsController extends Controller
     /**
      * Edit an existing group.
      *
-     * @param  \Rogue\Models\Group  $group
+     * @param  \App\Models\Group  $group
      */
     public function edit(Group $group)
     {
@@ -75,7 +75,7 @@ class GroupsController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Rogue\Models\Group  $group
+     * @param  \App\Models\Group  $group
      * @param  \Illuminate\Http\Request  $request
      */
     public function update(Group $group, Request $request)

--- a/app/Http/Controllers/Web/ImagesController.php
+++ b/app/Http/Controllers/Web/ImagesController.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\Post;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
@@ -9,8 +11,6 @@ use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\Memory\MemoryAdapter;
 use League\Glide\Responses\LaravelResponseFactory;
 use League\Glide\ServerFactory;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\Post;
 
 class ImagesController extends Controller
 {

--- a/app/Http/Controllers/Web/OriginalsController.php
+++ b/app/Http/Controllers/Web/OriginalsController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\Post;
 use Illuminate\Http\Request;
 use Intervention\Image\Facades\Image;
-use Rogue\Http\Controllers\Controller;
-use Rogue\Models\Post;
 use Storage;
 
 class OriginalsController extends Controller

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http;
+namespace App\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
@@ -14,10 +14,10 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        \Rogue\Http\Middleware\TrustProxies::class,
-        \Rogue\Http\Middleware\CheckForMaintenanceMode::class,
+        \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \Rogue\Http\Middleware\TrimStrings::class,
+        \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
     ];
 
@@ -28,11 +28,11 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \Rogue\Http\Middleware\EncryptCookies::class,
+            \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \Rogue\Http\Middleware\VerifyCsrfToken::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \DoSomething\Gateway\Laravel\Middleware\RefreshTokenMiddleware::class,
         ],
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
             'guard:api',
             'bindings',
             // 'throttle:60,1',
-            \Rogue\Http\Middleware\HandleCors::class,
+            \App\Http\Middleware\HandleCors::class,
         ],
     ];
 
@@ -53,15 +53,15 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => \Rogue\Http\Middleware\Authenticate::class,
+        'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' =>
             \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guard' => \DoSomething\Gateway\Server\Middleware\SetGuard::class,
-        'guest' => \Rogue\Http\Middleware\RedirectIfAuthenticated::class,
-        'role' => \Rogue\Http\Middleware\CheckRole::class,
+        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'role' => \App\Http\Middleware\CheckRole::class,
         'scopes' => \DoSomething\Gateway\Server\Middleware\RequireScope::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
@@ -77,7 +77,7 @@ class Kernel extends HttpKernel
     protected $middlewarePriority = [
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-        \Rogue\Http\Middleware\Authenticate::class,
+        \App\Http\Middleware\Authenticate::class,
         \Illuminate\Routing\Middleware\ThrottleRequests::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as Middleware;
 

--- a/app/Http/Middleware/CheckForMaintenanceMode.php
+++ b/app/Http/Middleware/CheckForMaintenanceMode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;
 

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use DoSomething\Gateway\Server\Middleware\RequireRole;

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Cookie\Middleware\EncryptCookies as BaseEncrypter;
 

--- a/app/Http/Middleware/HandleCors.php
+++ b/app/Http/Middleware/HandleCors.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Http\Middleware\TrimStrings as Middleware;
 

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Fideloper\Proxy\TrustProxies as Middleware;
 use Illuminate\Http\Request;

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as BaseVerifier;

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Http\Requests;
+namespace App\Http\Requests;
 
+use App\Types\PostType;
 use Illuminate\Validation\Rule;
-use Rogue\Types\PostType;
 
 class PostRequest extends Request
 {

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Requests;
+namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/app/Http/Transformers/AcceptedQuantityTransformer.php
+++ b/app/Http/Transformers/AcceptedQuantityTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
 use League\Fractal\TransformerAbstract;
 

--- a/app/Http/Transformers/ActionStatTransformer.php
+++ b/app/Http/Transformers/ActionStatTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\ActionStat;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\ActionStat;
 
 class ActionStatTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\ActionStat $actionStat
+     * @param \App\Models\ActionStat $actionStat
      * @return array
      */
     public function transform(ActionStat $actionStat)

--- a/app/Http/Transformers/ActionTransformer.php
+++ b/app/Http/Transformers/ActionTransformer.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Action;
+use App\Types\ActionType;
+use App\Types\PostType;
+use App\Types\TimeCommitment;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Action;
-use Rogue\Types\ActionType;
-use Rogue\Types\PostType;
-use Rogue\Types\TimeCommitment;
 
 class ActionTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Action $action
+     * @param \App\Models\Action $action
      * @return array
      */
     public function transform(Action $action)

--- a/app/Http/Transformers/CampaignTransformer.php
+++ b/app/Http/Transformers/CampaignTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Campaign;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Campaign;
 
 class CampaignTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Campaign $campaign
+     * @param \App\Models\Campaign $campaign
      * @return array
      */
     public function transform(Campaign $campaign)

--- a/app/Http/Transformers/ClubTransformer.php
+++ b/app/Http/Transformers/ClubTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Club;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Club;
 
 class ClubTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Club $club
+     * @param \App\Models\Club $club
      * @return array
      */
     public function transform(Club $club)

--- a/app/Http/Transformers/EventTransformer.php
+++ b/app/Http/Transformers/EventTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Event;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Event;
 
 class EventTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Event $event
+     * @param \App\Models\Event $event
      * @return array
      */
     public function transform(Event $event)

--- a/app/Http/Transformers/GroupTransformer.php
+++ b/app/Http/Transformers/GroupTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Group;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Group;
 
 class GroupTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Group $group
+     * @param \App\Models\Group $group
      * @return array
      */
     public function transform(Group $group)

--- a/app/Http/Transformers/GroupTypeTransformer.php
+++ b/app/Http/Transformers/GroupTypeTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\GroupType;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\GroupType;
 
 class GroupTypeTransformer extends TransformerAbstract
 {
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\GroupType $groupType
+     * @param \App\Models\GroupType $groupType
      * @return array
      */
     public function transform(GroupType $groupType)

--- a/app/Http/Transformers/PostTransformer.php
+++ b/app/Http/Transformers/PostTransformer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Post;
 use Gate;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Post;
 
 class PostTransformer extends TransformerAbstract
 {
@@ -20,7 +20,7 @@ class PostTransformer extends TransformerAbstract
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return array
      */
     public function transform(Post $post)
@@ -74,7 +74,7 @@ class PostTransformer extends TransformerAbstract
     /**
      * Include the signup.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \League\Fractal\Resource\Collection
      */
     public function includeSignup(Post $post)
@@ -91,7 +91,7 @@ class PostTransformer extends TransformerAbstract
     /**
      * Include the siblings.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \League\Fractal\Resource\Collection
      */
     public function includeSiblings(Post $post)
@@ -102,7 +102,7 @@ class PostTransformer extends TransformerAbstract
     /**
      * Include the action.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @return \League\Fractal\Resource\Collection
      */
     public function includeActionDetails(Post $post)

--- a/app/Http/Transformers/ReactionTransformer.php
+++ b/app/Http/Transformers/ReactionTransformer.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Reaction;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Reaction;
 
 class ReactionTransformer extends TransformerAbstract
 {
     /**
      * Transform the resource data.
      *
-     * @param \Rogue\Models\Reaction $reaction
+     * @param \App\Models\Reaction $reaction
      * @return array
      */
     public function transform(Reaction $reaction)

--- a/app/Http/Transformers/SignupTransformer.php
+++ b/app/Http/Transformers/SignupTransformer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Signup;
+use App\Services\Registrar;
 use Gate;
 use League\Fractal\TransformerAbstract;
-use Rogue\Models\Signup;
-use Rogue\Services\Registrar;
 
 class SignupTransformer extends TransformerAbstract
 {
@@ -19,7 +19,7 @@ class SignupTransformer extends TransformerAbstract
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return array
      */
     public function transform(Signup $signup)
@@ -51,7 +51,7 @@ class SignupTransformer extends TransformerAbstract
     /**
      * Include posts.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return \League\Fractal\Resource\Collection
      */
     public function includePosts(Signup $signup)
@@ -65,7 +65,7 @@ class SignupTransformer extends TransformerAbstract
     /**
      * Include the user data (optionally).
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return \League\Fractal\Resource\Item
      */
     public function includeUser(Signup $signup)
@@ -82,7 +82,7 @@ class SignupTransformer extends TransformerAbstract
     /**
      * Include accepted quantity.
      *
-     * @param \Rogue\Models\Signup $signup
+     * @param \App\Models\Signup $signup
      * @return \League\Fractal\Resource\Collection
      */
     public function includeAcceptedQuantity(Signup $signup)

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Http\Transformers;
+namespace App\Http\Transformers;
 
 use League\Fractal\TransformerAbstract;
 
@@ -9,7 +9,7 @@ class UserTransformer extends TransformerAbstract
     /**
      * Transform resource data.
      *
-     * @param \Rogue\Models\User $user
+     * @param \App\Models\User $user
      *
      * @return array
      */

--- a/app/Jobs/CreateCustomerIoEvent.php
+++ b/app/Jobs/CreateCustomerIoEvent.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Rogue\Jobs;
+namespace App\Jobs;
 
+use App\Services\CustomerIo;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
-use Rogue\Services\CustomerIo;
 
 class CreateCustomerIoEvent implements ShouldQueue
 {

--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Jobs;
+namespace App\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/app/Jobs/Middleware/CustomerIoRateLimit.php
+++ b/app/Jobs/Middleware/CustomerIoRateLimit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Jobs\Middleware;
+namespace App\Jobs\Middleware;
 
 use Illuminate\Support\Facades\Redis;
 

--- a/app/Jobs/RejectPost.php
+++ b/app/Jobs/RejectPost.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rogue\Jobs;
+namespace App\Jobs;
 
-use Rogue\Models\Post;
+use App\Models\Post;
 
 class RejectPost extends Job
 {

--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Jobs;
+namespace App\Jobs;
 
-use Rogue\Jobs\Middleware\CustomerIoRateLimit;
-use Rogue\Models\Post;
-use Rogue\Services\CustomerIo;
+use App\Jobs\Middleware\CustomerIoRateLimit;
+use App\Models\Post;
+use App\Services\CustomerIo;
 
 class SendPostToCustomerIo extends Job
 {

--- a/app/Jobs/SendReviewedPostToCustomerIo.php
+++ b/app/Jobs/SendReviewedPostToCustomerIo.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Jobs;
+namespace App\Jobs;
 
-use Rogue\Jobs\Middleware\CustomerIoRateLimit;
-use Rogue\Models\Post;
-use Rogue\Services\CustomerIo;
+use App\Jobs\Middleware\CustomerIoRateLimit;
+use App\Models\Post;
+use App\Services\CustomerIo;
 
 class SendReviewedPostToCustomerIo extends Job
 {

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Jobs;
+namespace App\Jobs;
 
-use Rogue\Jobs\Middleware\CustomerIoRateLimit;
-use Rogue\Models\Signup;
-use Rogue\Services\CustomerIo;
+use App\Jobs\Middleware\CustomerIoRateLimit;
+use App\Models\Signup;
+use App\Services\CustomerIo;
 
 class SendSignupToCustomerIo extends Job
 {

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -1,27 +1,27 @@
 <?php
 
-namespace Rogue\Managers;
+namespace App\Managers;
 
-use Rogue\Jobs\CreateCustomerIoEvent;
-use Rogue\Jobs\SendPostToCustomerIo;
-use Rogue\Jobs\SendReviewedPostToCustomerIo;
-use Rogue\Models\Post;
-use Rogue\Repositories\PostRepository;
-use Rogue\Services\Fastly;
+use App\Jobs\CreateCustomerIoEvent;
+use App\Jobs\SendPostToCustomerIo;
+use App\Jobs\SendReviewedPostToCustomerIo;
+use App\Models\Post;
+use App\Repositories\PostRepository;
+use App\Services\Fastly;
 
 class PostManager
 {
     /**
      * The Fastly API client.
      *
-     * @var Rogue\Services\Fastly
+     * @var App\Services\Fastly
      */
     protected $fastly;
 
     /*
      * The post repository.
      *
-     * @var Rogue\Repositories\PostRepository;
+     * @var App\Repositories\PostRepository;
      */
     protected $repository;
 
@@ -44,7 +44,7 @@ class PostManager
      * @param int $signupId
      * @param string $authenticatedUserRole
      *
-     * @return \Rogue\Models\Post
+     * @return \App\Models\Post
      */
     public function create($data, $signupId, $authenticatedUserRole = null)
     {
@@ -78,10 +78,10 @@ class PostManager
     /**
      * Handles all business logic around updating posts.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @param array $data
      * @param bool $log
-     * @return \Rogue\Models\Post
+     * @return \App\Models\Post
      */
     public function update($post, $data, $log = true)
     {
@@ -112,9 +112,9 @@ class PostManager
     /**
      * Handles all business logic around reviewing posts.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @param array $data
-     * @return \Rogue\Models\Post
+     * @return \App\Models\Post
      */
     public function review($post, $data, $comment = null, $admin = null)
     {

--- a/app/Managers/SignupManager.php
+++ b/app/Managers/SignupManager.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Rogue\Managers;
+namespace App\Managers;
 
-use Rogue\Jobs\CreateCustomerIoEvent;
-use Rogue\Jobs\SendSignupToCustomerIo;
-use Rogue\Repositories\SignupRepository;
+use App\Jobs\CreateCustomerIoEvent;
+use App\Jobs\SendSignupToCustomerIo;
+use App\Repositories\SignupRepository;
 
 class SignupManager
 {
     /*
      * SignupRepository Instance
      *
-     * @var Rogue\Repositories\SignupRepository;
+     * @var App\Repositories\SignupRepository;
      */
     protected $signup;
 
@@ -60,10 +60,10 @@ class SignupManager
     /**
      * Handles all business logic around updating signups.
      *
-     * @param Rogue\Models\Signup $signup
+     * @param App\Models\Signup $signup
      * @param array $data
      * @param bool $log
-     * @return Rogue\Models\Signup $model
+     * @return App\Models\Signup $model
      */
     public function update($signup, $data, $log = true)
     {
@@ -101,7 +101,7 @@ class SignupManager
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @return \Rogue\Models\Signup|null
+     * @return \App\Models\Signup|null
      */
     public function get($northstarId, $campaignId)
     {

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/app/Models/ActionStat.php
+++ b/app/Models/ActionStat.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
+use App\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
-use Rogue\Models\Traits\HasCursor;
 
 class ActionStat extends Model
 {

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
+use App\Models\Traits\HasCursor;
+use App\Types\Cause;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Laravel\Scout\Searchable;
-use Rogue\Models\Traits\HasCursor;
-use Rogue\Types\Cause;
 
 class Campaign extends Model
 {

--- a/app/Models/Club.php
+++ b/app/Models/Club.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
+use App\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
-use Rogue\Models\Traits\HasCursor;
 
 class Club extends Model
 {

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
@@ -40,7 +40,7 @@ class Event extends Model
     public function scopeForSignup($query, $id)
     {
         return $query
-            ->where('eventable_type', 'Rogue\Models\Signup')
+            ->where('eventable_type', 'App\Models\Signup')
             ->where('eventable_id', $id);
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
+use App\Models\Traits\HasCursor;
 use Illuminate\Database\Eloquent\Model;
-use Rogue\Models\Traits\HasCursor;
 
 class Group extends Model
 {

--- a/app/Models/GroupType.php
+++ b/app/Models/GroupType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
+use App\Models\Traits\HasCursor;
+use App\Notifications\PostTagged;
+use App\Services\GraphQL;
 use Hashids\Hashids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -10,9 +13,6 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
-use Rogue\Models\Traits\HasCursor;
-use Rogue\Notifications\PostTagged;
-use Rogue\Services\GraphQL;
 
 class Post extends Model
 {

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
+use App\Models\Traits\HasCursor;
+use App\Services\GraphQL;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
-use Rogue\Models\Traits\HasCursor;
-use Rogue\Services\GraphQL;
 
 class Signup extends Model
 {

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/app/Models/Traits/HasCursor.php
+++ b/app/Models/Traits/HasCursor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models\Traits;
+namespace App\Models\Traits;
 
 trait HasCursor
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Models;
+namespace App\Models;
 
 use DoSomething\Gateway\Contracts\NorthstarUserContract;
 use DoSomething\Gateway\Laravel\HasNorthstarToken;

--- a/app/Notifications/PostTagged.php
+++ b/app/Notifications/PostTagged.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Notifications;
+namespace App\Notifications;
 
+use App\Models\Post;
+use App\Models\Tag;
+use App\Services\GraphQL;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Rogue\Models\Post;
-use Rogue\Models\Tag;
-use Rogue\Services\GraphQL;
 
 const USER_AND_REVIEWER_QUERY = '
     query UserAndReviewerQuery($userId: String!, $adminId: String!) {
@@ -37,14 +37,14 @@ class PostTagged extends Notification implements ShouldQueue
     /*
      * Post Instance
      *
-     * @var Rogue\Models\Post;
+     * @var App\Models\Post;
      */
     public $post;
 
     /*
      * Tag Instance
      *
-     * @var Rogue\Models\Tag;
+     * @var App\Models\Tag;
      */
     public $tag;
 

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rogue\Observers;
+namespace App\Observers;
 
-use Rogue\Models\Group;
-use Rogue\Models\Post;
+use App\Models\Group;
+use App\Models\Post;
 
 class PostObserver
 {
     /**
      * Handle the Post "creating" event.
      *
-     * @param  \Rogue\Models\Post  $post
+     * @param  \App\Models\Post  $post
      * @return void
      */
     public function creating(Post $post)
@@ -38,7 +38,7 @@ class PostObserver
     /**
      * Handle the Post "created" event.
      *
-     * @param  \Rogue\Models\Post  $post
+     * @param  \App\Models\Post  $post
      * @return void
      */
     public function created(Post $post)
@@ -49,7 +49,7 @@ class PostObserver
     /**
      * Handle the Post "updated" event.
      *
-     * @param  \Rogue\Models\Post  $post
+     * @param  \App\Models\Post  $post
      * @return void
      */
     public function updated(Post $post)

--- a/app/Observers/SignupObserver.php
+++ b/app/Observers/SignupObserver.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Observers;
+namespace App\Observers;
 
-use Rogue\Models\Signup;
-use Rogue\Services\GraphQL;
+use App\Models\Signup;
+use App\Services\GraphQL;
 
 const USER_CLUB_ID_QUERY = '
     query UserClubIdQuery($userId: String!) {
@@ -31,7 +31,7 @@ class SignupObserver
     /**
      * Handle the Signup "creating" event.
      *
-     * @param  \Rogue\Models\Signup  $signup
+     * @param  \App\Models\Signup  $signup
      * @return void
      */
     public function creating(Signup $signup)

--- a/app/Policies/CampaignPolicy.php
+++ b/app/Policies/CampaignPolicy.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Policies;
+namespace App\Policies;
 
+use App\Models\Campaign;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Rogue\Models\Campaign;
 
 class CampaignPolicy
 {
@@ -13,7 +13,7 @@ class CampaignPolicy
      * Determine if the given post can be updated by the user.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-     * @param  Rogue\Models\Campaign $campaign
+     * @param  App\Models\Campaign $campaign
      * @return bool
      */
     public function update($user, Campaign $campaign)

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Policies;
+namespace App\Policies;
 
+use App\Models\Post;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Rogue\Models\Post;
 
 class PostPolicy
 {
@@ -14,7 +14,7 @@ class PostPolicy
      * Determine if the full post should be displayed.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-     * @param  Rogue\Models\Post $post
+     * @param  App\Models\Post $post
      * @return bool
      */
     public function viewAll($user, Post $post)
@@ -26,7 +26,7 @@ class PostPolicy
      * Determine if the given post can be seen by the user.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-     * @param  Rogue\Models\Post $post
+     * @param  App\Models\Post $post
      * @return bool
      */
     public function show(?Authenticatable $user, Post $post)
@@ -42,7 +42,7 @@ class PostPolicy
      * Determine if the given post can be updated by the user.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-     * @param  Rogue\Models\Post $post
+     * @param  App\Models\Post $post
      * @return bool
      */
     public function update($user, Post $post)
@@ -54,7 +54,7 @@ class PostPolicy
      * Determine if the given post can be reviewed by the user.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-     * @param  Rogue\Models\Post $post
+     * @param  App\Models\Post $post
      * @return bool
      */
     public function review($user, Post $post)

--- a/app/Policies/SignupPolicy.php
+++ b/app/Policies/SignupPolicy.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Policies;
+namespace App\Policies;
 
+use App\Models\Signup;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Rogue\Models\Signup;
 
 class SignupPolicy
 {
@@ -13,7 +13,7 @@ class SignupPolicy
      * Determine if the full signup should be displayed.
      *
      * @param  Illuminate\Contracts\Auth\Authenticatable $user
-     * @param  Rogue\Models\Signup $signup
+     * @param  App\Models\Signup $signup
      * @return bool
      */
     public function viewAll($user, Signup $signup)

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,7 +1,11 @@
 <?php
 
-namespace Rogue\Providers;
+namespace App\Providers;
 
+use App\Models\Post;
+use App\Models\Signup;
+use App\Observers\PostObserver;
+use App\Observers\SignupObserver;
 use Closure;
 use Hashids\Hashids;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -12,10 +16,6 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
-use Rogue\Observers\PostObserver;
-use Rogue\Observers\SignupObserver;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Rogue\Providers;
+namespace App\Providers;
 
+use App\Models\Campaign;
+use App\Models\Post;
+use App\Models\Signup;
+use App\Policies\CampaignPolicy;
+use App\Policies\PostPolicy;
+use App\Policies\SignupPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Rogue\Models\Campaign;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
-use Rogue\Policies\CampaignPolicy;
-use Rogue\Policies\PostPolicy;
-use Rogue\Policies\SignupPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Providers;
+namespace App\Providers;
 
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\ServiceProvider;

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rogue\Providers;
+namespace App\Providers;
 
+use App\Events\PostTagged;
+use App\Listeners\SendTaggedNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Rogue\Events\PostTagged;
-use Rogue\Listeners\SendTaggedNotification;
 
 class EventServiceProvider extends ServiceProvider
 {

--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rogue\Providers;
+namespace App\Providers;
 
+use App\Jobs\RejectPost;
+use App\Models\Event;
+use App\Models\Post;
+use App\Models\Review;
+use App\Models\Signup;
 use Illuminate\Support\ServiceProvider;
-use Rogue\Jobs\RejectPost;
-use Rogue\Models\Event;
-use Rogue\Models\Post;
-use Rogue\Models\Review;
-use Rogue\Models\Signup;
 
 class ModelServiceProvider extends ServiceProvider
 {

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Providers;
+namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
@@ -14,7 +14,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    protected $namespace = 'Rogue\Http\Controllers';
+    protected $namespace = 'App\Http\Controllers';
 
     /**
      * Define your route model bindings, pattern filters, etc.
@@ -25,8 +25,8 @@ class RouteServiceProvider extends ServiceProvider
     {
         parent::boot();
 
-        Route::model('post', \Rogue\Models\Post::class);
-        Route::model('signup', \Rogue\Models\Signup::class);
+        Route::model('post', \App\Models\Post::class);
+        Route::model('signup', \App\Models\Signup::class);
     }
 
     /**

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Rogue\Repositories;
+namespace App\Repositories;
 
+use App\Models\Action;
+use App\Models\Post;
+use App\Models\Review;
+use App\Models\Signup;
+use App\Services\ImageStorage;
 use Illuminate\Validation\ValidationException;
 use Intervention\Image\Facades\Image;
-use Rogue\Models\Action;
-use Rogue\Models\Post;
-use Rogue\Models\Review;
-use Rogue\Models\Signup;
-use Rogue\Services\ImageStorage;
 
 class PostRepository
 {
     /**
      * Image storage service (either disk or S3).
      *
-     * @var \Rogue\Services\ImageStorage
+     * @var \App\Services\ImageStorage
      */
     protected $storage;
 
@@ -33,7 +33,7 @@ class PostRepository
      * Find a post by post_id and return associated signup and tags.
      *
      * @param int $id
-     * @return \Rogue\Models\Post
+     * @return \App\Models\Post
      */
     public function find($id)
     {
@@ -47,7 +47,7 @@ class PostRepository
      * @param  int $signupId
      * @param  string $authenticatedUserRole
      *
-     * @return \Rogue\Models\Post|null
+     * @return \App\Models\Post|null
      */
     public function create(
         array $data,
@@ -160,7 +160,7 @@ class PostRepository
     /**
      * Update an existing Post.
      *
-     * @param \Rogue\Models\Post $post
+     * @param \App\Models\Post $post
      * @param array $data
      *
      * @return Post

--- a/app/Repositories/SignupRepository.php
+++ b/app/Repositories/SignupRepository.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rogue\Repositories;
+namespace App\Repositories;
 
-use Rogue\Models\Signup;
+use App\Models\Signup;
 
 class SignupRepository
 {
@@ -12,7 +12,7 @@ class SignupRepository
      * @param  array $data
      * @param  string $northstarId
      * @param  int $campaignId
-     * @return \Rogue\Models\Signup|null
+     * @return \App\Models\Signup|null
      */
     public function create($data, $northstarId, $campaignId)
     {
@@ -45,7 +45,7 @@ class SignupRepository
      *
      * @param array $data
      * @param array $data
-     * @return \Rogue\Models\Signup
+     * @return \App\Models\Signup
      */
     public function update($signup, $data)
     {
@@ -59,7 +59,7 @@ class SignupRepository
      *
      * @param  string $northstarId
      * @param  int $campaignId
-     * @return \Rogue\Models\Signup|null
+     * @return \App\Models\Signup|null
      */
     public function get($northstarId, $campaignId)
     {

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Services;
+namespace App\Services;
 
 class CustomerIo
 {

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rogue\Services;
+namespace App\Services;
 
+use App\Models\Post;
 use DoSomething\Gateway\Common\RestApiClient;
-use Rogue\Models\Post;
 
 class Fastly extends RestApiClient
 {

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Services;
+namespace App\Services;
 
 use Softonic\GraphQL\ClientBuilder;
 

--- a/app/Services/ImageStorage.php
+++ b/app/Services/ImageStorage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Rogue\Services;
+namespace App\Services;
 
+use App\Models\Post;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Facades\Image as ImageManager;
 use Intervention\Image\Image;
-use Rogue\Models\Post;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Services;
+namespace App\Services;
 
 use DoSomething\Gateway\Northstar;
 

--- a/app/Types/ActionType.php
+++ b/app/Types/ActionType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Types;
+namespace App\Types;
 
 class ActionType extends Type
 {

--- a/app/Types/Cause.php
+++ b/app/Types/Cause.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Types;
+namespace App\Types;
 
 class Cause extends Type
 {

--- a/app/Types/PostType.php
+++ b/app/Types/PostType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Types;
+namespace App\Types;
 
 class PostType extends Type
 {

--- a/app/Types/TimeCommitment.php
+++ b/app/Types/TimeCommitment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Types;
+namespace App\Types;
 
 class TimeCommitment extends Type
 {

--- a/app/Types/Type.php
+++ b/app/Types/Type.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rogue\Types;
+namespace App\Types;
 
 use Illuminate\Support\Arr;
 use MyCLabs\Enum\Enum;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,7 @@
 */
 
 $app = new Illuminate\Foundation\Application(
-    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__),
 );
 
 /*
@@ -28,17 +28,17 @@ $app = new Illuminate\Foundation\Application(
 
 $app->singleton(
     Illuminate\Contracts\Http\Kernel::class,
-    Rogue\Http\Kernel::class
+    App\Http\Kernel::class,
 );
 
 $app->singleton(
     Illuminate\Contracts\Console\Kernel::class,
-    Rogue\Console\Kernel::class
+    App\Console\Kernel::class,
 );
 
 $app->singleton(
     Illuminate\Contracts\Debug\ExceptionHandler::class,
-    Rogue\Exceptions\Handler::class
+    App\Exceptions\Handler::class,
 );
 
 /*

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
       "app/helpers.php"
     ],
     "psr-4": {
-      "Rogue\\": "app/"
+      "App\\": "app/"
     }
   },
   "autoload-dev": {

--- a/config/app.php
+++ b/config/app.php
@@ -170,12 +170,12 @@ return [
         /*
          * Application Service Providers...
          */
-        Rogue\Providers\AppServiceProvider::class,
-        Rogue\Providers\AuthServiceProvider::class,
-        Rogue\Providers\BroadcastServiceProvider::class,
-        Rogue\Providers\EventServiceProvider::class,
-        Rogue\Providers\RouteServiceProvider::class,
-        Rogue\Providers\ModelServiceProvider::class,
+        App\Providers\AppServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
+        App\Providers\BroadcastServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
+        App\Providers\RouteServiceProvider::class,
+        App\Providers\ModelServiceProvider::class,
     ],
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -66,7 +66,7 @@ return [
     'providers' => [
         'local' => [
             'driver' => 'eloquent',
-            'model' => Rogue\Models\User::class,
+            'model' => App\Models\User::class,
         ],
 
         'northstar' => [
@@ -105,5 +105,5 @@ return [
         ],
     ],
 
-    'model' => Rogue\Models\User::class,
+    'model' => App\Models\User::class,
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -58,7 +58,7 @@ return [
     ],
 
     'stripe' => [
-        'model' => Rogue\User::class,
+        'model' => App\User::class,
         'key' => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
         'webhook' => [

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -2,22 +2,22 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
+use App\Models\Action;
+use App\Models\ActionStat;
+use App\Models\Campaign;
+use App\Models\Club;
+use App\Models\Group;
+use App\Models\GroupType;
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\Signup;
+use App\Models\User;
+use App\Types\ActionType;
+use App\Types\Cause;
+use App\Types\PostType;
+use App\Types\TimeCommitment;
 use Faker\Generator;
 use Illuminate\Support\Str;
-use Rogue\Models\Action;
-use Rogue\Models\ActionStat;
-use Rogue\Models\Campaign;
-use Rogue\Models\Club;
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
-use Rogue\Models\Post;
-use Rogue\Models\Reaction;
-use Rogue\Models\Signup;
-use Rogue\Models\User;
-use Rogue\Types\ActionType;
-use Rogue\Types\Cause;
-use Rogue\Types\PostType;
-use Rogue\Types\TimeCommitment;
 
 /*
  * Here you may define all of your model factories. Model factories give

--- a/database/faker/FakerPostUrl.php
+++ b/database/faker/FakerPostUrl.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Services\ImageStorage;
 use Faker\Provider\Base;
-use Rogue\Services\ImageStorage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FakerPostUrl extends Base

--- a/database/migrations/2017_07_31_153255_add_campaign_id_to_posts.php
+++ b/database/migrations/2017_07_31_153255_add_campaign_id_to_posts.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Models\Post;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Rogue\Models\Post;
 
 class AddCampaignIdToPosts extends Migration
 {

--- a/database/migrations/2017_08_16_153159_move_tagging_tags_to_tags_table.php
+++ b/database/migrations/2017_08_16_153159_move_tagging_tags_to_tags_table.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\Tag;
 use Illuminate\Database\Migrations\Migration;
-use Rogue\Models\Tag;
 
 class MoveTaggingTagsToTagsTable extends Migration
 {

--- a/database/migrations/2017_08_21_212932_move_tagging_tagged_to_post_tag.php
+++ b/database/migrations/2017_08_21_212932_move_tagging_tagged_to_post_tag.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\Post;
 use Illuminate\Database\Migrations\Migration;
-use Rogue\Models\Post;
 
 class MoveTaggingTaggedToPostTag extends Migration
 {

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,10 +1,10 @@
 <?php
 
+use App\Models\Action;
+use App\Models\Campaign;
+use App\Models\Post;
+use App\Models\Signup;
 use Illuminate\Database\Seeder;
-use Rogue\Models\Action;
-use Rogue\Models\Campaign;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
 
 class DatabaseSeeder extends Seeder
 {

--- a/database/seeds/VoterRegistrationSeeder.php
+++ b/database/seeds/VoterRegistrationSeeder.php
@@ -1,11 +1,11 @@
 <?php
 
+use App\Models\Action;
+use App\Models\Campaign;
+use App\Models\Group;
+use App\Models\GroupType;
+use App\Models\Post;
 use Illuminate\Database\Seeder;
-use Rogue\Models\Action;
-use Rogue\Models\Campaign;
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
-use Rogue\Models\Post;
 
 class VoterRegistrationSeeder extends Seeder
 {

--- a/docs/endpoints/events.md
+++ b/docs/endpoints/events.md
@@ -20,7 +20,7 @@ Example Response:
     {
       "event_id": 1117,
       "eventable_id": 18,
-      "event_type": "Rogue\\Models\\Signup",
+      "event_type": "App\\Models\\Signup",
       "content": {
         "id": "18",
         "northstar_id": "574dace47f43c21f1e0d674c",
@@ -40,7 +40,7 @@ Example Response:
     {
       "event_id": 747,
       "eventable_id": 18,
-      "event_type": "Rogue\\Models\\Signup",
+      "event_type": "App\\Models\\Signup",
       "content": {
         "id": "18",
         "northstar_id": "574dace47f43c21f1e0d674c",

--- a/docs/features/algolia.md
+++ b/docs/features/algolia.md
@@ -43,7 +43,7 @@ The Application ID can be found in the [API Keys section](https://www.algolia.co
 The environment specific secret can be found in the list of [All API Keys](https://www.algolia.com/apps/P5JW2OEUP0/api-keys/restricted).
 
 To intiate the batch import on a specific environment, run the following command on the server assigning the specific Heroku application environment via the `-a` flag, e.g.:
-`heroku run php artisan scout:import "Rogue\\\Models\\\Campaign" -a dosomething-rogue-qa`
+`heroku run php artisan scout:import "App\\\Models\\\Campaign" -a dosomething-rogue-qa`
 
 (You can omit the Heroku portion on your local environment of course).
 

--- a/resources/assets/_mocks_/__mockData__/events.json
+++ b/resources/assets/_mocks_/__mockData__/events.json
@@ -3,7 +3,7 @@
     {
       "event_id": 1,
       "eventable_id": 251696,
-      "event_type": "Rogue\\Models\\Signup",
+      "event_type": "App\\Models\\Signup",
       "content": {
         "northstar_id": "55a52808469c64d53d8ba746",
         "campaign_id": "4",
@@ -23,7 +23,7 @@
     {
       "event_id": 2,
       "eventable_id": 251697,
-      "event_type": "Rogue\\Models\\Signup",
+      "event_type": "App\\Models\\Signup",
       "content": {
         "northstar_id": "55a52809469c64d53d8ba74a",
         "campaign_id": "36",

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Route;
  * contains the "api" middleware group. Now create something great!
  *
  * @var \Illuminate\Routing\Router $router
- * @see \Rogue\Providers\RouteServiceProvider
+ * @see \App\Providers\RouteServiceProvider
  */
 
 // Assets

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Route;
  * routes are loaded by the RouteServiceProvider within a group which
  * contains the "web" middleware group. Now create something great!
  *
- * @see \Rogue\Providers\RouteServiceProvider
+ * @see \App\Providers\RouteServiceProvider
  */
 
 // Homepage & FAQ

--- a/tests/Console/BackfillHoursSpentOnPostsTest.php
+++ b/tests/Console/BackfillHoursSpentOnPostsTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Console;
 
-use Rogue\Models\Post;
+use App\Models\Post;
 use Tests\TestCase;
 
 class BackfillHoursSpentOnPostsTest extends TestCase

--- a/tests/Console/ImportGroupsCommandTest.php
+++ b/tests/Console/ImportGroupsCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Console;
 
-use Rogue\Models\GroupType;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class ImportGroupsCommandTest extends TestCase

--- a/tests/Console/ImportNasspGroupsCommandTest.php
+++ b/tests/Console/ImportNasspGroupsCommandTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Console;
 
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
+use App\Models\Group;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class ImportNasspGroupsCommandTest extends TestCase

--- a/tests/Console/ImportSignupsCommandTest.php
+++ b/tests/Console/ImportSignupsCommandTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Console;
 
+use App\Models\Signup;
 use Carbon\Carbon;
-use Rogue\Models\Signup;
 use Tests\TestCase;
 
 class ImportSignupsCommandTest extends TestCase

--- a/tests/Console/StandardizeCausesCommandTest.php
+++ b/tests/Console/StandardizeCausesCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Console;
 
-use Rogue\Models\Campaign;
+use App\Models\Campaign;
 use Tests\TestCase;
 
 class StandardizeCausesCommandTest extends TestCase

--- a/tests/Console/UpdateSignupAndPostCampaignIdsCommandTest.php
+++ b/tests/Console/UpdateSignupAndPostCampaignIdsCommandTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Console;
 
-use Rogue\Models\Campaign;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
+use App\Models\Campaign;
+use App\Models\Post;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class UpdateSignupAndPostCampaignIdsCommandTest extends TestCase

--- a/tests/Http/ActionStatsTest.php
+++ b/tests/Http/ActionStatsTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\ActionStat;
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
+use App\Models\ActionStat;
+use App\Models\Group;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class ActionStatsTest extends TestCase

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Action;
-use Rogue\Models\Campaign;
+use App\Models\Action;
+use App\Models\Campaign;
 use Tests\TestCase;
 
 class ActionTest extends TestCase

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Http;
 
+use App\Models\Campaign;
+use App\Models\GroupType;
+use App\Models\Post;
+use App\Types\Cause;
 use Illuminate\Support\Facades\Artisan;
-use Rogue\Models\Campaign;
-use Rogue\Models\GroupType;
-use Rogue\Models\Post;
-use Rogue\Types\Cause;
 use Tests\TestCase;
 
 class CampaignTest extends Testcase

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Club;
+use App\Models\Club;
 use Tests\TestCase;
 
 class ClubTest extends TestCase

--- a/tests/Http/EventTest.php
+++ b/tests/Http/EventTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
+use App\Models\Post;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class EventTest extends TestCase
@@ -21,7 +21,7 @@ class EventTest extends TestCase
 
         // Make sure we created an event for the signup creation.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Signup',
+            'eventable_type' => 'App\Models\Signup',
             'created_at' => '2017-08-03 17:02:00',
         ]);
     }
@@ -44,13 +44,13 @@ class EventTest extends TestCase
 
         // Make sure we created an event for the signup creation.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Signup',
+            'eventable_type' => 'App\Models\Signup',
             'created_at' => '2017-08-03 17:02:00',
         ]);
 
         // Make sure we also created an event for the signup update.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Signup',
+            'eventable_type' => 'App\Models\Signup',
             'created_at' => '2017-08-04 18:02:00',
         ]);
     }
@@ -68,7 +68,7 @@ class EventTest extends TestCase
 
         // Make sure we created an event for the post creation.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Post',
+            'eventable_type' => 'App\Models\Post',
             'created_at' => '2017-08-03 17:02:00',
         ]);
     }
@@ -94,19 +94,19 @@ class EventTest extends TestCase
 
         // Make sure we created an event for the post creation.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Post',
+            'eventable_type' => 'App\Models\Post',
             'created_at' => '2017-08-03 17:02:00',
         ]);
 
         // Make sure we also created an event for the post update.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Post',
+            'eventable_type' => 'App\Models\Post',
             'created_at' => '2017-08-04 18:02:00',
         ]);
 
         // Make sure a signup event wasn't created when the post was updated.
         $this->assertDatabaseMissing('events', [
-            'eventable_type' => 'Rogue\Models\Signup',
+            'eventable_type' => 'App\Models\Signup',
             'created_at' => '2017-08-04 18:02:00',
         ]);
     }
@@ -128,7 +128,7 @@ class EventTest extends TestCase
 
         // Make sure an event is created when the post is deleted.
         $this->assertDatabaseHas('events', [
-            'eventable_type' => 'Rogue\Models\Post',
+            'eventable_type' => 'App\Models\Post',
             'created_at' => '2017-08-04 18:02:00',
         ]);
     }

--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Group;
-use Rogue\Models\GroupType;
+use App\Models\Group;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class GroupTest extends TestCase

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\GroupType;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class GroupTypeTest extends TestCase

--- a/tests/Http/ImagesTest.php
+++ b/tests/Http/ImagesTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Post;
+use App\Models\Post;
 use Tests\TestCase;
 
 class ImagesTest extends TestCase

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -2,18 +2,18 @@
 
 namespace Tests\Http;
 
+use App\Models\Action;
+use App\Models\Campaign;
+use App\Models\Club;
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\Signup;
+use App\Models\User;
+use App\Services\CustomerIo;
+use App\Services\Fastly;
+use App\Services\GraphQL;
 use Illuminate\Http\UploadedFile;
-use Rogue\Models\Action;
-use Rogue\Models\Campaign;
-use Rogue\Models\Club;
-use Rogue\Models\Group;
-use Rogue\Models\Post;
-use Rogue\Models\Reaction;
-use Rogue\Models\Signup;
-use Rogue\Models\User;
-use Rogue\Services\CustomerIo;
-use Rogue\Services\Fastly;
-use Rogue\Services\GraphQL;
 use Tests\TestCase;
 
 class PostTest extends TestCase

--- a/tests/Http/ReactionTest.php
+++ b/tests/Http/ReactionTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Post;
-use Rogue\Models\Reaction;
-use Rogue\Models\Signup;
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class ReactionTest extends TestCase

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Http;
 
+use App\Jobs\SendReviewedPostToCustomerIo;
+use App\Models\Post;
 use Illuminate\Support\Facades\Bus;
-use Rogue\Jobs\SendReviewedPostToCustomerIo;
-use Rogue\Models\Post;
 use Tests\TestCase;
 
 class ReviewsTest extends TestCase

--- a/tests/Http/SignupTest.php
+++ b/tests/Http/SignupTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\Http;
 
+use App\Models\Club;
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\Signup;
+use App\Models\User;
+use App\Observers\SignupObserver;
+use App\Services\CustomerIo;
+use App\Services\GraphQL;
 use Illuminate\Support\Str;
-use Rogue\Models\Club;
-use Rogue\Models\Group;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
-use Rogue\Models\User;
-use Rogue\Observers\SignupObserver;
-use Rogue\Services\CustomerIo;
-use Rogue\Services\GraphQL;
 use Tests\TestCase;
 
 class SignupTest extends TestCase

--- a/tests/Http/TagsTest.php
+++ b/tests/Http/TagsTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Post;
+use App\Models\Post;
 use Tests\TestCase;
 
 class TagsTest extends TestCase

--- a/tests/Http/UsersTest.php
+++ b/tests/Http/UsersTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Http;
 
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
+use App\Models\Post;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class UsersTest extends TestCase

--- a/tests/Http/Web/ClubTest.php
+++ b/tests/Http/Web/ClubTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http\Web;
 
-use Rogue\Models\Club;
+use App\Models\Club;
 use Tests\TestCase;
 
 class ClubTest extends TestCase

--- a/tests/Http/Web/GroupTest.php
+++ b/tests/Http/Web/GroupTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http\Web;
 
-use Rogue\Models\GroupType;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class GroupTest extends TestCase

--- a/tests/Http/Web/GroupTypeTest.php
+++ b/tests/Http/Web/GroupTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http\Web;
 
-use Rogue\Models\GroupType;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class GroupTypeTest extends TestCase

--- a/tests/Unit/Models/CampaignTest.php
+++ b/tests/Unit/Models/CampaignTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\Models;
 
-use Rogue\Models\Action;
-use Rogue\Models\Campaign;
-use Rogue\Models\GroupType;
+use App\Models\Action;
+use App\Models\Campaign;
+use App\Models\GroupType;
 use Tests\TestCase;
 
 class CampaignTest extends TestCase

--- a/tests/Unit/Models/PostModelTest.php
+++ b/tests/Unit/Models/PostModelTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit\Models;
 
-use Rogue\Models\Action;
-use Rogue\Models\Group;
-use Rogue\Models\Post;
-use Rogue\Models\Signup;
+use App\Models\Action;
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class PostModelTest extends TestCase

--- a/tests/Unit/Models/ReactionModelTest.php
+++ b/tests/Unit/Models/ReactionModelTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit\Models;
 
-use Rogue\Models\Post;
-use Rogue\Models\Reaction;
-use Rogue\Models\Signup;
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class ReactionModelTest extends TestCase

--- a/tests/Unit/Models/SignupModelTest.php
+++ b/tests/Unit/Models/SignupModelTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Models;
 
-use Rogue\Models\Group;
-use Rogue\Models\Signup;
+use App\Models\Group;
+use App\Models\Signup;
 use Tests\TestCase;
 
 class SignupModelTest extends TestCase

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Rogue\Models\User;
+use App\Models\User;
 
 trait WithAuthentication
 {

--- a/tests/WithMocks.php
+++ b/tests/WithMocks.php
@@ -2,12 +2,12 @@
 
 namespace Tests;
 
+use App\Observers\SignupObserver;
+use App\Services\GraphQL;
 use Carbon\Carbon;
 use DoSomething\Gateway\Northstar;
 use DoSomething\Gateway\Resources\NorthstarUser;
 use Illuminate\Support\Facades\Storage;
-use Rogue\Observers\SignupObserver;
-use Rogue\Services\GraphQL;
 
 trait WithMocks
 {


### PR DESCRIPTION
### What's this PR do?

This pull request replaces Rogue's custom `Rogue\` namespace with `App\`, in prep for merging into Northstar!

### How should this be reviewed?

This was basically a big find-replace! Tests still pass! 😌

### Any background context you want to provide?

See [Remove Custom App Namespaces RFC](https://github.com/DoSomething/rfcs/blob/master/012-remove-custom-app-namespace.md).

### Relevant tickets

References [Pivotal #176469276](https://www.pivotaltracker.com/story/show/176469276).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
